### PR TITLE
Make .struct emit field-offset constants and __size

### DIFF
--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -76,6 +76,7 @@ from a816.parse.ast.nodes import (
     MapAstNode,
     OpcodeAstNode,
     ScopeAstNode,
+    StructAstNode,
     SymbolAffectationAstNode,
     Term,
 )
@@ -203,6 +204,17 @@ class A816Document:
         if node.module_name and node.module_name not in self.imports:
             self.imports.append(node.module_name)
 
+    def _record_struct(self, node: StructAstNode) -> None:
+        """Index struct fields as Name.field symbols so goto-def works."""
+        token = node.file_info
+        if not token.position:
+            return
+        pos = Position(line=token.position.line, character=token.position.column)
+        file_uri = self._get_file_uri_for_token(token)
+        for field_name, _field_type in node.fields:
+            self.symbols[f"{node.name}.{field_name}"] = (pos, file_uri)
+        self.symbols[f"{node.name}.__size"] = (pos, file_uri)
+
     def _visit_include(self, node: IncludeAstNode) -> None:
         for child in node.included_nodes:
             if isinstance(child, AstNode):
@@ -240,6 +252,9 @@ class A816Document:
             self._record_macro(node)
         elif isinstance(node, ImportAstNode):
             self._record_import(node)
+        elif isinstance(node, StructAstNode):
+            self._record_struct(node)
+            return
         elif isinstance(node, IncludeAstNode):
             self._visit_include(node)
             return
@@ -1450,6 +1465,7 @@ class A816LanguageServer:
         AssignAstNode,
         ExternAstNode,
         ImportAstNode,
+        StructAstNode,
         DataNode,
     )
 

--- a/a816/parse/ast/nodes.py
+++ b/a816/parse/ast/nodes.py
@@ -505,17 +505,20 @@ class CodeLookupAstNode(AstNode):
 
 
 class StructAstNode(AstNode):
-    def __init__(self, name: str, fields: dict[str, str], file_info: Token) -> None:
+    def __init__(self, name: str, fields: list[tuple[str, str]], file_info: Token) -> None:
         super().__init__("struct", file_info)
         self.name = name
-        self.fields = fields
+        # Insertion-ordered (name, type) pairs. List instead of dict so
+        # downstream consumers can rely on the declared order without poking
+        # at dict semantics, and so duplicate names get caught at parse time.
+        self.fields: list[tuple[str, str]] = list(fields)
 
     def to_representation(self) -> tuple[Any, ...]:
-        return self.kind, self.name, self.fields
+        return self.kind, self.name, list(self.fields)
 
     def to_canonical(self) -> str:
-        fields_str = ", ".join(f"{name}: {type_}" for name, type_ in self.fields.items())
-        return f".struct {self.name} {{ {fields_str} }}"
+        body = "\n".join(f"    {field_type} {field_name}" for field_name, field_type in self.fields)
+        return f".struct {self.name} {{\n{body}\n}}"
 
 
 class ForAstNode(AstNode):

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -33,6 +33,7 @@ from a816.parse.ast.nodes import (
     OpcodeAstNode,
     RegisterSizeAstNode,
     ScopeAstNode,
+    StructAstNode,
     SymbolAffectationAstNode,
     TableAstNode,
     Term,
@@ -120,6 +121,32 @@ def generate_scope(
     code += _code_gen(node.body.body, resolver, macro_definitions)
     code.append(PopScopeNode(resolver))
     resolver.restore_scope(exports=False)
+    return code
+
+
+# Byte sizes per declared struct field type. dword is 4 because users who
+# write it mean 32-bit; 65c816 effective addresses fit in 24 (use `long`).
+_STRUCT_FIELD_SIZES = {"byte": 1, "word": 2, "long": 3, "dword": 4}
+
+
+def generate_struct(
+    node: StructAstNode,
+    resolver: Resolver,
+    macro_definitions: MacroDefinitions,
+    file_info: Token,
+) -> GenNodes:
+    """Push a NamedScope, register one offset symbol per field, then export."""
+    resolver.append_named_scope(node.name)
+    resolver.use_next_scope()
+    code: list[NodeProtocol] = [ScopeNode(resolver)]
+    offset = 0
+    for field_name, field_type in node.fields:
+        resolver.current_scope.add_symbol(field_name, offset)
+        offset += _STRUCT_FIELD_SIZES[field_type]
+    resolver.current_scope.add_symbol("__size", offset)
+    code.append(PopScopeNode(resolver))
+    # exports=True promotes Name.field and Name.__size to the parent scope.
+    resolver.restore_scope(exports=True)
     return code
 
 
@@ -768,6 +795,7 @@ generators = {
     "comment": generate_comment,
     "debug": generate_debug,
     "register_size": generate_register_size,
+    "struct": generate_struct,
 }
 
 

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -315,10 +315,19 @@ class LinkedModuleNode(NodeProtocol):
 
         return current_pc + len(self.code)
 
-    @staticmethod
-    def _write_reloc(code_array: bytearray, offset: int, value: int, size: int, expr: str) -> None:
+    def _reloc_context(self, offset: int) -> str:
+        return f"module '{self.module_name}' offset 0x{offset:x}/0x{len(self.code):x}"
+
+    def _write_reloc(self, code_array: bytearray, offset: int, value: int, size: int, expr: str) -> None:
+        ctx = self._reloc_context(offset)
         if size not in (1, 2, 3):
-            logger.warning(f"Unsupported relocation size {size} for expression '{expr}'")
+            logger.warning(f"Unsupported relocation size {size} for expression '{expr}' [{ctx}]")
+            return
+        if offset + size > len(code_array):
+            logger.warning(
+                f"Relocation runs past module code: offset 0x{offset:x} + size {size} "
+                f"> 0x{len(code_array):x} for expression '{expr}' [{ctx}]"
+            )
             return
         for i in range(size):
             code_array[offset + i] = (value >> (8 * i)) & 0xFF
@@ -326,13 +335,14 @@ class LinkedModuleNode(NodeProtocol):
     def _eval_one_relocation(self, expr: str, offset: int, size: int, code_array: bytearray) -> None:
         from a816.parse.ast.expression import eval_expression_str
 
+        ctx = self._reloc_context(offset)
         try:
             value = eval_expression_str(expr, self.resolver)
         except (SymbolNotDefined, NodeError, ValueError) as e:
-            logger.warning(f"Failed to evaluate expression '{expr}': {e}")
+            logger.warning(f"Failed to evaluate expression '{expr}': {e} [{ctx}]")
             return
         if not isinstance(value, int):
-            logger.warning(f"Expression '{expr}' did not evaluate to int: {value}")
+            logger.warning(f"Expression '{expr}' did not evaluate to int: {value} [{ctx}]")
             return
         self._write_reloc(code_array, offset, value, size, expr)
 

--- a/a816/parse/parser_states.py
+++ b/a816/parse/parser_states.py
@@ -234,6 +234,9 @@ def parse_for(p: Parser) -> ForAstNode:
     return ForAstNode(variable.value, start, end, block, current)
 
 
+STRUCT_FIELD_TYPES = {"byte", "word", "long", "dword"}
+
+
 def parse_struct(p: Parser) -> StructAstNode:
     current = p.current()
 
@@ -241,21 +244,38 @@ def parse_struct(p: Parser) -> StructAstNode:
     expect_token(variable, TokenType.IDENTIFIER)
 
     expect_token(p.next(), TokenType.LBRACE)
-    fields = {}
+    fields: list[tuple[str, str]] = []
+    seen: set[str] = set()
     while p.current().type != TokenType.EOF:
         if p.current().type == TokenType.COMMENT:
+            p.next()
+            continue
+        if p.current().type == TokenType.COMMA:
             p.next()
             continue
         if p.current().type == TokenType.RBRACE:
             break
 
-        expect_token(p.current(), TokenType.TYPE)
-        field_type = p.next()
-        expect_token(p.current(), TokenType.IDENTIFIER)
-        field_identifier = p.current()
+        type_token = p.current()
+        expect_token(type_token, TokenType.IDENTIFIER)
+        if type_token.value not in STRUCT_FIELD_TYPES:
+            raise ParserSyntaxError(
+                f"Unknown struct field type {type_token.value!r}; expected one of {sorted(STRUCT_FIELD_TYPES)}",
+                type_token,
+                TokenType.IDENTIFIER,
+            )
+        p.next()
 
-        fields[field_identifier.value] = field_type.value
-
+        name_token = p.current()
+        expect_token(name_token, TokenType.IDENTIFIER)
+        if name_token.value in seen:
+            raise ParserSyntaxError(
+                f"Duplicate struct field {name_token.value!r}",
+                name_token,
+                TokenType.IDENTIFIER,
+            )
+        seen.add(name_token.value)
+        fields.append((name_token.value, type_token.value))
         p.next()
 
     expect_token(p.next(), TokenType.RBRACE)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -122,6 +122,46 @@ named_scope {
     load_system_menu_text_pointer(named_scope.yaha_text)
 ```
 
+## Structs
+
+`.struct Name { ... }` declares a layout. Each field is one of `byte`,
+`word`, `long` (24-bit), or `dword` (32-bit). Field names export as
+`Name.field` constants holding the byte offset from the start of the
+struct, plus `Name.__size` for the total length.
+
+```ca65
+.struct OAM {
+    word x
+    byte y
+    byte tile
+    byte attr
+}
+```
+
+emits `OAM.x = 0`, `OAM.y = 2`, `OAM.tile = 3`, `OAM.attr = 4`,
+`OAM.__size = 5`.
+
+Use the offsets against any base address — a hardware register, a WRAM
+pointer, an array stride:
+
+```ca65
+.struct PPU {
+    byte INIDISP
+    byte OBSEL
+    word OAMADDR
+}
+
+*=0x008000
+    lda.w 0x2100 + PPU.OAMADDR  ; assembles as LDA $2102
+
+player = 0x7E0010
+    lda.b player + OAM.x
+    sta.b player + OAM.tile
+```
+
+Structs are layout-only; they don't reserve storage and don't emit
+bytes. Pair with `*=` or a memory-map directive to place an instance.
+
 ## Modules
 
 `.import "module"` brings symbols from another translation unit; `.extern`

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,7 +2,6 @@ import logging
 import struct
 import unittest
 from typing import cast
-from unittest import skip
 
 from a816.cpu.cpu_65c816 import AddressingMode
 from a816.parse.ast.nodes import DocstringAstNode, IncludeIpsAstNode, MacroAstNode, ScopeAstNode, Term, UnaryOp
@@ -453,7 +452,6 @@ lda #1
         assert isinstance(ast_result.nodes[0], DocstringAstNode)  # for type narrowing
         self.assertEqual(ast_result.nodes[0].text, "Module description")
 
-    @skip("experimental")
     def test_parse_struct(self) -> None:
         input_program = """
         .struct a_struct {
@@ -464,12 +462,13 @@ lda #1
 
         program = Program()
         ast = program.parser.parse_as_ast(input_program)
+        assert ast.error is None, ast.error
         self.assertEqual(
             [
                 (
                     "struct",
                     "a_struct",
-                    {"id": "byte", "offset": "word", "pointer": "long"},
+                    [("id", "byte"), ("offset", "word"), ("pointer", "long")],
                 )
             ],
             ast.ast,

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1,0 +1,126 @@
+"""Codegen for `.struct`: emits dotted offset constants and __size."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from a816.program import Program
+
+
+def _resolve(source: str) -> Program:
+    """Run a program through resolve so resolver scopes are populated."""
+    program = Program()
+    error = program.assemble_string_with_emitter(source, "memory.s", _NoopEmitter())
+    assert error is None, error
+    return program
+
+
+class _NoopEmitter:
+    def begin(self) -> None: ...
+
+    def end(self) -> None: ...
+
+    def write_block_header(self, *_: object, **__: object) -> None: ...
+
+    def write_block(self, *_: object, **__: object) -> None: ...
+
+
+def test_struct_emits_field_offsets_and_size() -> None:
+    program = _resolve(
+        """
+        .struct OAM {
+            word x
+            byte y
+            byte tile
+            byte attr
+        }
+        """
+    )
+
+    labels = dict(program.resolver.get_all_labels())
+    # Symbols, not labels — fields are constants.
+    symbols: dict[str, int] = {}
+    for scope in program.resolver.scopes:
+        for name, value in scope.symbols.items():
+            if isinstance(value, int):
+                symbols[name] = value
+
+    assert symbols["OAM.x"] == 0
+    assert symbols["OAM.y"] == 2
+    assert symbols["OAM.tile"] == 3
+    assert symbols["OAM.attr"] == 4
+    assert symbols["OAM.__size"] == 5
+    # Struct fields are not labels.
+    assert "OAM.x" not in labels
+
+
+def test_struct_offsets_resolve_in_expressions() -> None:
+    """`lda.b ptr + Struct.field` assembles with the right operand."""
+
+    src = """
+        .struct PPU {
+            byte INIDISP
+            byte OBSEL
+            word OAMADDR
+        }
+        *=0x008000
+            lda.w 0x2100 + PPU.OAMADDR
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        asm = root / "main.s"
+        asm.write_text(src, encoding="utf-8")
+        ips = root / "out.ips"
+        program = Program()
+        assert program.assemble_as_patch(str(asm), ips) == 0
+        assert ips.exists()
+        # IPS contents must contain `AD 02 21` (LDA $2102) — operand = 0x2100 + 2.
+        data = ips.read_bytes()
+        assert b"\xad\x02\x21" in data
+
+
+def test_struct_duplicate_field_raises() -> None:
+    program = Program()
+    src = """
+        .struct Bad {
+            byte x
+            byte x
+        }
+    """
+    error, _ = program.parser.parse(src, "memory.s")
+    assert error is not None
+    assert "Duplicate struct field" in str(error)
+
+
+def test_struct_unknown_type_raises() -> None:
+    program = Program()
+    src = """
+        .struct Bad {
+            qword x
+        }
+    """
+    error, _ = program.parser.parse(src, "memory.s")
+    assert error is not None
+    assert "Unknown struct field type" in str(error)
+
+
+def test_struct_supports_dword() -> None:
+    program = _resolve(
+        """
+        .struct Big {
+            byte tag
+            dword payload
+        }
+        """
+    )
+    symbols: dict[str, int] = {
+        name: value
+        for scope in program.resolver.scopes
+        for name, value in scope.symbols.items()
+        if isinstance(value, int)
+    }
+    assert symbols["Big.tag"] == 0
+    assert symbols["Big.payload"] == 1
+    assert symbols["Big.__size"] == 5


### PR DESCRIPTION
## Summary

- \`.struct Name { byte/word/long/dword field … }\` is now wired end-to-end. Codegen pushes a NamedScope, assigns one symbol per field at the running byte offset, and exports \`Name.field\` plus \`Name.__size\` to the parent scope.
- Parser accepts \`byte\`, \`word\`, \`long\`, \`dword\` as plain identifiers (no lexer change). Duplicate field names and unknown types raise \`ParserSyntaxError\` with descriptive messages.
- LSP indexer records struct fields as \`Name.field\` symbols and adds \`StructAstNode\` to the semantic-token directive set so highlighting and goto-def light up.
- Docs: new \"Structs\" section in \`docs/docs/index.md\` covering the OAM/PPU layout idiom.

## Why

a816 was the only major SNES toolchain missing struct codegen — the parser and AST were skeletons; the test was \`@skip(\"experimental\")\`. ff4-modules (and any project using hardware-register layouts or WRAM object structs) had to roll the offsets by hand.

## Test plan

- [x] \`hatch run tests:tests tests/test_parse.py tests/test_struct.py -v\` — passes (parse, codegen, end-to-end IPS round-trip, duplicate / unknown-type errors).
- [x] \`hatch run tests:all\` — 560 pass, 1 skipped, mypy + ruff clean.
- [x] Hand-rolled smoke: \`.struct PPU { byte INIDISP; byte OBSEL; word OAMADDR }; lda.w 0x2100 + PPU.OAMADDR\` produces \`AD 02 21\` (LDA \$2102).