### PR TITLE
Multi-region object modules (v6 .o format)

### DIFF
--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -313,10 +313,13 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
     "bne": {AddressingMode.direct: RelativeJumpOpcode(0xD0)},
     "bpl": {AddressingMode.direct: RelativeJumpOpcode(0x10)},
     "bra": {AddressingMode.direct: RelativeJumpOpcode(0x80)},
-    "brk": {
-        AddressingMode.none: OpcodeWithoutOperand(0x00),
-        AddressingMode.immediate: Opcode([0x00]),
-    },
+    # BRK / COP / WDM are 2-byte instructions on 65816: opcode + a
+    # signature byte the handler reads off the stack (PC pushed is the
+    # instruction + 2). Force callers to supply the signature so the
+    # second byte is never silently whatever happens to follow in ROM.
+    "brk": {AddressingMode.immediate: Opcode([0x00])},
+    "cop": {AddressingMode.immediate: Opcode([0x02])},
+    "wdm": {AddressingMode.immediate: Opcode([0x42])},
     "clc": {AddressingMode.none: OpcodeWithoutOperand(0x18)},
     "cmp": {
         AddressingMode.immediate: Opcode([0xC9, 0xC9], is_a=True),

--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -132,11 +132,13 @@ class Opcode(OpcodeProtocol):
                     size_bytes = 2
                 else:
                     size_bytes = 3
-                # Add expression relocation at current PC offset + 1 (after opcode byte)
-                current_offset = resolver.pc + 1
-                resolver.context.object_writer.add_expression_relocation(
-                    current_offset, value_node._deferred_expression, size_bytes
-                )
+                # Operand lands one byte past the opcode in the current region.
+                writer = resolver.context.object_writer
+                if writer is not None:
+                    current_offset = writer.relocation_offset(pending_block_bytes=1)
+                    writer.add_expression_relocation(
+                        current_offset, value_node._deferred_expression, size_bytes
+                    )
 
         if size == "b":
             return struct.pack("B", value & 0xFF)

--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -313,7 +313,10 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
     "bne": {AddressingMode.direct: RelativeJumpOpcode(0xD0)},
     "bpl": {AddressingMode.direct: RelativeJumpOpcode(0x10)},
     "bra": {AddressingMode.direct: RelativeJumpOpcode(0x80)},
-    "brk": {AddressingMode.none: OpcodeWithoutOperand(0x00)},
+    "brk": {
+        AddressingMode.none: OpcodeWithoutOperand(0x00),
+        AddressingMode.immediate: Opcode([0x00]),
+    },
     "clc": {AddressingMode.none: OpcodeWithoutOperand(0x18)},
     "cmp": {
         AddressingMode.immediate: Opcode([0xC9, 0xC9], is_a=True),

--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -136,9 +136,7 @@ class Opcode(OpcodeProtocol):
                 writer = resolver.context.object_writer
                 if writer is not None:
                     current_offset = writer.relocation_offset(pending_block_bytes=1)
-                    writer.add_expression_relocation(
-                        current_offset, value_node._deferred_expression, size_bytes
-                    )
+                    writer.add_expression_relocation(current_offset, value_node._deferred_expression, size_bytes)
 
         if size == "b":
             return struct.pack("B", value & 0xFF)

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -9,35 +9,45 @@ from a816.exceptions import (
     RelocationError,
     UnresolvedSymbolError,
 )
-from a816.object_file import ObjectFile, RelocationType, SymbolSection, SymbolType
+from a816.object_file import ObjectFile, Region, RelocationType, SymbolSection, SymbolType
 
 SYMBOL_TOKEN_RE = re.compile(r"([A-Za-z_\.][A-Za-z0-9_\.]*)")
 
 
 class Linker:
+    """Links a list of ObjectFiles into one ObjectFile.
+
+    Each input object's regions are placed at their declared (absolute)
+    base_address — relocatable modules are shifted by the linker's
+    base_address against region 0. Region offsets are then translated to
+    final logical addresses, and relocations are patched into per-region
+    bytearrays. The linked output preserves the per-region structure so
+    downstream IPS/SFC writers emit one block per region rather than one
+    flat span.
+    """
+
     def __init__(self, object_files: list[ObjectFile], base_address: int = 0) -> None:
         self.object_files = object_files
         self.base_address = base_address
-        self.linked_code: bytearray = bytearray()
+        # Linked regions, keyed by their final logical base_address.
+        self.linked_regions: list[Region] = []
         self.linked_symbols: list[tuple[str, int, SymbolType, SymbolSection]] = []
-        self.linked_relocations: list[tuple[int, str, RelocationType]] = []
-        self.linked_expression_relocations: list[tuple[int, str, int]] = []  # (offset, expression, size_bytes)
-        self.linked_aliases: list[tuple[str, str]] = []  # (name, expression)
+        # (final_address, region_idx, symbol_name, RelocationType)
+        self._linked_relocations: list[tuple[int, int, str, RelocationType]] = []
+        # (final_address, region_idx, expression, size_bytes)
+        self._linked_expression_relocations: list[tuple[int, int, str, int]] = []
+        self.linked_aliases: list[tuple[str, str]] = []
         self.linked_files: list[str] = []
-        self.linked_lines: list[tuple[int, int, int, int, int]] = []
         self._file_index: dict[str, int] = {}
         self.symbol_map: dict[str, int] = {}
+        self._region_buffers: dict[int, bytearray] = {}
+
+    @property
+    def linked_code(self) -> bytes:
+        """Concatenated bytes of all linked regions, kept for legacy callers."""
+        return b"".join(region.code for region in self.linked_regions)
 
     def link(self, base_address: int | None = None) -> ObjectFile:
-        """Link object files into a single object file.
-
-        Args:
-            base_address: Optional override for the base ROM address. Defaults to value
-                         passed at construction time (0 if not specified).
-
-        Returns:
-            A linked ObjectFile containing combined code, resolved symbols, and remaining relocations.
-        """
         if base_address is not None:
             self.base_address = base_address
         self._resolve_symbols()
@@ -46,39 +56,72 @@ class Linker:
         self._apply_relocations()
         self._apply_expression_relocations()
         return ObjectFile(
-            bytes(self.linked_code),
+            self.linked_regions,
             self.linked_symbols,
-            self.linked_relocations,
+            aliases=[],
             files=self.linked_files,
-            lines=self.linked_lines,
+            relocatable=False,
         )
 
-    def _resolved_address(self, address: int, section: SymbolSection, code_offset: int) -> int:
-        # CODE = base + module offset + symbol offset; DATA = absolute.
-        return address if section == SymbolSection.DATA else self.base_address + code_offset + address
+    def _delta_for(self, obj_file: ObjectFile, running_offset: int) -> int:
+        """How much to shift this module's logical addresses by.
 
-    def _ingest_symbol(self, sym: tuple[str, int, SymbolType, SymbolSection], code_offset: int) -> None:
+        Relocatable modules anchor region 0 at the linker's base_address
+        plus the running byte offset of prior relocatable modules. Pinned
+        modules keep their declared *= addresses unchanged.
+        """
+        if obj_file.relocatable and obj_file.regions:
+            return self.base_address + running_offset - obj_file.regions[0].base_address
+        return 0
+
+    def _ingest_object(self, obj_file: ObjectFile, running_offset: int) -> None:
+        delta = self._delta_for(obj_file, running_offset)
+        local_to_linked_file = self._merge_file_table(obj_file)
+
+        for region in obj_file.regions:
+            final_base = region.base_address + delta
+            region_idx = len(self.linked_regions)
+            new_region = Region(
+                base_address=final_base,
+                code=bytes(region.code),
+                relocations=list(region.relocations),
+                expression_relocations=list(region.expression_relocations),
+                lines=[
+                    (offset, local_to_linked_file.get(file_idx, 0), line, column, flags)
+                    for offset, file_idx, line, column, flags in region.lines
+                ],
+            )
+            self.linked_regions.append(new_region)
+
+            for offset, name, reloc_type in region.relocations:
+                self._linked_relocations.append((final_base + offset, region_idx, name, reloc_type))
+            for offset, expression, size_bytes in region.expression_relocations:
+                self._linked_expression_relocations.append((final_base + offset, region_idx, expression, size_bytes))
+
+        for sym in obj_file.symbols:
+            self._ingest_symbol(sym, delta)
+
+        self.linked_aliases.extend(obj_file.aliases)
+
+    def _ingest_symbol(self, sym: tuple[str, int, SymbolType, SymbolSection], delta: int) -> None:
         name, address, symbol_type, section = sym
         if symbol_type == SymbolType.EXTERNAL:
             self._external_symbols_needed.add(name)
             return
+        # CODE symbols ride the module's delta; DATA/BSS are absolute.
+        final_address = address + delta if section == SymbolSection.CODE else address
         if symbol_type == SymbolType.GLOBAL:
             if name in self.symbol_map:
                 raise DuplicateSymbolError(name)
-            final_address = self._resolved_address(address, section, code_offset)
             self.symbol_map[name] = final_address
             self.linked_symbols.append((name, final_address, symbol_type, section))
             return
         if symbol_type == SymbolType.LOCAL:
-            local_address = self._resolved_address(address, section, code_offset)
-            self.linked_symbols.append((name, local_address, symbol_type, section))
+            self.linked_symbols.append((name, final_address, symbol_type, section))
             return
         raise ValueError(f"Unknown symbol type: {symbol_type}")
 
-    def _ingest_lines(self, obj_file: ObjectFile, code_offset: int) -> None:
-        if not obj_file.lines:
-            return
-        # Map per-object file indices into the linked file table.
+    def _merge_file_table(self, obj_file: ObjectFile) -> dict[int, int]:
         local_to_linked: dict[int, int] = {}
         for local_idx, path in enumerate(obj_file.files):
             if path in self._file_index:
@@ -88,30 +131,15 @@ class Linker:
                 self.linked_files.append(path)
                 self._file_index[path] = new_idx
                 local_to_linked[local_idx] = new_idx
-        for offset, file_idx, line, column, flags in obj_file.lines:
-            mapped = local_to_linked.get(file_idx, 0)
-            # Bake the final logical address so consumers don't have to know
-            # the linker's base/code-offset math.
-            final_offset = self.base_address + code_offset + offset
-            self.linked_lines.append((final_offset, mapped, line, column, flags))
-
-    def _ingest_object(self, obj_file: ObjectFile, code_offset: int) -> None:
-        self.linked_code.extend(obj_file.code)
-        for sym in obj_file.symbols:
-            self._ingest_symbol(sym, code_offset)
-        for offset, symbol_name, relocation_type in obj_file.relocations:
-            self.linked_relocations.append((code_offset + offset, symbol_name, relocation_type))
-        for offset, expression, size_bytes in obj_file.expression_relocations:
-            self.linked_expression_relocations.append((code_offset + offset, expression, size_bytes))
-        self.linked_aliases.extend(obj_file.aliases)
-        self._ingest_lines(obj_file, code_offset)
+        return local_to_linked
 
     def _resolve_symbols(self) -> None:
         self._external_symbols_needed: set[str] = set()
-        current_code_offset = 0
+        running_offset = 0
         for obj_file in self.object_files:
-            self._ingest_object(obj_file, current_code_offset)
-            current_code_offset += len(obj_file.code)
+            self._ingest_object(obj_file, running_offset)
+            if obj_file.relocatable:
+                running_offset += sum(len(r.code) for r in obj_file.regions)
 
     def _check_unresolved(self) -> None:
         unresolved_symbols = self._external_symbols_needed - set(self.symbol_map.keys())
@@ -119,10 +147,8 @@ class Linker:
             raise UnresolvedSymbolError(unresolved_symbols)
 
     def _resolve_aliases(self) -> None:
-        """Resolve aliases iteratively. An alias may depend on another alias."""
         if not self.linked_aliases:
             return
-
         remaining = list(self.linked_aliases)
         progress = True
         while remaining and progress:
@@ -138,30 +164,38 @@ class Linker:
                 self.linked_symbols.append((name, value, SymbolType.GLOBAL, SymbolSection.DATA))
                 progress = True
             remaining = still_pending
-
         if remaining:
-            unresolved = {name for name, _ in remaining}
-            raise UnresolvedSymbolError(unresolved)
+            raise UnresolvedSymbolError({name for name, _ in remaining})
+
+    def _region_view(self, region_idx: int) -> tuple[Region, bytearray]:
+        region = self.linked_regions[region_idx]
+        buf = self._region_buffers.get(region_idx)
+        if buf is None:
+            buf = bytearray(region.code)
+            self._region_buffers[region_idx] = buf
+        return region, buf
+
+    def _flush_region_buffers(self) -> None:
+        for region_idx, buf in self._region_buffers.items():
+            self.linked_regions[region_idx].code = bytes(buf)
+        self._region_buffers.clear()
 
     def _apply_relocations(self) -> None:
-        base_address = self.base_address
-
-        for offset, symbol_name, relocation_type in self.linked_relocations:
+        self._region_buffers = {}
+        for final_address, region_idx, symbol_name, relocation_type in self._linked_relocations:
             if symbol_name not in self.symbol_map:
                 raise UnresolvedSymbolError({symbol_name})
-
             symbol_address = self.symbol_map[symbol_name]
+            region, code = self._region_view(region_idx)
+            offset = final_address - region.base_address
 
             match relocation_type:
                 case RelocationType.ABSOLUTE_16:
                     if not 0 <= symbol_address <= 0xFFFF:
                         raise RelocationError(
-                            symbol_name,
-                            "16-bit absolute",
-                            symbol_address,
-                            "is out of range (must be 0x0000-0xFFFF)",
+                            symbol_name, "16-bit absolute", symbol_address, "is out of range (must be 0x0000-0xFFFF)"
                         )
-                    struct.pack_into("<H", self.linked_code, offset, symbol_address)
+                    struct.pack_into("<H", code, offset, symbol_address)
                 case RelocationType.ABSOLUTE_24:
                     if not 0 <= symbol_address <= 0xFFFFFF:
                         raise RelocationError(
@@ -170,11 +204,9 @@ class Linker:
                             symbol_address,
                             "is out of range (must be 0x000000-0xFFFFFF)",
                         )
-                    self._write_le24(offset, symbol_address)
+                    self._write_le24(code, offset, symbol_address)
                 case RelocationType.RELATIVE_16:
-                    # For relative relocations, current PC = base_address + offset
-                    current_pc = base_address + offset
-                    target_address = symbol_address - (current_pc + 2)
+                    target_address = symbol_address - (final_address + 2)
                     if not -0x8000 <= target_address <= 0x7FFF:
                         raise RelocationError(
                             symbol_name,
@@ -182,11 +214,9 @@ class Linker:
                             target_address,
                             "is out of range (must be -0x8000 to 0x7FFF)",
                         )
-                    struct.pack_into("<h", self.linked_code, offset, target_address)
+                    struct.pack_into("<h", code, offset, target_address)
                 case RelocationType.RELATIVE_24:
-                    # For relative relocations, current PC = base_address + offset
-                    current_pc = base_address + offset
-                    target_address = symbol_address - (current_pc + 3)
+                    target_address = symbol_address - (final_address + 3)
                     if not -0x800000 <= target_address <= 0x7FFFFF:
                         raise RelocationError(
                             symbol_name,
@@ -194,50 +224,41 @@ class Linker:
                             target_address,
                             "is out of range (must be -0x800000 to 0x7FFFFF)",
                         )
-                    self._write_le24(offset, target_address & 0xFFFFFF)
+                    self._write_le24(code, offset, target_address & 0xFFFFFF)
                 case _:
                     raise ValueError(f"Unknown relocation type: {relocation_type}")
 
-    def _apply_expression_relocations(self) -> None:
-        """Evaluate expressions with resolved symbols and apply to code"""
-        for offset, expression, size_bytes in self.linked_expression_relocations:
-            # Simple expression evaluator for basic arithmetic
-            # This handles expressions like "EXTERN_VALUE + 0x8000"
-            evaluated_value = self._evaluate_expression(expression)
+        self._flush_region_buffers()
 
-            # Apply the evaluated value to the code
+    def _apply_expression_relocations(self) -> None:
+        self._region_buffers = {}
+        for final_address, region_idx, expression, size_bytes in self._linked_expression_relocations:
+            evaluated_value = self._evaluate_expression(expression)
+            region, code = self._region_view(region_idx)
+            offset = final_address - region.base_address
             if size_bytes == 1:
-                struct.pack_into("<B", self.linked_code, offset, evaluated_value & 0xFF)
+                struct.pack_into("<B", code, offset, evaluated_value & 0xFF)
             elif size_bytes == 2:
-                struct.pack_into("<H", self.linked_code, offset, evaluated_value & 0xFFFF)
+                struct.pack_into("<H", code, offset, evaluated_value & 0xFFFF)
             elif size_bytes == 3:
                 if not -0x800000 <= evaluated_value <= 0xFFFFFF:
                     raise ExpressionEvaluationError(
-                        expression,
-                        f"result {evaluated_value:#x} is out of 24-bit range",
+                        expression, f"result {evaluated_value:#x} is out of 24-bit range"
                     )
-                self._write_le24(offset, evaluated_value & 0xFFFFFF)
+                self._write_le24(code, offset, evaluated_value & 0xFFFFFF)
             else:
-                raise ExpressionEvaluationError(
-                    expression,
-                    f"unsupported operand size: {size_bytes} bytes",
-                )
+                raise ExpressionEvaluationError(expression, f"unsupported operand size: {size_bytes} bytes")
+
+        self._flush_region_buffers()
 
     def _evaluate_expression(self, expression: str) -> int:
-        """Simple expression evaluator that resolves symbols from the symbol map"""
-        # This is a simple evaluator for basic expressions
-        # Replace symbols with their values and evaluate
         expr_to_eval = self._substitute_symbols(expression)
-
-        # Safely evaluate the expression using Python's eval with no builtins
         try:
             return cast(int, eval(expr_to_eval, {"__builtins__": {}}, {}))
         except (SyntaxError, NameError, TypeError, ValueError) as e:
             raise ExpressionEvaluationError(expression, str(e)) from e
 
     def _substitute_symbols(self, expression: str) -> str:
-        """Replace symbol occurrences with their numeric values without touching substrings."""
-
         def replace(match: Match[str]) -> str:
             token = match.group(0)
             if token in self.symbol_map:
@@ -246,9 +267,8 @@ class Linker:
 
         return SYMBOL_TOKEN_RE.sub(replace, expression)
 
-    def _write_le24(self, offset: int, value: int) -> None:
-        """Write a 24-bit little endian value into the linked code buffer."""
-        self.linked_code[offset : offset + 3] = bytes(
+    def _write_le24(self, code: bytearray, offset: int, value: int) -> None:
+        code[offset : offset + 3] = bytes(
             (
                 value & 0xFF,
                 (value >> 8) & 0xFF,

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -242,9 +242,7 @@ class Linker:
                 struct.pack_into("<H", code, offset, evaluated_value & 0xFFFF)
             elif size_bytes == 3:
                 if not -0x800000 <= evaluated_value <= 0xFFFFFF:
-                    raise ExpressionEvaluationError(
-                        expression, f"result {evaluated_value:#x} is out of 24-bit range"
-                    )
+                    raise ExpressionEvaluationError(expression, f"result {evaluated_value:#x} is out of 24-bit range")
                 self._write_le24(code, offset, evaluated_value & 0xFFFFFF)
             else:
                 raise ExpressionEvaluationError(expression, f"unsupported operand size: {size_bytes} bytes")

--- a/a816/object_file.py
+++ b/a816/object_file.py
@@ -1,4 +1,5 @@
 import struct
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import IO
 
@@ -24,126 +25,140 @@ class SymbolSection(Enum):
     BSS = 0x02
 
 
+@dataclass
+class Region:
+    """A contiguous span of emitted code and its associated relocations.
+
+    A new region is opened on every `*=` directive during compilation. Offsets
+    in `relocations`, `expression_relocations`, and `lines` are byte offsets
+    into this region's `code`, not into the concatenated module.
+    """
+
+    base_address: int
+    code: bytes
+    relocations: list[tuple[int, str, RelocationType]] = field(default_factory=list)
+    expression_relocations: list[tuple[int, str, int]] = field(default_factory=list)
+    lines: list[tuple[int, int, int, int, int]] = field(default_factory=list)
+
+
 class ObjectFile:
     MAGIC_NUMBER = 0x41383136  # 'A816'
-    VERSION = 0x0005  # Version 5: optional source-line + file table for .adbg propagation.
+    VERSION = 0x0006  # Version 6: region-aware code layout.
 
     def __init__(
         self,
-        code: bytes,
+        regions_or_code: list[Region] | bytes,
         symbols: list[tuple[str, int, SymbolType, SymbolSection]],
-        relocations: list[tuple[int, str, RelocationType]],
-        expression_relocations: list[tuple[int, str, int]] | None = None,  # (offset, expression_str, size_bytes)
-        aliases: list[tuple[str, str]] | None = None,  # (name, expression_str)
+        relocations: list[tuple[int, str, RelocationType]] | None = None,
+        expression_relocations: list[tuple[int, str, int]] | None = None,
+        aliases: list[tuple[str, str]] | None = None,
         files: list[str] | None = None,
-        # (offset, file_idx, line, column, flags) — offset is relative to code start.
         lines: list[tuple[int, int, int, int, int]] | None = None,
+        relocatable: bool = True,
     ) -> None:
-        self.code: bytes = code
+        # `relocatable` is True iff the source contained no `*=` directive,
+        # so the importer is free to place region 0 at the import site PC
+        # and shift CODE symbols accordingly. Once `*=` is present, every
+        # region is pinned to its compile-time base_address.
+        if isinstance(regions_or_code, bytes):
+            # Legacy single-region constructor used by tests.
+            self.regions: list[Region] = [
+                Region(
+                    base_address=0,
+                    code=regions_or_code,
+                    relocations=list(relocations) if relocations else [],
+                    expression_relocations=list(expression_relocations) if expression_relocations else [],
+                    lines=list(lines) if lines else [],
+                )
+            ]
+        else:
+            self.regions = regions_or_code
         self.symbols: list[tuple[str, int, SymbolType, SymbolSection]] = symbols
-        self.relocations: list[tuple[int, str, RelocationType]] = relocations
-        self.expression_relocations: list[tuple[int, str, int]] = expression_relocations or []
         self.aliases: list[tuple[str, str]] = aliases or []
         self.files: list[str] = files or []
-        self.lines: list[tuple[int, int, int, int, int]] = lines or []
+        self.relocatable: bool = relocatable
+
+    # ----- legacy single-region accessors (tests / older callers) -----
+    def _ensure_first_region(self) -> Region:
+        if not self.regions:
+            self.regions.append(Region(base_address=0, code=b""))
+        return self.regions[0]
+
+    @property
+    def code(self) -> bytes:
+        return self.regions[0].code if self.regions else b""
+
+    @code.setter
+    def code(self, value: bytes) -> None:
+        self._ensure_first_region().code = value
+
+    @property
+    def relocations(self) -> list[tuple[int, str, RelocationType]]:
+        return self.regions[0].relocations if self.regions else []
+
+    @relocations.setter
+    def relocations(self, value: list[tuple[int, str, RelocationType]]) -> None:
+        self._ensure_first_region().relocations = list(value)
+
+    @property
+    def expression_relocations(self) -> list[tuple[int, str, int]]:
+        return self.regions[0].expression_relocations if self.regions else []
+
+    @expression_relocations.setter
+    def expression_relocations(self, value: list[tuple[int, str, int]]) -> None:
+        self._ensure_first_region().expression_relocations = list(value)
+
+    @property
+    def lines(self) -> list[tuple[int, int, int, int, int]]:
+        out: list[tuple[int, int, int, int, int]] = []
+        for region in self.regions:
+            out.extend(region.lines)
+        return out
 
     def write(self, filename: str) -> None:
         with open(filename, "wb") as f:
             self._write_header(f)
-            self._write_code_data_section(f)
+            self._write_regions(f)
             self._write_symbol_table(f)
-            self._write_relocation_table(f)
-            self._write_expression_relocation_table(f)
             self._write_alias_table(f)
             self._write_file_table(f)
-            self._write_line_table(f)
 
     def _write_header(self, f: IO[bytes]) -> None:
-        code_size = len(self.code)
-        symbol_table_size = self._calculate_symbol_table_size()
-        relocation_table_size = self._calculate_relocation_table_size()
-        expression_relocation_table_size = self._calculate_expression_relocation_table_size()
-        alias_table_size = self._calculate_alias_table_size()
-        file_table_size = self._calculate_file_table_size()
-        line_table_size = self._calculate_line_table_size()
-
-        # Only the current version is supported; bump VERSION when the layout
-        # changes and update the reader in lockstep.
+        flags = 0x01 if self.relocatable else 0x00
         header = struct.pack(
-            "<IHIIIIIII",
+            "<IHB",
             self.MAGIC_NUMBER,
             self.VERSION,
-            code_size,
-            symbol_table_size,
-            relocation_table_size,
-            expression_relocation_table_size,
-            alias_table_size,
-            file_table_size,
-            line_table_size,
+            flags,
         )
         f.write(header)
 
-    def _write_code_data_section(self, f: IO[bytes]) -> None:
-        f.write(self.code)
+    def _write_regions(self, f: IO[bytes]) -> None:
+        f.write(struct.pack("<H", len(self.regions)))
+        for region in self.regions:
+            f.write(struct.pack("<II", region.base_address, len(region.code)))
+            f.write(struct.pack("<HHI", len(region.relocations), len(region.expression_relocations), len(region.lines)))
+            f.write(region.code)
+            for offset, name, reloc_type in region.relocations:
+                name_bytes = name.encode("utf-8")
+                f.write(struct.pack("<IB", offset, len(name_bytes)))
+                f.write(name_bytes)
+                f.write(struct.pack("<B", reloc_type.value))
+            for offset, expression, size_bytes in region.expression_relocations:
+                expr_bytes = expression.encode("utf-8")
+                f.write(struct.pack("<IH", offset, len(expr_bytes)))
+                f.write(expr_bytes)
+                f.write(struct.pack("<B", size_bytes))
+            for offset, file_idx, line, column, flags in region.lines:
+                f.write(struct.pack("<IIIHB", offset, file_idx, line, column & 0xFFFF, flags & 0xFF))
 
     def _write_symbol_table(self, f: IO[bytes]) -> None:
-        num_symbols = len(self.symbols)
-        f.write(struct.pack("<H", num_symbols))
+        f.write(struct.pack("<H", len(self.symbols)))
         for name, address, symbol_type, section in self.symbols:
             name_bytes = name.encode("utf-8")
             f.write(struct.pack("<B", len(name_bytes)))
             f.write(name_bytes)
-            f.write(struct.pack("<I", address))
-            f.write(struct.pack("<B", symbol_type.value))
-            f.write(struct.pack("<B", section.value))
-
-    def _write_relocation_table(self, f: IO[bytes]) -> None:
-        num_relocations = len(self.relocations)
-        f.write(struct.pack("<H", num_relocations))
-        for offset, symbol_name, relocation_type in self.relocations:
-            name_bytes = symbol_name.encode("utf-8")
-            f.write(struct.pack("<I", offset))
-            f.write(struct.pack("<B", len(name_bytes)))
-            f.write(name_bytes)
-            f.write(struct.pack("<B", relocation_type.value))
-
-    def _calculate_symbol_table_size(self) -> int:
-        size = 2  # Number of symbols (2 bytes)
-        for name, _, _, _ in self.symbols:
-            size += 1  # Name length (1 byte)
-            size += len(name)  # Name bytes
-            size += 4  # Address (4 bytes)
-            size += 1  # Symbol Type (1 byte)
-            size += 1  # Symbol Section (1 byte)
-        return size
-
-    def _calculate_relocation_table_size(self) -> int:
-        size = 2  # Number of relocations (2 bytes)
-        for _, name, _ in self.relocations:
-            size += 4  # Offset (4 bytes)
-            size += 1  # Name length (1 byte)
-            size += len(name)  # Name bytes
-            size += 1  # Relocation Type (1 byte)
-        return size
-
-    def _write_expression_relocation_table(self, f: IO[bytes]) -> None:
-        num_expr_relocations = len(self.expression_relocations)
-        f.write(struct.pack("<H", num_expr_relocations))
-        for offset, expression, size_bytes in self.expression_relocations:
-            expr_bytes = expression.encode("utf-8")
-            f.write(struct.pack("<I", offset))
-            f.write(struct.pack("<H", len(expr_bytes)))
-            f.write(expr_bytes)
-            f.write(struct.pack("<B", size_bytes))
-
-    def _calculate_expression_relocation_table_size(self) -> int:
-        size = 2  # Number of expression relocations (2 bytes)
-        for _, expression, _ in self.expression_relocations:
-            size += 4  # Offset (4 bytes)
-            size += 2  # Expression length (2 bytes)
-            size += len(expression)  # Expression bytes
-            size += 1  # Size in bytes (1 byte)
-        return size
+            f.write(struct.pack("<IBB", address, symbol_type.value, section.value))
 
     def _write_alias_table(self, f: IO[bytes]) -> None:
         f.write(struct.pack("<H", len(self.aliases)))
@@ -155,12 +170,6 @@ class ObjectFile:
             f.write(struct.pack("<H", len(expr_bytes)))
             f.write(expr_bytes)
 
-    def _calculate_alias_table_size(self) -> int:
-        size = 2
-        for name, expression in self.aliases:
-            size += 1 + len(name) + 2 + len(expression)
-        return size
-
     def _write_file_table(self, f: IO[bytes]) -> None:
         f.write(struct.pack("<H", len(self.files)))
         for path in self.files:
@@ -168,123 +177,87 @@ class ObjectFile:
             f.write(struct.pack("<H", len(encoded)))
             f.write(encoded)
 
-    def _calculate_file_table_size(self) -> int:
-        size = 2
-        for path in self.files:
-            size += 2 + len(path.encode("utf-8"))
-        return size
-
-    def _write_line_table(self, f: IO[bytes]) -> None:
-        f.write(struct.pack("<I", len(self.lines)))
-        for offset, file_idx, line, column, flags in self.lines:
-            f.write(struct.pack("<IIIHB", offset, file_idx, line, column & 0xFFFF, flags & 0xFF))
-
-    def _calculate_line_table_size(self) -> int:
-        # Each entry: u32 offset + u32 file_idx + u32 line + u16 column + u8 flags = 15 bytes.
-        return 4 + 15 * len(self.lines)
-
     @staticmethod
-    def _read_file_table(f: IO[bytes], table_size: int) -> list[str]:
-        if table_size == 0:
-            return []
-        count = struct.unpack("<H", f.read(2))[0]
-        files: list[str] = []
+    def _read_regions(f: IO[bytes]) -> list[Region]:
+        (count,) = struct.unpack("<H", f.read(2))
+        regions: list[Region] = []
         for _ in range(count):
-            length = struct.unpack("<H", f.read(2))[0]
-            files.append(f.read(length).decode("utf-8"))
-        return files
+            base_address, code_size = struct.unpack("<II", f.read(8))
+            num_relocs, num_expr_relocs, num_lines = struct.unpack("<HHI", f.read(8))
+            code = f.read(code_size)
+            relocs: list[tuple[int, str, RelocationType]] = []
+            for _ in range(num_relocs):
+                offset, name_len = struct.unpack("<IB", f.read(5))
+                name = f.read(name_len).decode("utf-8")
+                (rt_value,) = struct.unpack("<B", f.read(1))
+                relocs.append((offset, name, RelocationType(rt_value)))
+            expr_relocs: list[tuple[int, str, int]] = []
+            for _ in range(num_expr_relocs):
+                offset, expr_len = struct.unpack("<IH", f.read(6))
+                expression = f.read(expr_len).decode("utf-8")
+                (size_bytes,) = struct.unpack("<B", f.read(1))
+                expr_relocs.append((offset, expression, size_bytes))
+            lines: list[tuple[int, int, int, int, int]] = []
+            for _ in range(num_lines):
+                offset, file_idx, line, column, flags = struct.unpack("<IIIHB", f.read(15))
+                lines.append((offset, file_idx, line, column, flags))
+            regions.append(
+                Region(
+                    base_address=base_address,
+                    code=code,
+                    relocations=relocs,
+                    expression_relocations=expr_relocs,
+                    lines=lines,
+                )
+            )
+        return regions
 
     @staticmethod
-    def _read_line_table(f: IO[bytes], table_size: int) -> list[tuple[int, int, int, int, int]]:
-        if table_size == 0:
-            return []
-        count = struct.unpack("<I", f.read(4))[0]
-        lines: list[tuple[int, int, int, int, int]] = []
+    def _read_symbol_table(f: IO[bytes]) -> list[tuple[str, int, SymbolType, SymbolSection]]:
+        (count,) = struct.unpack("<H", f.read(2))
+        out: list[tuple[str, int, SymbolType, SymbolSection]] = []
         for _ in range(count):
-            offset, file_idx, line, column, flags = struct.unpack("<IIIHB", f.read(15))
-            lines.append((offset, file_idx, line, column, flags))
-        return lines
+            (name_len,) = struct.unpack("<B", f.read(1))
+            name = f.read(name_len).decode("utf-8")
+            address, sym_type, section = struct.unpack("<IBB", f.read(6))
+            out.append((name, address, SymbolType(sym_type), SymbolSection(section)))
+        return out
 
     @staticmethod
-    def _read_symbols(f: IO[bytes]) -> list[tuple[str, int, SymbolType, SymbolSection]]:
-        num_symbols = struct.unpack("<H", f.read(2))[0]
-        symbols = []
-        for _ in range(num_symbols):
-            name_length = struct.unpack("<B", f.read(1))[0]
-            name = f.read(name_length).decode("utf-8")
-            address = struct.unpack("<I", f.read(4))[0]
-            symbol_type = SymbolType(struct.unpack("<B", f.read(1))[0])
-            section = SymbolSection(struct.unpack("<B", f.read(1))[0])
-            symbols.append((name, address, symbol_type, section))
-        return symbols
+    def _read_alias_table(f: IO[bytes]) -> list[tuple[str, str]]:
+        (count,) = struct.unpack("<H", f.read(2))
+        out: list[tuple[str, str]] = []
+        for _ in range(count):
+            (name_len,) = struct.unpack("<B", f.read(1))
+            name = f.read(name_len).decode("utf-8")
+            (expr_len,) = struct.unpack("<H", f.read(2))
+            expression = f.read(expr_len).decode("utf-8")
+            out.append((name, expression))
+        return out
 
     @staticmethod
-    def _read_relocations(f: IO[bytes]) -> list[tuple[int, str, RelocationType]]:
-        num_relocations = struct.unpack("<H", f.read(2))[0]
-        relocations = []
-        for _ in range(num_relocations):
-            offset = struct.unpack("<I", f.read(4))[0]
-            name_length = struct.unpack("<B", f.read(1))[0]
-            name = f.read(name_length).decode("utf-8")
-            relocation_type = RelocationType(struct.unpack("<B", f.read(1))[0])
-            relocations.append((offset, name, relocation_type))
-        return relocations
-
-    @staticmethod
-    def _read_expression_relocations(f: IO[bytes], table_size: int) -> list[tuple[int, str, int]]:
-        if table_size == 0:
-            return []
-        num_expr_relocations = struct.unpack("<H", f.read(2))[0]
-        expression_relocations = []
-        for _ in range(num_expr_relocations):
-            offset = struct.unpack("<I", f.read(4))[0]
-            expr_length = struct.unpack("<H", f.read(2))[0]
-            expression = f.read(expr_length).decode("utf-8")
-            size_bytes = struct.unpack("<B", f.read(1))[0]
-            expression_relocations.append((offset, expression, size_bytes))
-        return expression_relocations
-
-    @staticmethod
-    def _read_aliases(f: IO[bytes], table_size: int) -> list[tuple[str, str]]:
-        if table_size == 0:
-            return []
-        num_aliases = struct.unpack("<H", f.read(2))[0]
-        aliases: list[tuple[str, str]] = []
-        for _ in range(num_aliases):
-            name_length = struct.unpack("<B", f.read(1))[0]
-            name = f.read(name_length).decode("utf-8")
-            expr_length = struct.unpack("<H", f.read(2))[0]
-            expression = f.read(expr_length).decode("utf-8")
-            aliases.append((name, expression))
-        return aliases
+    def _read_file_table(f: IO[bytes]) -> list[str]:
+        (count,) = struct.unpack("<H", f.read(2))
+        out: list[str] = []
+        for _ in range(count):
+            (path_len,) = struct.unpack("<H", f.read(2))
+            out.append(f.read(path_len).decode("utf-8"))
+        return out
 
     @staticmethod
     def from_file(filename: str) -> "ObjectFile":
         with open(filename, "rb") as f:
-            header_data = f.read(34)
-            if len(header_data) < 34:
+            header = f.read(7)
+            if len(header) < 7:
                 raise ValueError(INVALID_FILE_FORMAT)
-            (
-                magic_number,
-                version,
-                code_size,
-                _,
-                _,
-                expression_relocation_table_size,
-                alias_table_size,
-                file_table_size,
-                line_table_size,
-            ) = struct.unpack("<IHIIIIIII", header_data)
-            if magic_number != ObjectFile.MAGIC_NUMBER:
+            magic, version, flags = struct.unpack("<IHB", header)
+            if magic != ObjectFile.MAGIC_NUMBER:
                 raise ValueError("Invalid magic number")
             if version != ObjectFile.VERSION:
                 raise ValueError(f"Unsupported version: {version} (expected {ObjectFile.VERSION})")
-
-            code = f.read(code_size)
-            symbols = ObjectFile._read_symbols(f)
-            relocations = ObjectFile._read_relocations(f)
-            expression_relocations = ObjectFile._read_expression_relocations(f, expression_relocation_table_size)
-            aliases = ObjectFile._read_aliases(f, alias_table_size)
-            files = ObjectFile._read_file_table(f, file_table_size)
-            lines = ObjectFile._read_line_table(f, line_table_size)
-            return ObjectFile(code, symbols, relocations, expression_relocations, aliases, files=files, lines=lines)
+            relocatable = bool(flags & 0x01)
+            regions = ObjectFile._read_regions(f)
+            symbols = ObjectFile._read_symbol_table(f)
+            aliases = ObjectFile._read_alias_table(f)
+            files = ObjectFile._read_file_table(f)
+            return ObjectFile(regions, symbols, aliases=aliases, files=files, relocatable=relocatable)

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -388,8 +388,7 @@ def _import_from_object(
         symbols_data = [
             (name, address, sym_type.value, section.value) for name, address, sym_type, section in obj_file.symbols
         ]
-        expr_relocs = list(obj_file.expression_relocations) if obj_file.expression_relocations else []
-        return [LinkedModuleNode(module_name, obj_file.code, symbols_data, resolver, expr_relocs)]
+        return [LinkedModuleNode(module_name, obj_file.regions, symbols_data, resolver, obj_file.relocatable)]
 
     return [ExternNode(name, resolver) for name, _, sym_type, _ in obj_file.symbols if sym_type == SymbolType.GLOBAL]
 

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -369,8 +369,7 @@ class LinkedModuleNode(NodeProtocol):
 
     def _reloc_context(self, offset: int, region: Region) -> str:
         return (
-            f"module '{self.module_name}' region@0x{region.base_address:x} "
-            f"offset 0x{offset:x}/0x{len(region.code):x}"
+            f"module '{self.module_name}' region@0x{region.base_address:x} offset 0x{offset:x}/0x{len(region.code):x}"
         )
 
     def _write_reloc(
@@ -389,9 +388,7 @@ class LinkedModuleNode(NodeProtocol):
         for i in range(size):
             code_array[offset + i] = (value >> (8 * i)) & 0xFF
 
-    def _eval_one_relocation(
-        self, expr: str, offset: int, size: int, code_array: bytearray, region: Region
-    ) -> None:
+    def _eval_one_relocation(self, expr: str, offset: int, size: int, code_array: bytearray, region: Region) -> None:
         from a816.parse.ast.expression import eval_expression_str
 
         ctx = self._reloc_context(offset, region)

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -10,6 +10,7 @@ from a816.cpu.cpu_65c816 import (
 from a816.cpu.mapping import Address
 from a816.cpu.types import AddressingMode, ValueSize
 from a816.exceptions import ExternalExpressionReference, ExternalSymbolReference, SymbolNotDefined
+from a816.object_file import Region
 from a816.parse.ast.expression import eval_expression, eval_expression_str
 from a816.parse.ast.nodes import BlockAstNode, ExpressionAstNode
 from a816.parse.tokens import Token
@@ -257,85 +258,137 @@ class BinaryNode(NodeProtocol):
 
 
 class LinkedModuleNode(NodeProtocol):
-    """Node that emits code from a compiled module and binds its symbols.
+    """Emits a compiled module's regions and binds its symbols.
 
-    This is used by .import for position-dependent code (like ROM patches).
-    It loads the module's compiled code and adjusts symbol addresses based
-    on the current PC position.
+    Each region has a compile-time `base_address` (from `*=`) and a code
+    blob. If the module is `relocatable` (no `*=` was present), region 0
+    gets shifted by `delta = import_pc - regions[0].base_address` and
+    every CODE symbol moves with it. Otherwise regions land at their
+    declared absolute addresses, ignoring the import site.
     """
 
     def __init__(
         self,
         module_name: str,
-        code: bytes,
-        symbols: list[tuple[str, int, int, int]],  # (name, offset, type, section)
+        regions: list[Region],
+        symbols: list[tuple[str, int, int, int]],  # (name, address, type, section)
         resolver: Resolver,
-        expression_relocations: list[tuple[int, str, int]] | None = None,  # (offset, expr, size)
+        relocatable: bool = True,
     ) -> None:
         self.module_name = module_name
-        self.code = code
+        self.regions = regions
         self.symbols = symbols
         self.resolver = resolver
-        self.expression_relocations = expression_relocations or []
+        self.relocatable = relocatable
+        self._delta = 0
+        # Cache placed regions for emit_blocks; refreshed on every pc_after.
+        self._placed: list[tuple[int, bytes]] = []
 
     def emit(self, current_addr: Address) -> bytes:
-        # Apply expression relocations every emit; symbols may have moved between passes.
-        if self.expression_relocations:
-            return self._apply_expression_relocations()
-        return self.code
+        # Single-region modules still flow through the legacy single-bytes
+        # path used by writers that don't know about emit_blocks.
+        del current_addr
+        if not self._placed:
+            return b""
+        if len(self._placed) == 1:
+            return self._placed[0][1]
+        # Multi-region modules must go through emit_blocks; returning the
+        # concatenation here would silently corrupt the output.
+        return b""
+
+    def emit_blocks(self, current_addr: Address) -> list[tuple[int, bytes]]:
+        del current_addr
+        return list(self._placed)
 
     def pc_after(self, current_pc: Address) -> Address:
-        # Rebind every pass: write directly to the scope dicts to avoid
-        # add_symbol's duplicate-warning while keeping the symbol map current.
         from a816.object_file import SymbolSection, SymbolType
 
+        if not self.regions:
+            return current_pc
+
         scope = self.resolver.current_scope
-        base_address = current_pc.logical_value
-        # Track this module's load base so the producer of .sym/.adbg can
-        # report the resolved address range without re-walking the linker.
-        self.base_address = base_address
-        # Module-private map for LOCAL labels (kept off of scope to avoid
-        # cross-module name clashes — e.g. two modules both define `loop`).
+        if self.relocatable:
+            self._delta = current_pc.logical_value - self.regions[0].base_address
+        else:
+            self._delta = 0
+
+        # Shifted base of region 0 — used for the .sym/.adbg producer to
+        # report where the module actually landed.
+        self.base_address = self.regions[0].base_address + self._delta
+        self._placed = self._compute_placement()
         self._local_map: dict[str, int] = {}
-        for name, offset, sym_type, section in self.symbols:
+
+        for name, address, sym_type, section in self.symbols:
+            final = self._resolve_symbol_address(address, section)
             if sym_type == SymbolType.GLOBAL.value:
+                scope.symbols[name] = final
                 if section == SymbolSection.CODE.value:
-                    final = base_address + offset
-                    scope.symbols[name] = final
-                    # Without this the symbol never reaches get_all_labels,
-                    # so .sym output drops every module-defined label.
                     scope.labels[name] = final
-                else:
-                    scope.symbols[name] = offset
             elif sym_type == SymbolType.LOCAL.value:
-                if section == SymbolSection.CODE.value:
-                    self._local_map[name] = base_address + offset
-                else:
-                    self._local_map[name] = offset
+                self._local_map[name] = final
 
-        return current_pc + len(self.code)
+        # Only region 0 advances the importer's PC; later regions sit at
+        # their declared absolute addresses and do not consume linear
+        # space at the import site.
+        first_base, first_code = self._placed[0]
+        return self.resolver.get_bus().get_address(first_base + len(first_code))
 
-    def _reloc_context(self, offset: int) -> str:
-        return f"module '{self.module_name}' offset 0x{offset:x}/0x{len(self.code):x}"
+    def _resolve_symbol_address(self, address: int, section: int) -> int:
+        from a816.object_file import SymbolSection
 
-    def _write_reloc(self, code_array: bytearray, offset: int, value: int, size: int, expr: str) -> None:
-        ctx = self._reloc_context(offset)
+        if section != SymbolSection.CODE.value:
+            return address
+        return address + self._delta
+
+    def _compute_placement(self) -> list[tuple[int, bytes]]:
+        placed: list[tuple[int, bytes]] = []
+        for region in self.regions:
+            base = region.base_address + self._delta
+            patched = self._apply_region_relocations(region)
+            placed.append((base, patched))
+        return placed
+
+    def _apply_region_relocations(self, region: Region) -> bytes:
+        if not region.expression_relocations:
+            return region.code
+        code_array = bytearray(region.code)
+        root_scope = self.resolver.scopes[0]
+        saved = self._inject_locals(root_scope)
+        try:
+            for offset, expr, size in region.expression_relocations:
+                self._eval_one_relocation(expr, offset, size, code_array, region)
+        finally:
+            self._restore_locals(root_scope, saved)
+        return bytes(code_array)
+
+    def _reloc_context(self, offset: int, region: Region) -> str:
+        return (
+            f"module '{self.module_name}' region@0x{region.base_address:x} "
+            f"offset 0x{offset:x}/0x{len(region.code):x}"
+        )
+
+    def _write_reloc(
+        self, code_array: bytearray, offset: int, value: int, size: int, expr: str, region: Region
+    ) -> None:
+        ctx = self._reloc_context(offset, region)
         if size not in (1, 2, 3):
             logger.warning(f"Unsupported relocation size {size} for expression '{expr}' [{ctx}]")
             return
         if offset + size > len(code_array):
             logger.warning(
-                f"Relocation runs past module code: offset 0x{offset:x} + size {size} "
+                f"Relocation runs past region code: offset 0x{offset:x} + size {size} "
                 f"> 0x{len(code_array):x} for expression '{expr}' [{ctx}]"
             )
             return
         for i in range(size):
             code_array[offset + i] = (value >> (8 * i)) & 0xFF
 
-    def _eval_one_relocation(self, expr: str, offset: int, size: int, code_array: bytearray) -> None:
+    def _eval_one_relocation(
+        self, expr: str, offset: int, size: int, code_array: bytearray, region: Region
+    ) -> None:
         from a816.parse.ast.expression import eval_expression_str
 
-        ctx = self._reloc_context(offset)
+        ctx = self._reloc_context(offset, region)
         try:
             value = eval_expression_str(expr, self.resolver)
         except (SymbolNotDefined, NodeError, ValueError) as e:
@@ -344,7 +397,7 @@ class LinkedModuleNode(NodeProtocol):
         if not isinstance(value, int):
             logger.warning(f"Expression '{expr}' did not evaluate to int: {value} [{ctx}]")
             return
-        self._write_reloc(code_array, offset, value, size, expr)
+        self._write_reloc(code_array, offset, value, size, expr, region)
 
     def _inject_locals(self, root_scope: Scope) -> dict[str, int | str]:
         local_map = getattr(self, "_local_map", {})
@@ -363,23 +416,12 @@ class LinkedModuleNode(NodeProtocol):
             else:
                 root_scope.symbols.pop(name, None)
 
-    def _apply_expression_relocations(self) -> bytes:
-        """Apply expression relocations to the module's code."""
-        code_array = bytearray(self.code)
-        # Inject this module's LOCAL labels into the resolver's root scope
-        # for the duration of the eval; restore afterwards. Keeps two
-        # modules' identical local names from colliding with each other.
-        root_scope = self.resolver.scopes[0]
-        saved = self._inject_locals(root_scope)
-        try:
-            for offset, expr, size in self.expression_relocations:
-                self._eval_one_relocation(expr, offset, size, code_array)
-        finally:
-            self._restore_locals(root_scope, saved)
-        return bytes(code_array)
-
     def __str__(self) -> str:
-        return f"LinkedModuleNode({self.module_name}, {len(self.code)} bytes, {len(self.symbols)} symbols)"
+        total = sum(len(r.code) for r in self.regions)
+        return (
+            f"LinkedModuleNode({self.module_name}, {len(self.regions)} regions, "
+            f"{total} bytes, {len(self.symbols)} symbols)"
+        )
 
 
 class LongNode(NodeProtocol):
@@ -393,7 +435,9 @@ class LongNode(NodeProtocol):
             resolver = self.value_node.resolver
             if resolver.context.is_object_mode and resolver.context.object_writer is not None:
                 resolver.context.object_writer.add_expression_relocation(
-                    resolver.pc, self.value_node._deferred_expression, 3
+                    resolver.context.object_writer.relocation_offset(),
+                    self.value_node._deferred_expression,
+                    3,
                 )
         return struct.pack("<HB", value & 0xFFFF, (value >> 16) & 0xFF)
 
@@ -412,7 +456,9 @@ class WordNode(NodeProtocol):
             resolver = self.value_node.resolver
             if resolver.context.is_object_mode and resolver.context.object_writer is not None:
                 resolver.context.object_writer.add_expression_relocation(
-                    resolver.pc, self.value_node._deferred_expression, 2
+                    resolver.context.object_writer.relocation_offset(),
+                    self.value_node._deferred_expression,
+                    2,
                 )
         return struct.pack("<H", value & 0xFFFF)
 
@@ -460,7 +506,9 @@ class ByteNode(NodeProtocol):
             resolver = self.value_node.resolver
             if resolver.context.is_object_mode and resolver.context.object_writer is not None:
                 resolver.context.object_writer.add_expression_relocation(
-                    resolver.pc, self.value_node._deferred_expression, 1
+                    resolver.context.object_writer.relocation_offset(),
+                    self.value_node._deferred_expression,
+                    1,
                 )
         return struct.pack("B", value & 0xFF)
 

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -340,9 +340,14 @@ class LinkedModuleNode(NodeProtocol):
         if self.is_loser:
             return current_pc
 
-        # Only region 0 advances the importer's PC; later regions sit at
-        # their declared absolute addresses and do not consume linear
-        # space at the import site.
+        # Pinned modules (any explicit `*=`) land at their declared
+        # absolute base addresses; the importer's PC stays where it was
+        # because the module does not occupy linear space at the import
+        # site. Only relocatable single-region modules advance the
+        # importer's PC by their first-region size.
+        if not self.relocatable:
+            return current_pc
+
         first = self.regions[0]
         first_end = first.base_address + self._delta + len(first.code)
         return self.resolver.get_bus().get_address(first_end)

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -280,6 +280,12 @@ class LinkedModuleNode(NodeProtocol):
         self.symbols = symbols
         self.resolver = resolver
         self.relocatable = relocatable
+        # Set by Program._mark_import_winners: True for every duplicate
+        # `.import` of the same module except the last occurrence in
+        # program order. Losers bind symbols (so the loser's source can
+        # still reference them) but do NOT advance the PC and do NOT
+        # emit bytes — the winner is the canonical placement.
+        self.is_loser: bool = False
         self._delta = 0
         # Cache placed regions for emit_blocks; refreshed on every pc_after.
         self._placed: list[tuple[int, bytes]] = []
@@ -326,6 +332,13 @@ class LinkedModuleNode(NodeProtocol):
                     scope.labels[name] = final
             elif sym_type == SymbolType.LOCAL.value:
                 self._local_map[name] = final
+
+        # Loser duplicates publish symbols (winner overwrites later via
+        # last-pass) but must not consume PC space — otherwise inline
+        # source surrounding the loser .import shifts forward by the
+        # module's size and lands on top of unrelated ROM.
+        if self.is_loser:
+            return current_pc
 
         # Only region 0 advances the importer's PC; later regions sit at
         # their declared absolute addresses and do not consume linear

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -288,17 +288,18 @@ class LinkedModuleNode(NodeProtocol):
         # Single-region modules still flow through the legacy single-bytes
         # path used by writers that don't know about emit_blocks.
         del current_addr
-        if not self._placed:
+        placed = self._compute_placement()
+        if not placed:
             return b""
-        if len(self._placed) == 1:
-            return self._placed[0][1]
+        if len(placed) == 1:
+            return placed[0][1]
         # Multi-region modules must go through emit_blocks; returning the
         # concatenation here would silently corrupt the output.
         return b""
 
     def emit_blocks(self, current_addr: Address) -> list[tuple[int, bytes]]:
         del current_addr
-        return list(self._placed)
+        return self._compute_placement()
 
     def pc_after(self, current_pc: Address) -> Address:
         from a816.object_file import SymbolSection, SymbolType
@@ -315,7 +316,6 @@ class LinkedModuleNode(NodeProtocol):
         # Shifted base of region 0 — used for the .sym/.adbg producer to
         # report where the module actually landed.
         self.base_address = self.regions[0].base_address + self._delta
-        self._placed = self._compute_placement()
         self._local_map: dict[str, int] = {}
 
         for name, address, sym_type, section in self.symbols:
@@ -330,8 +330,9 @@ class LinkedModuleNode(NodeProtocol):
         # Only region 0 advances the importer's PC; later regions sit at
         # their declared absolute addresses and do not consume linear
         # space at the import site.
-        first_base, first_code = self._placed[0]
-        return self.resolver.get_bus().get_address(first_base + len(first_code))
+        first = self.regions[0]
+        first_end = first.base_address + self._delta + len(first.code)
+        return self.resolver.get_bus().get_address(first_end)
 
     def _resolve_symbol_address(self, address: int, section: int) -> int:
         from a816.object_file import SymbolSection
@@ -341,11 +342,16 @@ class LinkedModuleNode(NodeProtocol):
         return address + self._delta
 
     def _compute_placement(self) -> list[tuple[int, bytes]]:
+        # Re-evaluate every call: cross-module symbols may have been bound
+        # by other LinkedModuleNodes after this one's pc_after ran. Doing
+        # the eval lazily at emit time avoids spurious "Failed to
+        # evaluate" warnings during the first resolve_labels pass.
         placed: list[tuple[int, bytes]] = []
         for region in self.regions:
             base = region.base_address + self._delta
             patched = self._apply_region_relocations(region)
             placed.append((base, patched))
+        self._placed = placed
         return placed
 
     def _apply_region_relocations(self, region: Region) -> bytes:

--- a/a816/program.py
+++ b/a816/program.py
@@ -211,8 +211,11 @@ class Program:
                 for base, block in blocks:
                     if block:
                         writer.write_block(block, self._to_physical(base))
-                if blocks:
-                    first_base, first_code = blocks[0]
+                # Pinned modules don't consume linear PC at the import
+                # site; only relocatable modules advance the importer's
+                # PC by their first-region size (matching pc_after).
+                if blocks and node.relocatable:
+                    first_code = blocks[0][1]
                     advance = len(first_code)
                     self.resolver.pc += advance
                     self.resolver.reloc_address += advance

--- a/a816/program.py
+++ b/a816/program.py
@@ -130,6 +130,28 @@ class Program:
             previous_pc = node.pc_after(previous_pc)
         self.resolver_reset()
 
+    def _to_physical(self, logical_address: int) -> int:
+        """Translate a logical SNES bus address to its physical ROM offset.
+
+        IPS/SFC writers expect physical (file) offsets. The legacy emit()
+        path got this for free because resolver.pc tracks physical, but
+        regions carry logical bases — convert at the write boundary.
+
+        Falls back to the logical address if no mapping is configured for
+        the current rom_type (some rom types have no default bus); the
+        caller would have written the logical address pre-multi-region
+        anyway, so the fallback preserves existing behavior.
+        """
+        try:
+            bus = self.resolver.get_bus()
+            addr = bus.get_address(logical_address)
+            physical = addr.physical
+        except KeyError:
+            return logical_address
+        if physical is None:
+            return logical_address
+        return physical
+
     def emit(self, program: list[NodeProtocol], writer: Writer) -> None:
         """Emit machine code from resolved nodes to a writer.
 
@@ -158,7 +180,7 @@ class Program:
                 blocks = node.emit_blocks(self.resolver.reloc_address)
                 for base, block in blocks:
                     if block:
-                        writer.write_block(block, base)
+                        writer.write_block(block, self._to_physical(base))
                 if blocks:
                     first_base, first_code = blocks[0]
                     advance = len(first_code)
@@ -592,7 +614,7 @@ class Program:
 
                 for region in linked_obj.regions:
                     if region.code:
-                        ips_emitter.write_block(region.code, region.base_address)
+                        ips_emitter.write_block(region.code, self._to_physical(region.base_address))
 
                 ips_emitter.end()
                 self.write_debug_info_for_linked(linked_obj, ips_file)
@@ -621,7 +643,7 @@ class Program:
 
                 for region in linked_obj.regions:
                     if region.code:
-                        sfc_emitter.write_block(region.code, region.base_address)
+                        sfc_emitter.write_block(region.code, self._to_physical(region.base_address))
 
                 sfc_emitter.end()
                 self.write_debug_info_for_linked(linked_obj, sfc_file)

--- a/a816/program.py
+++ b/a816/program.py
@@ -165,12 +165,34 @@ class Program:
         """
         from a816.parse.nodes import LinkedModuleNode
 
+        # `.import "foo"` is idempotent across the program: a project may
+        # carry the import in both an included patch file and the main
+        # source for symbol-visibility reasons. Only the LAST occurrence
+        # of each module name materializes the bytes; earlier occurrences
+        # still let pc_after rebind globals.
+        last_module_index: dict[str, int] = {}
+        for idx, node in enumerate(program):
+            if isinstance(node, LinkedModuleNode):
+                last_module_index[node.module_name] = idx
+
         current_block = b""
         current_block_addr = self.resolver.pc
-        for node in program:
+        for idx, node in enumerate(program):
             pre_emit_addr = self.resolver.reloc_address.logical_value
 
             if isinstance(node, LinkedModuleNode):
+                if last_module_index.get(node.module_name) != idx:
+                    # Symbols already (re-)bound in pc_after; advance the
+                    # resolver in lockstep with pc_after's first-region
+                    # delta so any inline code that follows this earlier
+                    # `.import` lands at the right address even though no
+                    # bytes are emitted here.
+                    if node.regions:
+                        advance = len(node.regions[0].code)
+                        self.resolver.pc += advance
+                        self.resolver.reloc_address += advance
+                        current_block_addr = self.resolver.pc
+                    continue
                 # Multi-region modules emit separate blocks at their own
                 # absolute base addresses; flush the pending block first so
                 # writes don't get re-keyed under the module's address.

--- a/a816/program.py
+++ b/a816/program.py
@@ -102,6 +102,30 @@ class Program:
         self.resolver.last_used_scope = 0
         self.resolver.current_scope = self.resolver.scopes[0]
 
+    @staticmethod
+    def _mark_import_winners(program_nodes: list[NodeProtocol]) -> None:
+        """Tag every duplicate `.import "foo"` LinkedModuleNode except the
+        last as `is_loser=True`.
+
+        `.import` is idempotent across the program: a module may appear
+        in an `.include`'d patch file as well as the main source for
+        symbol-visibility reasons. Only the last occurrence emits bytes
+        and consumes PC space; earlier ones still bind symbols (for
+        scope visibility in the surrounding source) but otherwise are
+        no-ops in both `pc_after` and `emit`. Marking happens before
+        `resolve_labels` so the winner/loser distinction is consistent
+        across the address-resolution and emission passes.
+        """
+        from a816.parse.nodes import LinkedModuleNode
+
+        last_idx: dict[str, int] = {}
+        for idx, node in enumerate(program_nodes):
+            if isinstance(node, LinkedModuleNode):
+                last_idx[node.module_name] = idx
+        for idx, node in enumerate(program_nodes):
+            if isinstance(node, LinkedModuleNode):
+                node.is_loser = last_idx[node.module_name] != idx
+
     def resolve_labels(self, program_nodes: list[NodeProtocol]) -> None:
         """Resolve all labels and symbols through multi-pass processing.
 
@@ -165,36 +189,17 @@ class Program:
         """
         from a816.parse.nodes import LinkedModuleNode
 
-        # `.import "foo"` is idempotent across the program: a project may
-        # carry the import in both an included patch file and the main
-        # source for symbol-visibility reasons. Only the LAST occurrence
-        # of each module name materializes the bytes; earlier occurrences
-        # still let pc_after rebind globals.
-        last_module_index: dict[str, int] = {}
-        for idx, node in enumerate(program):
-            if isinstance(node, LinkedModuleNode):
-                last_module_index[node.module_name] = idx
-
         current_block = b""
         current_block_addr = self.resolver.pc
-        for idx, node in enumerate(program):
+        for node in program:
             pre_emit_addr = self.resolver.reloc_address.logical_value
 
             if isinstance(node, LinkedModuleNode):
-                if last_module_index.get(node.module_name) != idx:
-                    # Symbols already (re-)bound in pc_after; this earlier
-                    # `.import` is symbol-only. Flush the pending block at
-                    # its original address before advancing the PC so the
-                    # next current_block_addr reflects the post-skip
-                    # position rather than re-keying old bytes there.
-                    if node.regions:
-                        if len(current_block) > 0:
-                            writer.write_block(current_block, current_block_addr)
-                            current_block = b""
-                        advance = len(node.regions[0].code)
-                        self.resolver.pc += advance
-                        self.resolver.reloc_address += advance
-                        current_block_addr = self.resolver.pc
+                if node.is_loser:
+                    # Loser duplicate `.import`: pc_after did not advance,
+                    # symbols already bound elsewhere. Treat as a pure
+                    # no-op — leave current_block untouched so surrounding
+                    # inline source keeps its address layout.
                     continue
                 # Multi-region modules emit separate blocks at their own
                 # absolute base addresses; flush the pending block first so
@@ -313,6 +318,7 @@ class Program:
         if error is not None:
             return error
 
+        self._mark_import_winners(nodes)
         self.logger.info("Resolving labels")
         self.resolve_labels(nodes)
 
@@ -428,6 +434,7 @@ class Program:
                     self.logger.error(error)
                     return -1
 
+                self._mark_import_winners(nodes)
                 self.logger.info("Resolving labels")
                 self.resolve_labels(nodes)
                 self._export_object_symbols(object_writer)

--- a/a816/program.py
+++ b/a816/program.py
@@ -141,10 +141,32 @@ class Program:
             program: List of resolved executable nodes.
             writer: Output writer (IPSWriter, SFCWriter, etc.).
         """
+        from a816.parse.nodes import LinkedModuleNode
+
         current_block = b""
         current_block_addr = self.resolver.pc
         for node in program:
             pre_emit_addr = self.resolver.reloc_address.logical_value
+
+            if isinstance(node, LinkedModuleNode):
+                # Multi-region modules emit separate blocks at their own
+                # absolute base addresses; flush the pending block first so
+                # writes don't get re-keyed under the module's address.
+                if len(current_block) > 0:
+                    writer.write_block(current_block, current_block_addr)
+                    current_block = b""
+                blocks = node.emit_blocks(self.resolver.reloc_address)
+                for base, block in blocks:
+                    if block:
+                        writer.write_block(block, base)
+                if blocks:
+                    first_base, first_code = blocks[0]
+                    advance = len(first_code)
+                    self.resolver.pc += advance
+                    self.resolver.reloc_address += advance
+                    current_block_addr = self.resolver.pc
+                continue
+
             node_bytes = node.emit(self.resolver.reloc_address)
 
             if node_bytes:
@@ -189,50 +211,51 @@ class Program:
         self._debug_lines.append((address, position.file.filename, position.line, position.column))
 
     def emit_with_relocations(self, program: list[NodeProtocol], object_writer: ObjectWriter) -> None:
-        """
-        Emit code while tracking symbols that need relocation for object files.
-        This is similar to emit() but also identifies and records relocations.
+        """Emit code into per-region object-file buckets.
+
+        A new region opens on every CodePositionNode. Relocation/line offsets
+        recorded by emitting nodes are region-relative byte offsets, decoupled
+        from `resolver.pc` (which CodePositionNode rewrites to a physical
+        address).
         """
         current_block = b""
-        current_offset = 0
 
-        # For object files, we don't use absolute addresses - everything is relative to start of object
         original_pc = self.resolver.pc
         original_reloc = self.resolver.reloc_address
-        self.resolver.pc = 0
-        self.resolver.reloc_address = self.resolver.get_bus().get_address(0)
+
+        # Seed the initial (implicit) region at the resolver's reloc_address.
+        # If the source begins with `*=`, that emit immediately closes this
+        # placeholder region and opens a new explicit one.
+        object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=False)
 
         try:
             for node in program:
-                # Note: External symbol references are handled during parsing/codegen.
-                # The OpcodeNode and ExpressionNode classes already create relocations
-                # when they encounter external symbols (via ExternalSymbolReference).
-                # Here we simply emit the code - relocations are stored in the ObjectWriter.
-                pre_emit_offset = self.resolver.pc
                 node_bytes = node.emit(self.resolver.reloc_address)
 
                 if node_bytes:
-                    self._record_object_line(node, pre_emit_offset, object_writer)
+                    self._record_object_line(node, object_writer.relocation_offset(), object_writer)
                     current_block += node_bytes
                     self.resolver.pc += len(node_bytes)
                     self.resolver.reloc_address += len(node_bytes)
 
                 if isinstance(node, CodePositionNode):
                     if len(current_block) > 0:
-                        object_writer.write_block(current_block, current_offset)
-                        current_offset += len(current_block)
+                        object_writer.write_block(current_block, 0)
                     current_block = b""
+                    object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=True)
 
                 if isinstance(node, IncludeIpsNode):
-                    for _block_addr, block in node.blocks:
-                        object_writer.write_block(block, current_offset)
-                        current_offset += len(block)
+                    if len(current_block) > 0:
+                        object_writer.write_block(current_block, 0)
+                        current_block = b""
+                    for block_addr, block in node.blocks:
+                        object_writer.start_region(block_addr, explicit=True)
+                        object_writer.write_block(block, block_addr)
 
             if len(current_block) > 0:
-                object_writer.write_block(current_block, current_offset)
+                object_writer.write_block(current_block, 0)
 
         finally:
-            # Restore original state
             self.resolver.pc = original_pc
             self.resolver.reloc_address = original_reloc
 
@@ -315,7 +338,7 @@ class Program:
             return -1
 
     def _classify_object_symbol(
-        self, name: str, value: int, base_address: int, label_names: set[str]
+        self, name: str, value: int, label_names: set[str]
     ) -> tuple[SymbolType, SymbolSection, int]:
         # Anonymous-block labels stay LOCAL (would otherwise leak as globals);
         # `_` prefix marks private; root-scope (or NamedScope dotted) is GLOBAL.
@@ -324,16 +347,16 @@ class Program:
         else:
             symbol_type = SymbolType.GLOBAL
         section = SymbolSection.CODE if name in label_names else SymbolSection.DATA
-        # CODE values are logical addresses; emit module-relative offsets.
-        symbol_value = value - base_address if section == SymbolSection.CODE and isinstance(value, int) else value
-        return symbol_type, section, symbol_value
+        # Symbols carry their absolute logical address — relocatable modules
+        # apply a delta at .import time; pinned modules use the value as-is.
+        return symbol_type, section, value
 
-    def _export_object_symbols(self, object_writer: ObjectWriter, base_address: int) -> None:
+    def _export_object_symbols(self, object_writer: ObjectWriter) -> None:
         label_names = {n for n, _ in self.resolver.get_all_labels(mangle_nested=True)}
         for name, value in self.resolver.get_all_symbols():
             if self.resolver.current_scope.is_external_symbol(name):
                 continue  # already added by ExternNode
-            sym_type, section, sym_value = self._classify_object_symbol(name, value, base_address, label_names)
+            sym_type, section, sym_value = self._classify_object_symbol(name, value, label_names)
             object_writer.add_symbol(name, sym_value, sym_type, section)
 
     def assemble_with_object_emitter(
@@ -345,7 +368,6 @@ class Program:
         try:
             self.resolver.context.mode = AssemblyMode.OBJECT
             self.resolver.context.object_writer = object_writer
-            base_address = self.resolver.reloc_address.logical_value
 
             with open(asm_file, encoding="utf-8") as f:
                 input_program = f.read()
@@ -360,7 +382,7 @@ class Program:
 
                 self.logger.info("Resolving labels")
                 self.resolve_labels(nodes)
-                self._export_object_symbols(object_writer, base_address)
+                self._export_object_symbols(object_writer)
 
                 if self.dump_symbols:
                     self.resolver.dump_symbol_map()
@@ -505,7 +527,12 @@ class Program:
             SymbolScope,
         )
 
-        if not linked_obj.symbols and not linked_obj.lines:
+        # Lines are stored region-relative; bake the final logical address.
+        all_lines: list[tuple[int, int, int, int, int]] = []
+        for region in linked_obj.regions:
+            for offset, file_idx, line, column, flags in region.lines:
+                all_lines.append((region.base_address + offset, file_idx, line, column, flags))
+        if not linked_obj.symbols and not all_lines:
             return None
 
         info = DebugInfo()
@@ -524,9 +551,9 @@ class Program:
             scope_kind = scope_by_type[sym_type]
             kind = SymbolKind.LABEL if section == SymbolSection.CODE else SymbolKind.CONSTANT
             info.symbols.append(SymbolEntry(name=name, address=value, scope=scope_kind, module_idx=0, kind=kind))
-        for offset, file_idx, line, column, flags in linked_obj.lines:
+        for address, file_idx, line, column, flags in all_lines:
             info.lines.append(
-                LineEntry(address=offset, file_idx=file_idx, line=line, column=column, module_idx=0, flags=flags)
+                LineEntry(address=address, file_idx=file_idx, line=line, column=column, module_idx=0, flags=flags)
             )
 
         from a816.debug_info import write as write_debug_info
@@ -563,10 +590,9 @@ class Program:
                 ips_emitter = IPSWriter(f, copier_header)
                 ips_emitter.begin()
 
-                if linked_obj.code:
-                    # Determine start address from CODE symbols, default to 0x8000
-                    start_address = self._get_code_start_address(linked_obj)
-                    ips_emitter.write_block(linked_obj.code, start_address)
+                for region in linked_obj.regions:
+                    if region.code:
+                        ips_emitter.write_block(region.code, region.base_address)
 
                 ips_emitter.end()
                 self.write_debug_info_for_linked(linked_obj, ips_file)
@@ -593,10 +619,9 @@ class Program:
                 sfc_emitter = SFCWriter(f)
                 sfc_emitter.begin()
 
-                if linked_obj.code:
-                    # Determine start address from CODE symbols, default to 0x8000
-                    start_address = self._get_code_start_address(linked_obj)
-                    sfc_emitter.write_block(linked_obj.code, start_address)
+                for region in linked_obj.regions:
+                    if region.code:
+                        sfc_emitter.write_block(region.code, region.base_address)
 
                 sfc_emitter.end()
                 self.write_debug_info_for_linked(linked_obj, sfc_file)

--- a/a816/program.py
+++ b/a816/program.py
@@ -257,6 +257,7 @@ class Program:
                 if node_bytes:
                     self._record_object_line(node, object_writer.relocation_offset(), object_writer)
                     current_block += node_bytes
+                    object_writer.mark_emitted(len(node_bytes))
                     self.resolver.pc += len(node_bytes)
                     self.resolver.reloc_address += len(node_bytes)
 

--- a/a816/program.py
+++ b/a816/program.py
@@ -219,7 +219,11 @@ class Program:
                     advance = len(first_code)
                     self.resolver.pc += advance
                     self.resolver.reloc_address += advance
-                    current_block_addr = self.resolver.pc
+                # Either way, the next inline byte will land at the
+                # current PC — refresh current_block_addr so the next
+                # flush keys those bytes against the post-import
+                # position rather than the stale pre-flush address.
+                current_block_addr = self.resolver.pc
                 continue
 
             node_bytes = node.emit(self.resolver.reloc_address)

--- a/a816/program.py
+++ b/a816/program.py
@@ -182,12 +182,15 @@ class Program:
 
             if isinstance(node, LinkedModuleNode):
                 if last_module_index.get(node.module_name) != idx:
-                    # Symbols already (re-)bound in pc_after; advance the
-                    # resolver in lockstep with pc_after's first-region
-                    # delta so any inline code that follows this earlier
-                    # `.import` lands at the right address even though no
-                    # bytes are emitted here.
+                    # Symbols already (re-)bound in pc_after; this earlier
+                    # `.import` is symbol-only. Flush the pending block at
+                    # its original address before advancing the PC so the
+                    # next current_block_addr reflects the post-skip
+                    # position rather than re-keying old bytes there.
                     if node.regions:
+                        if len(current_block) > 0:
+                            writer.write_block(current_block, current_block_addr)
+                            current_block = b""
                         advance = len(node.regions[0].code)
                         self.resolver.pc += advance
                         self.resolver.reloc_address += advance

--- a/a816/program.py
+++ b/a816/program.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from a816.parse.nodes import (
     CodePositionNode,
     IncludeIpsNode,
     LabelNode,
+    LinkedModuleNode,
     NodeError,
     SymbolNode,
 )
@@ -19,6 +21,14 @@ from a816.symbols import Resolver
 from a816.writers import IPSWriter, ObjectWriter, SFCWriter, Writer
 
 logger = logging.getLogger("a816")
+
+
+@dataclass
+class _EmitState:
+    """Mutable state threaded through Program.emit's per-node helpers."""
+
+    current_block: bytes
+    current_block_addr: int
 
 
 class Program:
@@ -116,8 +126,6 @@ class Program:
         `resolve_labels` so the winner/loser distinction is consistent
         across the address-resolution and emission passes.
         """
-        from a816.parse.nodes import LinkedModuleNode
-
         last_idx: dict[str, int] = {}
         for idx, node in enumerate(program_nodes):
             if isinstance(node, LinkedModuleNode):
@@ -187,65 +195,74 @@ class Program:
             program: List of resolved executable nodes.
             writer: Output writer (IPSWriter, SFCWriter, etc.).
         """
-        from a816.parse.nodes import LinkedModuleNode
-
-        current_block = b""
-        current_block_addr = self.resolver.pc
+        state = _EmitState(current_block=b"", current_block_addr=self.resolver.pc)
         for node in program:
-            pre_emit_addr = self.resolver.reloc_address.logical_value
+            self._emit_one(node, writer, state)
+        self._flush_pending(writer, state)
 
-            if isinstance(node, LinkedModuleNode):
-                if node.is_loser:
-                    # Loser duplicate `.import`: pc_after did not advance,
-                    # symbols already bound elsewhere. Treat as a pure
-                    # no-op — leave current_block untouched so surrounding
-                    # inline source keeps its address layout.
-                    continue
-                # Multi-region modules emit separate blocks at their own
-                # absolute base addresses; flush the pending block first so
-                # writes don't get re-keyed under the module's address.
-                if len(current_block) > 0:
-                    writer.write_block(current_block, current_block_addr)
-                    current_block = b""
-                blocks = node.emit_blocks(self.resolver.reloc_address)
-                for base, block in blocks:
-                    if block:
-                        writer.write_block(block, self._to_physical(base))
-                # Pinned modules don't consume linear PC at the import
-                # site; only relocatable modules advance the importer's
-                # PC by their first-region size (matching pc_after).
-                if blocks and node.relocatable:
-                    first_code = blocks[0][1]
-                    advance = len(first_code)
-                    self.resolver.pc += advance
-                    self.resolver.reloc_address += advance
-                # Either way, the next inline byte will land at the
-                # current PC — refresh current_block_addr so the next
-                # flush keys those bytes against the post-import
-                # position rather than the stale pre-flush address.
-                current_block_addr = self.resolver.pc
-                continue
+    def _emit_one(self, node: NodeProtocol, writer: Writer, state: _EmitState) -> None:
+        """Dispatch a single node to the right emission path."""
+        if isinstance(node, LinkedModuleNode):
+            self._emit_linked_module(node, writer, state)
+            return
+        self._emit_default(node, writer, state)
+        if isinstance(node, CodePositionNode):
+            self._handle_code_position(writer, state)
+        if isinstance(node, IncludeIpsNode):
+            self._emit_ips_blocks(node, writer)
 
-            node_bytes = node.emit(self.resolver.reloc_address)
+    def _emit_linked_module(self, node: LinkedModuleNode, writer: Writer, state: _EmitState) -> None:
+        """Emit a `.import`'d module's regions and refresh emission state.
 
-            if node_bytes:
-                self._record_debug_line(node, pre_emit_addr)
-                current_block += node_bytes
-                self.resolver.pc += len(node_bytes)
-                self.resolver.reloc_address += len(node_bytes)
+        Loser duplicates are pure no-ops (pc_after also bailed out so
+        the resolver PC is untouched — leaving current_block alone keeps
+        surrounding inline source addressed correctly).
+        """
+        if node.is_loser:
+            return
+        self._flush_pending(writer, state)
+        blocks = node.emit_blocks(self.resolver.reloc_address)
+        for base, block in blocks:
+            if block:
+                writer.write_block(block, self._to_physical(base))
+        # Only relocatable modules consume linear PC at the import site;
+        # pinned regions land at their declared `*=` and the importer's
+        # PC stays where it was.
+        if blocks and node.relocatable:
+            advance = len(blocks[0][1])
+            self.resolver.pc += advance
+            self.resolver.reloc_address += advance
+        state.current_block_addr = self.resolver.pc
 
-            if isinstance(node, CodePositionNode):  # or isinstance(node, RelocationAddressNode):
-                if len(current_block) > 0:
-                    writer.write_block(current_block, current_block_addr)
-                current_block_addr = self.resolver.pc
-                current_block = b""
+    def _emit_default(self, node: NodeProtocol, writer: Writer, state: _EmitState) -> None:
+        """Emit a non-LinkedModule node and accumulate its bytes."""
+        del writer  # accumulation only — flush happens at boundaries
+        pre_emit_addr = self.resolver.reloc_address.logical_value
+        node_bytes = node.emit(self.resolver.reloc_address)
+        if not node_bytes:
+            return
+        self._record_debug_line(node, pre_emit_addr)
+        state.current_block += node_bytes
+        self.resolver.pc += len(node_bytes)
+        self.resolver.reloc_address += len(node_bytes)
 
-            if isinstance(node, IncludeIpsNode):
-                for block_addr, block in node.blocks:
-                    writer.write_block(block, block_addr)
+    def _handle_code_position(self, writer: Writer, state: _EmitState) -> None:
+        """Flush at a `*=` boundary and re-anchor for subsequent bytes."""
+        self._flush_pending(writer, state)
+        state.current_block_addr = self.resolver.pc
 
-        if len(current_block) > 0:
-            writer.write_block(current_block, current_block_addr)
+    @staticmethod
+    def _emit_ips_blocks(node: IncludeIpsNode, writer: Writer) -> None:
+        """Pass an `.includeips`-loaded patch's blocks straight through."""
+        for block_addr, block in node.blocks:
+            writer.write_block(block, block_addr)
+
+    @staticmethod
+    def _flush_pending(writer: Writer, state: _EmitState) -> None:
+        """Write the accumulated current_block at its anchor and reset."""
+        if state.current_block:
+            writer.write_block(state.current_block, state.current_block_addr)
+            state.current_block = b""
 
     def _record_object_line(self, node: NodeProtocol, offset: int, object_writer: ObjectWriter) -> None:
         """Record an addr->line entry on the ObjectWriter so .o files carry line info."""

--- a/a816/program.py
+++ b/a816/program.py
@@ -31,6 +31,13 @@ class _EmitState:
     current_block_addr: int
 
 
+@dataclass
+class _ObjectEmitState:
+    """Mutable state threaded through Program.emit_with_relocations."""
+
+    current_block: bytes
+
+
 class Program:
     """Main assembler program orchestrating parsing, symbol resolution, and code emission.
 
@@ -294,8 +301,6 @@ class Program:
         from `resolver.pc` (which CodePositionNode rewrites to a physical
         address).
         """
-        current_block = b""
-
         original_pc = self.resolver.pc
         original_reloc = self.resolver.reloc_address
 
@@ -303,38 +308,63 @@ class Program:
         # If the source begins with `*=`, that emit immediately closes this
         # placeholder region and opens a new explicit one.
         object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=False)
-
+        state = _ObjectEmitState(current_block=b"")
         try:
             for node in program:
-                node_bytes = node.emit(self.resolver.reloc_address)
-
-                if node_bytes:
-                    self._record_object_line(node, object_writer.relocation_offset(), object_writer)
-                    current_block += node_bytes
-                    object_writer.mark_emitted(len(node_bytes))
-                    self.resolver.pc += len(node_bytes)
-                    self.resolver.reloc_address += len(node_bytes)
-
-                if isinstance(node, CodePositionNode):
-                    if len(current_block) > 0:
-                        object_writer.write_block(current_block, 0)
-                    current_block = b""
-                    object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=True)
-
-                if isinstance(node, IncludeIpsNode):
-                    if len(current_block) > 0:
-                        object_writer.write_block(current_block, 0)
-                        current_block = b""
-                    for block_addr, block in node.blocks:
-                        object_writer.start_region(block_addr, explicit=True)
-                        object_writer.write_block(block, block_addr)
-
-            if len(current_block) > 0:
-                object_writer.write_block(current_block, 0)
-
+                self._object_emit_one(node, object_writer, state)
+            self._flush_object_block(object_writer, state)
         finally:
             self.resolver.pc = original_pc
             self.resolver.reloc_address = original_reloc
+
+    def _object_emit_one(
+        self, node: NodeProtocol, object_writer: ObjectWriter, state: "_ObjectEmitState"
+    ) -> None:
+        """Emit one node into the current object-writer region.
+
+        Splits the dispatch the way `emit()` does so each branch — the
+        common byte accumulator, the `*=` boundary, and the `.includeips`
+        passthrough — owns a single concern.
+        """
+        self._accumulate_object_bytes(node, object_writer, state)
+        if isinstance(node, CodePositionNode):
+            self._object_open_region(object_writer, state, explicit=True)
+        if isinstance(node, IncludeIpsNode):
+            self._object_emit_ips_blocks(node, object_writer, state)
+
+    def _accumulate_object_bytes(
+        self, node: NodeProtocol, object_writer: ObjectWriter, state: "_ObjectEmitState"
+    ) -> None:
+        node_bytes = node.emit(self.resolver.reloc_address)
+        if not node_bytes:
+            return
+        self._record_object_line(node, object_writer.relocation_offset(), object_writer)
+        state.current_block += node_bytes
+        object_writer.mark_emitted(len(node_bytes))
+        self.resolver.pc += len(node_bytes)
+        self.resolver.reloc_address += len(node_bytes)
+
+    def _object_open_region(
+        self, object_writer: ObjectWriter, state: "_ObjectEmitState", *, explicit: bool
+    ) -> None:
+        """Flush any pending block then open a fresh region at the new PC."""
+        self._flush_object_block(object_writer, state)
+        object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=explicit)
+
+    def _object_emit_ips_blocks(
+        self, node: IncludeIpsNode, object_writer: ObjectWriter, state: "_ObjectEmitState"
+    ) -> None:
+        """Pass an `.includeips`-loaded patch through as one region per block."""
+        self._flush_object_block(object_writer, state)
+        for block_addr, block in node.blocks:
+            object_writer.start_region(block_addr, explicit=True)
+            object_writer.write_block(block, block_addr)
+
+    @staticmethod
+    def _flush_object_block(object_writer: ObjectWriter, state: "_ObjectEmitState") -> None:
+        if state.current_block:
+            object_writer.write_block(state.current_block, 0)
+            state.current_block = b""
 
     def assemble_string_with_emitter(self, input_program: str, filename: str, emitter: Writer) -> str | None:
         error, nodes = self.parser.parse(input_program, filename)

--- a/a816/writers.py
+++ b/a816/writers.py
@@ -1,7 +1,7 @@
 import struct
 from typing import BinaryIO, Protocol
 
-from a816.object_file import ObjectFile, RelocationType, SymbolSection, SymbolType
+from a816.object_file import ObjectFile, Region, RelocationType, SymbolSection, SymbolType
 
 
 class Writer(Protocol):
@@ -59,6 +59,7 @@ class SFCWriter(Writer):
 
     def write_block_header(self, block: bytes, block_address: int) -> None:
         """SFC is contiguous it only needs to implement write_block."""
+        del block, block_address
 
     def write_block(self, block: bytes, block_address: int) -> None:
         self.file.seek(block_address)
@@ -69,30 +70,61 @@ class SFCWriter(Writer):
 
 
 class ObjectWriter(Writer):
+    """Collects regions, symbols, relocations into a v6 ObjectFile.
+
+    Region lifecycle:
+        start_region(base_address) opens a new region and resets the
+        per-region byte counter. Subsequent write_block() appends to the
+        current region; add_relocation/add_expression_relocation/add_line
+        record their offsets relative to the current region's start.
+
+    The first region opens lazily on first write_block() (or first add_*
+    call) using `_pending_base_address`, which the emit driver seeds via
+    `start_region(initial_base)` before emission begins.
+    """
+
     def __init__(self, output_file: str) -> None:
         self.output_file = output_file
-        self.code_blocks: list[tuple[bytes, int]] = []
+        self.regions: list[Region] = []
         self.symbols: list[tuple[str, int, SymbolType, SymbolSection]] = []
-        self.relocations: list[tuple[int, str, RelocationType]] = []
-        self.expression_relocations: list[tuple[int, str, int]] = []  # (offset, expression_str, size_bytes)
-        self.aliases: list[tuple[str, str]] = []  # (name, expression_str)
+        self.aliases: list[tuple[str, str]] = []
         self.files: list[str] = []
-        # (offset, file_idx, line, column, flags) — offset is bytes from code start.
-        self.lines: list[tuple[int, int, int, int, int]] = []
         self._file_index: dict[str, int] = {}
-        self.current_offset = 0
+        self._current_region: Region | None = None
+        self._pending_base_address: int = 0
+        self._region_bytes_emitted: int = 0
+        self._has_explicit_position: bool = False
 
     def begin(self) -> None:
-        """Initialize object file creation"""
-        self.code_blocks = []
+        self.regions = []
         self.symbols = []
-        self.relocations = []
-        self.expression_relocations = []
         self.aliases = []
         self.files = []
-        self.lines = []
         self._file_index = {}
-        self.current_offset = 0
+        self._current_region = None
+        self._pending_base_address = 0
+        self._region_bytes_emitted = 0
+        self._has_explicit_position = False
+
+    def start_region(self, base_address: int, explicit: bool = False) -> None:
+        """Open a new region at base_address, closing any current region.
+
+        `explicit=True` marks this as the result of a `*=` directive — the
+        module loses single-region relocatability once any explicit region
+        is opened.
+        """
+        # Drop empty pending regions instead of leaving zero-byte placeholders.
+        if self._current_region is not None and not self._current_region.code:
+            self.regions.pop()
+        self._pending_base_address = base_address
+        self._current_region = None
+        self._region_bytes_emitted = 0
+        if explicit:
+            self._has_explicit_position = True
+
+    def relocation_offset(self, pending_block_bytes: int = 0) -> int:
+        """Byte offset where the next emitted byte will land in the region."""
+        return self._region_bytes_emitted + pending_block_bytes
 
     def add_file(self, path: str) -> int:
         if path in self._file_index:
@@ -104,48 +136,49 @@ class ObjectWriter(Writer):
 
     def add_line(self, offset: int, file_path: str, line: int, column: int, flags: int = 0) -> None:
         file_idx = self.add_file(file_path)
-        self.lines.append((offset, file_idx, line, column, flags))
+        self._ensure_region().lines.append((offset, file_idx, line, column, flags))
 
     def write_block_header(self, block: bytes, block_address: int) -> None:
-        """Object files don't use block headers"""
-        pass
+        del block, block_address
 
     def write_block(self, block: bytes, block_address: int) -> None:
-        """Collect code blocks for object file"""
-        self.code_blocks.append((block, self.current_offset))
-        self.current_offset += len(block)
+        del block_address  # object files key code by region, not absolute address
+        region = self._ensure_region()
+        region.code = region.code + block
+        self._region_bytes_emitted = len(region.code)
 
     def add_symbol(
         self, name: str, address: int, symbol_type: SymbolType, section: SymbolSection = SymbolSection.CODE
     ) -> None:
-        """Add a symbol to the object file"""
         self.symbols.append((name, address, symbol_type, section))
 
     def add_relocation(self, offset: int, symbol_name: str, relocation_type: RelocationType) -> None:
-        """Add a relocation entry to the object file"""
-        self.relocations.append((offset, symbol_name, relocation_type))
+        self._ensure_region().relocations.append((offset, symbol_name, relocation_type))
 
     def add_expression_relocation(self, offset: int, expression: str, size_bytes: int) -> None:
-        """Add an expression relocation entry to the object file"""
-        self.expression_relocations.append((offset, expression, size_bytes))
+        self._ensure_region().expression_relocations.append((offset, expression, size_bytes))
 
     def add_alias(self, name: str, expression: str) -> None:
-        """Register a symbol whose value is a deferred expression resolved at link time."""
         self.aliases.append((name, expression))
 
     def end(self) -> None:
-        """Write the object file to disk"""
-        total_code = bytearray()
-        for block, _ in self.code_blocks:
-            total_code.extend(block)
-
+        # Strip a trailing empty region (e.g. trailing `*=` with no code).
+        if self.regions and not self.regions[-1].code:
+            self.regions.pop()
+        relocatable = not self._has_explicit_position
         obj_file = ObjectFile(
-            bytes(total_code),
+            self.regions,
             self.symbols,
-            self.relocations,
-            self.expression_relocations,
-            self.aliases,
+            aliases=self.aliases,
             files=self.files,
-            lines=self.lines,
+            relocatable=relocatable,
         )
         obj_file.write(self.output_file)
+
+    def _ensure_region(self) -> Region:
+        if self._current_region is None:
+            region = Region(base_address=self._pending_base_address, code=b"")
+            self.regions.append(region)
+            self._current_region = region
+            self._region_bytes_emitted = 0
+        return self._current_region

--- a/a816/writers.py
+++ b/a816/writers.py
@@ -93,6 +93,11 @@ class ObjectWriter(Writer):
         self._current_region: Region | None = None
         self._pending_base_address: int = 0
         self._region_bytes_emitted: int = 0
+        # Bytes emitted from the active node but not yet flushed to the
+        # region via write_block. The driver (emit_with_relocations) calls
+        # mark_emitted(len(node_bytes)) after each node so relocation
+        # offsets recorded mid-emit reflect the right intra-region position.
+        self._pending_emit_bytes: int = 0
         self._has_explicit_position: bool = False
 
     def begin(self) -> None:
@@ -104,7 +109,18 @@ class ObjectWriter(Writer):
         self._current_region = None
         self._pending_base_address = 0
         self._region_bytes_emitted = 0
+        self._pending_emit_bytes = 0
         self._has_explicit_position = False
+
+    def mark_emitted(self, count: int) -> None:
+        """Advance the per-region emit cursor by ``count`` bytes.
+
+        Reloc emit sites query relocation_offset() before write_block is
+        called for the surrounding block, so this method lets the emit
+        driver advance the cursor in lockstep with bytes returned from
+        each NodeProtocol.emit().
+        """
+        self._pending_emit_bytes += count
 
     def start_region(self, base_address: int, explicit: bool = False) -> None:
         """Open a new region at base_address, closing any current region.
@@ -119,12 +135,13 @@ class ObjectWriter(Writer):
         self._pending_base_address = base_address
         self._current_region = None
         self._region_bytes_emitted = 0
+        self._pending_emit_bytes = 0
         if explicit:
             self._has_explicit_position = True
 
     def relocation_offset(self, pending_block_bytes: int = 0) -> int:
         """Byte offset where the next emitted byte will land in the region."""
-        return self._region_bytes_emitted + pending_block_bytes
+        return self._region_bytes_emitted + self._pending_emit_bytes + pending_block_bytes
 
     def add_file(self, path: str) -> int:
         if path in self._file_index:
@@ -146,6 +163,8 @@ class ObjectWriter(Writer):
         region = self._ensure_region()
         region.code = region.code + block
         self._region_bytes_emitted = len(region.code)
+        # Bytes are now part of the region, drop the pending counter.
+        self._pending_emit_bytes = 0
 
     def add_symbol(
         self, name: str, address: int, symbol_type: SymbolType, section: SymbolSection = SymbolSection.CODE

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -31,15 +31,27 @@ class CodeGenTest(unittest.TestCase):
         emitted = node.emit(program.resolver.reloc_address)
         self.assertEqual(emitted, b"\x00\x42")
 
-    def test_brk_without_operand_still_emits_opcode(self) -> None:
-        """Bare `brk` keeps its single-byte form for backward compatibility."""
+    def test_brk_without_operand_is_rejected(self) -> None:
+        """Bare `brk` is no longer accepted — signature byte is required."""
         program = Program()
-        _, nodes = program.parser.parse("brk")
+        error, _ = program.parser.parse("brk")
+        self.assertIsNotNone(error)
+
+    def test_cop_with_signature_byte(self) -> None:
+        program = Program()
+        _, nodes = program.parser.parse("cop #0x7F")
         program.resolve_labels(nodes)
         node = nodes[0]
         assert isinstance(node, OpcodeNode)
-        emitted = node.emit(program.resolver.reloc_address)
-        self.assertEqual(emitted, b"\x00")
+        self.assertEqual(node.emit(program.resolver.reloc_address), b"\x02\x7f")
+
+    def test_wdm_with_signature_byte(self) -> None:
+        program = Program()
+        _, nodes = program.parser.parse("wdm #0xAB")
+        program.resolve_labels(nodes)
+        node = nodes[0]
+        assert isinstance(node, OpcodeNode)
+        self.assertEqual(node.emit(program.resolver.reloc_address), b"\x42\xab")
 
     def test_ateq_reslove(self) -> None:
         program = Program()

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -21,6 +21,26 @@ class CodeGenTest(unittest.TestCase):
         self.assertEqual(node.value_node.get_value(), 0x1234)
         self.assertEqual(node.addressing_mode, AddressingMode.immediate)
 
+    def test_brk_with_signature_byte(self) -> None:
+        """`brk #imm` emits the opcode + the user-supplied signature byte."""
+        program = Program()
+        _, nodes = program.parser.parse("brk #0x42")
+        program.resolve_labels(nodes)
+        node = nodes[0]
+        assert isinstance(node, OpcodeNode)
+        emitted = node.emit(program.resolver.reloc_address)
+        self.assertEqual(emitted, b"\x00\x42")
+
+    def test_brk_without_operand_still_emits_opcode(self) -> None:
+        """Bare `brk` keeps its single-byte form for backward compatibility."""
+        program = Program()
+        _, nodes = program.parser.parse("brk")
+        program.resolve_labels(nodes)
+        node = nodes[0]
+        assert isinstance(node, OpcodeNode)
+        emitted = node.emit(program.resolver.reloc_address)
+        self.assertEqual(emitted, b"\x00")
+
     def test_ateq_reslove(self) -> None:
         program = Program()
         program.resolve_labels(

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -5,7 +5,7 @@ from a816.object_file import ObjectFile, RelocationType, SymbolSection, SymbolTy
 def test_link() -> None:
     # Create some example object files
     obj1 = ObjectFile(
-        b"\x01\x02\x03",
+        b"\x01\x02\x00\x00",
         [
             ("global_sym", 0x01, SymbolType.GLOBAL, SymbolSection.CODE),
             ("local_sym", 0x00, SymbolType.LOCAL, SymbolSection.CODE),
@@ -14,7 +14,7 @@ def test_link() -> None:
     )
 
     obj2 = ObjectFile(
-        b"\x04\x05\x06",
+        b"\x00\x00\x05\x06",
         [
             ("global_sym2", 0x01, SymbolType.GLOBAL, SymbolSection.CODE),
             ("local_sym2", 0x00, SymbolType.LOCAL, SymbolSection.CODE),

--- a/tests/test_object_file.py
+++ b/tests/test_object_file.py
@@ -1,82 +1,28 @@
-import struct
 from pathlib import Path
 
-from a816.object_file import ObjectFile, RelocationType, SymbolSection, SymbolType
-
-# Header format for version 5: <IHIIIIIII (34 bytes).
-# Adds u32 file_table_size and u32 line_table_size after the v4 layout.
-HEADER_SIZE = 34
-HEADER_FORMAT = "<IHIIIIIII"
+from a816.object_file import ObjectFile, Region, RelocationType, SymbolSection, SymbolType
 
 
 def test_write_empty_object_file(tmp_path: Path) -> None:
     test_filename = tmp_path / "test_object_file.o"
-    obj = ObjectFile(b"", [], [])
+    obj = ObjectFile([], [])
     obj.write(str(test_filename))
 
-    with open(test_filename, "rb") as f:
-        header = f.read(HEADER_SIZE)
-        (
-            magic,
-            version,
-            code_size,
-            symbol_table_size,
-            relocation_table_size,
-            expression_relocation_table_size,
-            alias_table_size,
-            file_table_size,
-            line_table_size,
-        ) = struct.unpack(HEADER_FORMAT, header)
-        assert alias_table_size == 2
-        assert magic == ObjectFile.MAGIC_NUMBER
-        assert version == ObjectFile.VERSION
-        assert code_size == 0
-        assert symbol_table_size == 2
-        assert relocation_table_size == 2
-        assert expression_relocation_table_size == 2
-
-        num_symbols = struct.unpack("<H", f.read(2))[0]
-        assert num_symbols == 0
-
-        num_relocations = struct.unpack("<H", f.read(2))[0]
-        assert num_relocations == 0
+    obj2 = ObjectFile.from_file(str(test_filename))
+    assert obj2.regions == []
+    assert obj2.symbols == []
 
 
 def test_write_object_file_with_code(tmp_path: Path) -> None:
     test_filename = tmp_path / "test_object_file.o"
     code = b"\x01\x02\x03\x04"
-    obj = ObjectFile(code, [], [])
+    obj = ObjectFile([Region(base_address=0x008000, code=code)], [])
     obj.write(str(test_filename))
 
-    with open(test_filename, "rb") as f:
-        header = f.read(HEADER_SIZE)
-        (
-            magic,
-            version,
-            code_size,
-            symbol_table_size,
-            relocation_table_size,
-            expression_relocation_table_size,
-            alias_table_size,
-            file_table_size,
-            line_table_size,
-        ) = struct.unpack(HEADER_FORMAT, header)
-        assert alias_table_size == 2
-        assert magic == ObjectFile.MAGIC_NUMBER
-        assert version == ObjectFile.VERSION
-        assert code_size == len(code)
-        assert symbol_table_size == 2
-        assert relocation_table_size == 2
-        assert expression_relocation_table_size == 2
-
-        read_code = f.read(code_size)
-        assert read_code == code
-
-        num_symbols = struct.unpack("<H", f.read(2))[0]
-        assert num_symbols == 0
-
-        num_relocations = struct.unpack("<H", f.read(2))[0]
-        assert num_relocations == 0
+    obj2 = ObjectFile.from_file(str(test_filename))
+    assert len(obj2.regions) == 1
+    assert obj2.regions[0].base_address == 0x008000
+    assert obj2.regions[0].code == code
 
 
 def test_write_object_file_with_symbols(tmp_path: Path) -> None:
@@ -85,29 +31,11 @@ def test_write_object_file_with_symbols(tmp_path: Path) -> None:
         ("symbol1", 0x1000, SymbolType.LOCAL, SymbolSection.CODE),
         ("symbol2", 0x2000, SymbolType.GLOBAL, SymbolSection.DATA),
     ]
-    obj = ObjectFile(b"", symbols, [])
+    obj = ObjectFile([], symbols)
     obj.write(str(test_filename))
 
-    with open(test_filename, "rb") as f:
-        f.read(HEADER_SIZE)  # Skip header
-        f.read(0)  # Skip code section
-        num_symbols = struct.unpack("<H", f.read(2))[0]
-        assert num_symbols == len(symbols)
-
-        for name, address, symbol_type, section in symbols:
-            name_length = struct.unpack("<B", f.read(1))[0]
-            read_name = f.read(name_length).decode("utf-8")
-            read_address = struct.unpack("<I", f.read(4))[0]
-            read_symbol_type = struct.unpack("<B", f.read(1))[0]
-            read_section = struct.unpack("<B", f.read(1))[0]
-
-            assert read_name == name
-            assert read_address == address
-            assert read_symbol_type == symbol_type.value
-            assert read_section == section.value
-
-        num_relocations = struct.unpack("<H", f.read(2))[0]
-        assert num_relocations == 0
+    obj2 = ObjectFile.from_file(str(test_filename))
+    assert obj2.symbols == symbols
 
 
 def test_write_object_file_with_relocations(tmp_path: Path) -> None:
@@ -116,47 +44,12 @@ def test_write_object_file_with_relocations(tmp_path: Path) -> None:
         (0x10, "symbol1", RelocationType.ABSOLUTE_16),
         (0x20, "symbol2", RelocationType.RELATIVE_24),
     ]
-    obj = ObjectFile(b"", [], relocations)
+    region = Region(base_address=0, code=b"\x00" * 0x40, relocations=relocations)
+    obj = ObjectFile([region], [])
     obj.write(str(test_filename))
 
-    with open(test_filename, "rb") as f:
-        f.read(HEADER_SIZE)  # Skip header
-        f.read(0)  # Skip code section
-        f.read(2)  # Skip symbol table size
-        num_relocations = struct.unpack("<H", f.read(2))[0]
-        assert num_relocations == len(relocations)
-
-        for offset, symbol_name, relocation_type in relocations:
-            read_offset = struct.unpack("<I", f.read(4))[0]
-            name_length = struct.unpack("<B", f.read(1))[0]
-            read_name = f.read(name_length).decode("utf-8")
-            read_relocation_type = struct.unpack("<B", f.read(1))[0]
-
-            assert read_offset == offset
-            assert read_name == symbol_name
-            assert read_relocation_type == relocation_type.value
-
-
-def test_calculate_symbol_table_size() -> None:
-    symbols: list[tuple[str, int, SymbolType, SymbolSection]] = [
-        ("symbol1", 0x1000, SymbolType.LOCAL, SymbolSection.CODE),
-        ("symbol2", 0x2000, SymbolType.GLOBAL, SymbolSection.DATA),
-        ("a", 0x3000, SymbolType.EXTERNAL, SymbolSection.BSS),
-    ]
-    obj = ObjectFile(b"", symbols, [])
-    expected_size = 2 + (1 + len("symbol1") + 4 + 1 + 1) + (1 + len("symbol2") + 4 + 1 + 1) + (1 + len("a") + 4 + 1 + 1)
-    assert obj._calculate_symbol_table_size() == expected_size
-
-
-def test_calculate_relocation_table_size() -> None:
-    relocations: list[tuple[int, str, RelocationType]] = [
-        (0x10, "symbol1", RelocationType.ABSOLUTE_16),
-        (0x20, "symbol2", RelocationType.RELATIVE_24),
-        (0x30, "a", RelocationType.RELATIVE_16),
-    ]
-    obj = ObjectFile(b"", [], relocations)
-    expected_size = 2 + (4 + 1 + len("symbol1") + 1) + (4 + 1 + len("symbol2") + 1) + (4 + 1 + len("a") + 1)
-    assert obj._calculate_relocation_table_size() == expected_size
+    obj2 = ObjectFile.from_file(str(test_filename))
+    assert obj2.regions[0].relocations == relocations
 
 
 def test_write_object_file_with_expression_relocations(tmp_path: Path) -> None:
@@ -165,46 +58,12 @@ def test_write_object_file_with_expression_relocations(tmp_path: Path) -> None:
         (0x10, "symbol1 + 5", 2),
         (0x20, "symbol2 - 1", 3),
     ]
-    obj = ObjectFile(b"", [], [], expression_relocations)
+    region = Region(base_address=0, code=b"\x00" * 0x40, expression_relocations=expression_relocations)
+    obj = ObjectFile([region], [])
     obj.write(str(test_filename))
 
-    with open(test_filename, "rb") as f:
-        header = f.read(HEADER_SIZE)
-        (
-            magic,
-            version,
-            code_size,
-            symbol_table_size,
-            relocation_table_size,
-            expression_relocation_table_size,
-            alias_table_size,
-            file_table_size,
-            line_table_size,
-        ) = struct.unpack(HEADER_FORMAT, header)
-        assert alias_table_size == 2
-        assert magic == ObjectFile.MAGIC_NUMBER
-        assert version == ObjectFile.VERSION
-        assert code_size == 0
-        assert symbol_table_size == 2
-        assert relocation_table_size == 2
-        expected_expr_size = 2 + (4 + 2 + len("symbol1 + 5") + 1) + (4 + 2 + len("symbol2 - 1") + 1)
-        assert expression_relocation_table_size == expected_expr_size
-
-        f.read(0)  # Skip code section
-        f.read(2)  # Skip symbol table size
-        f.read(2)  # Skip relocation table size
-        num_expr_relocations = struct.unpack("<H", f.read(2))[0]
-        assert num_expr_relocations == len(expression_relocations)
-
-        for offset, expression, size_bytes in expression_relocations:
-            read_offset = struct.unpack("<I", f.read(4))[0]
-            expr_length = struct.unpack("<H", f.read(2))[0]
-            read_expression = f.read(expr_length).decode("utf-8")
-            read_size_bytes = struct.unpack("<B", f.read(1))[0]
-
-            assert read_offset == offset
-            assert read_expression == expression
-            assert read_size_bytes == size_bytes
+    obj2 = ObjectFile.from_file(str(test_filename))
+    assert obj2.regions[0].expression_relocations == expression_relocations
 
 
 def test_read_write(tmp_path: Path) -> None:
@@ -225,7 +84,7 @@ def test_read_write_with_expression_relocations(tmp_path: Path) -> None:
         b"\x00\x01\x02\x03",
         [("sym1", 0x10, SymbolType.GLOBAL, SymbolSection.CODE)],
         [(0x02, "sym1", RelocationType.RELATIVE_16)],
-        [(0x04, "sym2 + 10", 2)],
+        [(0x00, "sym2 + 10", 2)],
     )
     obj.write(str(tmp_path / "test.o"))
     obj2 = ObjectFile.from_file(str(tmp_path / "test.o"))
@@ -235,15 +94,46 @@ def test_read_write_with_expression_relocations(tmp_path: Path) -> None:
     assert obj.expression_relocations == obj2.expression_relocations
 
 
-def test_symbol_offsets_in_scoped_blocks(tmp_path: Path) -> None:
-    """Test that labels inside { } scoped blocks get correct relative offsets.
+def test_multi_region_round_trip(tmp_path: Path) -> None:
+    regions = [
+        Region(base_address=0x008000, code=b"\xea\xea"),
+        Region(
+            base_address=0x018000,
+            code=b"\xa9\x42",
+            expression_relocations=[(1, "external + 1", 1)],
+        ),
+    ]
+    obj = ObjectFile(regions, [], relocatable=False)
+    obj.write(str(tmp_path / "multi.o"))
+    obj2 = ObjectFile.from_file(str(tmp_path / "multi.o"))
+    assert len(obj2.regions) == 2
+    assert obj2.regions[0].base_address == 0x008000
+    assert obj2.regions[0].code == b"\xea\xea"
+    assert obj2.regions[1].base_address == 0x018000
+    assert obj2.regions[1].code == b"\xa9\x42"
+    assert obj2.regions[1].expression_relocations == [(1, "external + 1", 1)]
+    assert obj2.relocatable is False
 
-    This tests a bug where labels inside anonymous scoped blocks were getting
-    logical addresses (0x8000+offset) instead of relative offsets (0+offset).
-    """
+
+def test_unsupported_version_rejected(tmp_path: Path) -> None:
+    """Older .o file versions are rejected — there is no v5 reader."""
+    import struct
+
+    path = tmp_path / "old.o"
+    with open(path, "wb") as f:
+        f.write(struct.pack("<IHB", ObjectFile.MAGIC_NUMBER, 0x0005, 0x00))
+    try:
+        ObjectFile.from_file(str(path))
+    except ValueError as e:
+        assert "Unsupported version" in str(e)
+    else:
+        raise AssertionError("expected ValueError for v5 .o file")
+
+
+def test_symbol_offsets_in_scoped_blocks(tmp_path: Path) -> None:
+    """Labels resolve to absolute logical addresses, including those in nested scopes."""
     from a816.program import Program
 
-    # Create test source with labels inside and outside scoped blocks
     source = """\
 first_label:
     lda #0x42
@@ -263,34 +153,19 @@ second_label:
     obj_file = tmp_path / "test_scoped.o"
     program = Program()
     result = program.assemble_as_object(str(src_file), obj_file)
-    assert result == 0, "Assembly should succeed"
+    assert result == 0
 
-    # Read the object file and check symbol offsets
     obj = ObjectFile.from_file(str(obj_file))
-
-    # Build a map of symbol name to offset
-    symbol_offsets = {name: offset for name, offset, _, _ in obj.symbols}
-
-    # first_label should be at offset 0
-    assert "first_label" in symbol_offsets
-    assert symbol_offsets["first_label"] == 0, f"first_label should be at 0, got {symbol_offsets['first_label']}"
-
-    # _inner_label should be at offset 3 (lda #imm = 2 bytes, rts = 1 byte)
-    assert "_inner_label" in symbol_offsets
-    inner_offset = symbol_offsets["_inner_label"]
-    # The offset should be a small positive number, NOT 0x8000+
-    assert inner_offset < 0x100, f"_inner_label should have small offset, got 0x{inner_offset:04x}"
-    assert inner_offset == 3, f"_inner_label should be at 3, got {inner_offset}"
-
-    # second_label should be at offset 6 (first_label code + inner_label code)
-    assert "second_label" in symbol_offsets
-    second_offset = symbol_offsets["second_label"]
-    assert second_offset < 0x100, f"second_label should have small offset, got 0x{second_offset:04x}"
-    assert second_offset == 6, f"second_label should be at 6, got {second_offset}"
+    by_name = {name: address for name, address, _, _ in obj.symbols}
+    assert "first_label" in by_name
+    assert "_inner_label" in by_name
+    assert "second_label" in by_name
+    # Labels are 3 bytes apart (lda #imm = 2 + rts = 1).
+    assert by_name["_inner_label"] - by_name["first_label"] == 3
+    assert by_name["second_label"] - by_name["first_label"] == 6
 
 
 def test_symbol_offsets_in_nested_scoped_blocks(tmp_path: Path) -> None:
-    """Test labels in nested scoped blocks get correct offsets."""
     from a816.program import Program
 
     source = """\
@@ -315,18 +190,13 @@ final:
     obj_file = tmp_path / "test_nested.o"
     program = Program()
     result = program.assemble_as_object(str(src_file), obj_file)
-    assert result == 0, "Assembly should succeed"
+    assert result == 0
 
     obj = ObjectFile.from_file(str(obj_file))
-    symbol_offsets = {name: offset for name, offset, _, _ in obj.symbols}
-
-    # All offsets should be small (relative to start of code, not logical addresses)
-    for name, offset in symbol_offsets.items():
-        assert offset < 0x100, f"{name} should have small offset, got 0x{offset:04x}"
-
-    # nop = 1 byte each
-    assert symbol_offsets.get("outer") == 0
-    assert symbol_offsets.get("_level1") == 1
-    assert symbol_offsets.get("_level2") == 2
-    assert symbol_offsets.get("_after_nested") == 3
-    assert symbol_offsets.get("final") == 4
+    by_name = {name: address for name, address, _, _ in obj.symbols}
+    base = by_name["outer"]
+    # nop = 1 byte; consecutive labels are one byte apart.
+    assert by_name["_level1"] - base == 1
+    assert by_name["_level2"] - base == 2
+    assert by_name["_after_nested"] - base == 3
+    assert by_name["final"] - base == 4

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -689,10 +689,16 @@ far_label:
             assert patched[0] | (patched[1] << 8) == target
 
     def test_multi_region_module_writes_multiple_ips_blocks(self) -> None:
-        """Linking a multi-region module emits one IPS block per region."""
+        """Linking a multi-region module emits one IPS block per region.
+
+        IPS records are keyed by physical (file) offset, so logical
+        SNES addresses must go through the LoROM bus mapping at the
+        write boundary — the same translation Program.emit() applies
+        via resolver.pc.
+        """
         source = """*=0x008000
 .db 0x11, 0x22
-*=0x018000
+*=0x028000
 .db 0x33
 """
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -706,6 +712,10 @@ far_label:
             assert Program().link_as_patch(linked, ips_path) == 0
             content = ips_path.read_bytes()
             assert content.startswith(b"PATCH")
-            # Both region bases must show up as IPS block headers (24-bit big-endian).
-            assert b"\x00\x80\x00" in content  # 0x008000
-            assert b"\x01\x80\x00" in content  # 0x018000
+            # Headers are 24-bit big-endian physical offsets:
+            #   *=0x008000 (LoROM) → physical 0x000000
+            #   *=0x028000 (LoROM) → physical 0x010000
+            # Length 2 then payload "\x11\x22" for region 0,
+            # length 1 then "\x33" for region 1.
+            assert b"\x00\x00\x00\x00\x02\x11\x22" in content
+            assert b"\x01\x00\x00\x00\x01\x33" in content

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -688,6 +688,56 @@ far_label:
             target = linker.symbol_map["far_label"] & 0xFFFF
             assert patched[0] | (patched[1] << 8) == target
 
+    def test_loser_import_does_not_shift_surrounding_layout(self) -> None:
+        """A skipped duplicate `.import` must consume zero PC — not its size.
+
+        Regression: the loser `.import` used to advance both pc_after and
+        the emit driver's PC by `len(region 0)`. When the loser sat in
+        a source-inlined patch file (e.g. ff4-modules' battle/sram.s
+        carrying `.import "dakuten"` while ff4.s also imports dakuten
+        later), the surrounding inline source ended up shifted forward
+        by the module's size, producing a phantom gap in the IPS that
+        the CPU later executed as garbage.
+
+        Layout under the fix: the `.import` site between the two inline
+        labels takes zero space; the labels straddle exactly the inline
+        bytes that follow, with the module placed once at its winning
+        site.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "mod.s"
+            mod.write_text("payload:\n    .db 0xCC, 0xCC, 0xCC, 0xCC\n")
+            assert Program().assemble_as_object(str(mod), tmp / "mod.o") == 0
+
+            inline_patch = tmp / "patch.s"
+            inline_patch.write_text('before_import:\n    .db 0xAA\n.import "mod"\nafter_import:\n    .db 0xBB\n')
+
+            main = tmp / "main.s"
+            # *=0x008000  -> inline patch (loser .import inside)
+            #             -> *=0x009000 -> winner .import "mod"
+            main.write_text('*=0x008000\n.include "patch.s"\n*=0x009000\n.import "mod"\n')
+
+            program = Program()
+            program.add_module_path(tmp)
+            program.add_include_path(tmp)
+            ips = tmp / "out.ips"
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            scope = program.resolver.current_scope
+            before = scope.labels.get("before_import")
+            after = scope.labels.get("after_import")
+            assert before is not None and after is not None
+            # Two labels with one inline byte between them — and crucially
+            # NOT separated by the (4-byte) module size. The loser must
+            # not advance the importer's PC.
+            assert (after.logical_value if hasattr(after, "logical_value") else after) - (
+                before.logical_value if hasattr(before, "logical_value") else before
+            ) == 1, "loser .import must consume zero PC space"
+
+            # Module payload still appears once, at the winning *=0x009000 site.
+            assert ips.read_bytes().count(b"\xcc\xcc\xcc\xcc") == 1
+
     def test_skipped_import_flushes_pending_block_before_advancing(self) -> None:
         """Inline bytes around a skipped duplicate .import keep their addresses.
 

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -688,6 +688,51 @@ far_label:
             target = linker.symbol_map["far_label"] & 0xFFFF
             assert patched[0] | (patched[1] << 8) == target
 
+    def test_pinned_module_import_does_not_advance_importer_pc(self) -> None:
+        """A `.import` of a pinned (`*=`) module must not consume PC.
+
+        Regression: LinkedModuleNode.pc_after used to return
+        `regions[0].base_address + len(regions[0].code)` for every
+        module, including pinned ones. For ff4-modules' assets module,
+        that landed the importer's PC at SNES $0B0000 (end of region
+        0 at $0AF000 + 0x1000), so any label following `.import "assets"`
+        was bound inside WRAM mirror space, and JSL operands compiled
+        against those labels jumped to RAM and BRK'd.
+
+        Pinned modules drop their code at their declared absolute
+        addresses; the importer's PC must stay where it was, so a label
+        defined right after `.import` on a pinned module sits next to
+        whatever inline code preceded the import.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "pinned.s"
+            # *=0x208000 makes this a pinned, non-relocatable module.
+            mod.write_text("*=0x208000\npayload:\n    .db 0x77, 0x77, 0x77, 0x77\n")
+            assert Program().assemble_as_object(str(mod), tmp / "pinned.o") == 0
+
+            main = tmp / "main.s"
+            main.write_text('*=0x008000\nbefore:\n.db 0xAA\n.import "pinned"\nafter:\n.db 0xBB\n')
+            ips = tmp / "out.ips"
+            program = Program()
+            program.add_module_path(tmp)
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            scope = program.resolver.current_scope
+            before = scope.labels.get("before")
+            after = scope.labels.get("after")
+            assert before is not None and after is not None
+            before_v = before.logical_value if hasattr(before, "logical_value") else before
+            after_v = after.logical_value if hasattr(after, "logical_value") else after
+            # Only the inline 0xAA byte separates `before` and `after`.
+            assert after_v - before_v == 1, (
+                f"pinned-module .import advanced importer PC; after-before = {after_v - before_v}"
+            )
+
+            # Pinned bytes still land at the module's declared base.
+            content = ips.read_bytes()
+            assert b"\x77\x77\x77\x77" in content
+
     def test_loser_import_does_not_shift_surrounding_layout(self) -> None:
         """A skipped duplicate `.import` must consume zero PC — not its size.
 

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -688,6 +688,40 @@ far_label:
             target = linker.symbol_map["far_label"] & 0xFFFF
             assert patched[0] | (patched[1] << 8) == target
 
+    def test_duplicate_import_emits_module_bytes_once_at_last_site(self) -> None:
+        """Two .import "foo" statements emit foo's bytes once, at the second site.
+
+        Regression: the same module being imported in an .include'd patch
+        file and again in the main source caused .import to materialize
+        the module's bytes at BOTH sites. The earlier emission landed at
+        whatever PC the prior *= happened to leave behind, clobbering
+        unrelated ROM. .import is now idempotent — only the last
+        occurrence emits, the earlier ones still publish the symbols via
+        pc_after so subsequent code can reference the module.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "mod.s"
+            mod.write_text("payload:\n    .db 0x42, 0x42, 0x42, 0x42\n")
+            assert Program().assemble_as_object(str(mod), tmp / "mod.o") == 0
+
+            main = tmp / "main.s"
+            main.write_text(
+                "*=0x008000\n"
+                '.import "mod"\n'  # first import — symbol-only
+                "*=0x009000\n"
+                '.import "mod"\n'  # second import — emits payload here
+            )
+            ips = tmp / "out.ips"
+            program = Program()
+            program.add_module_path(tmp)
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            content = ips.read_bytes()
+            assert content.count(b"\x42\x42\x42\x42") == 1, (
+                f"module bytes must appear exactly once in the IPS, got {content.count(b'\\x42\\x42\\x42\\x42')}"
+            )
+
     def test_multiple_intra_region_expression_relocations_get_distinct_offsets(self) -> None:
         """Three references to the same forward label must record three offsets.
 

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -688,6 +688,170 @@ far_label:
             target = linker.symbol_map["far_label"] & 0xFFFF
             assert patched[0] | (patched[1] << 8) == target
 
+    def test_inline_bytes_after_pinned_import_land_at_post_import_pc(self) -> None:
+        """Inline code following a pinned `.import` keys against post-PC.
+
+        Regression: even though pinned modules correctly leave the
+        importer's PC alone, the emit driver was failing to refresh
+        `current_block_addr` after writing the module's regions. The
+        next current_block flush therefore wrote the post-import
+        inline bytes back to the address used for the pre-import flush
+        — clobbering whatever module / inline run had landed there.
+
+        In ff4-modules this manifested as ~12 KB of `.incbin` data
+        (attack_names, monsters, places_names, …) overwriting the
+        menu-text region right after `.import "assets"`, so menu
+        screens displayed asset bytes instead of menu strings.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "pinned.s"
+            mod.write_text("*=0x208000\npayload:\n    .db 0x77, 0x77, 0x77, 0x77\n")
+            assert Program().assemble_as_object(str(mod), tmp / "pinned.o") == 0
+
+            main = tmp / "main.s"
+            main.write_text('*=0x008000\n.db 0xAA, 0xAA, 0xAA\n.import "pinned"\n.db 0xBB, 0xBB, 0xBB, 0xBB\n')
+            ips = tmp / "out.ips"
+            program = Program()
+            program.add_module_path(tmp)
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            placements = {phys: data for phys, data in self._parse_ips_records(ips.read_bytes())}
+            # Pre-import inline bytes at SNES 0x008000 → physical 0x000000.
+            assert placements.get(0x000000, b"")[:3] == b"\xaa\xaa\xaa"
+            # Pinned module bytes at SNES 0x208000 → physical 0x100000.
+            assert placements.get(0x100000) == b"\x77\x77\x77\x77"
+            # Post-import inline bytes must land at PC 0x000003 (right
+            # after the AA AA AA bytes), NOT at 0x000000 (the stale
+            # current_block_addr that pre-fix code re-used).
+            assert placements.get(0x000003) == b"\xbb\xbb\xbb\xbb"
+            assert b"\xbb\xbb\xbb\xbb" not in placements.get(0x000000, b"")[3:]
+
+    def test_multi_region_module_addresses_are_exact(self) -> None:
+        """End-to-end check that every region of a pinned multi-region
+        module lands at its declared `*=` address, with symbols and
+        bytes at the same address, and no inline-PC movement.
+
+        Covers the layout assumptions ff4-modules' assets module relies
+        on: three regions in distant LoROM banks ($20:8000, $22:8000,
+        $30:8000), each carrying a labeled byte sentinel. The test
+        asserts:
+
+        - the .o has three regions with the right base_address values;
+        - each region's symbol resolves to its compile-time absolute
+          logical address (no delta) after `.import`;
+        - the IPS contains each region's sentinel at the correct
+          LoROM-physical file offset and nowhere else;
+        - the importer's PC does not move across the `.import` (a
+          label placed right after the import sits next to inline code
+          that came right before it).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "tri.s"
+            mod.write_text(
+                "*=0x208000\n"
+                "region_a:\n"
+                ".db 0xA1, 0xA2, 0xA3, 0xA4\n"
+                "*=0x228000\n"
+                "region_b:\n"
+                ".db 0xB1, 0xB2, 0xB3, 0xB4\n"
+                "*=0x308000\n"
+                "region_c:\n"
+                ".db 0xC1, 0xC2, 0xC3, 0xC4\n"
+            )
+            assert Program().assemble_as_object(str(mod), tmp / "tri.o") == 0
+
+            obj = ObjectFile.from_file(str(tmp / "tri.o"))
+            assert obj.relocatable is False
+            assert len(obj.regions) == 3
+            by_base = {r.base_address: r for r in obj.regions}
+            assert by_base[0x208000].code == b"\xa1\xa2\xa3\xa4"
+            assert by_base[0x228000].code == b"\xb1\xb2\xb3\xb4"
+            assert by_base[0x308000].code == b"\xc1\xc2\xc3\xc4"
+
+            sym_addr = {name: addr for name, addr, _, _ in obj.symbols}
+            assert sym_addr["region_a"] == 0x208000
+            assert sym_addr["region_b"] == 0x228000
+            assert sym_addr["region_c"] == 0x308000
+
+            main = tmp / "main.s"
+            main.write_text('*=0x008000\nbefore_import:\n.db 0xEE\n.import "tri"\nafter_import:\n.db 0xFF\n')
+            ips = tmp / "out.ips"
+            program = Program()
+            program.add_module_path(tmp)
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            scope = program.resolver.current_scope
+            label = scope.labels
+            symbols = scope.symbols
+
+            def _logical(value: object) -> int:
+                inner = getattr(value, "logical_value", value)
+                assert isinstance(inner, int)
+                return inner
+
+            assert _logical(symbols["region_a"]) == 0x208000
+            assert _logical(symbols["region_b"]) == 0x228000
+            assert _logical(symbols["region_c"]) == 0x308000
+
+            # Importer PC stays put across pinned .import.
+            assert _logical(label["after_import"]) - _logical(label["before_import"]) == 1
+
+            # Verify each region's bytes land at exactly the right LoROM
+            # physical offset and only there.
+            content = ips.read_bytes()
+            records = self._parse_ips_records(content)
+            placements: dict[int, bytes] = {phys: data for phys, data in records}
+
+            # LoROM physical for SNES bank N $8000-$FFFF = N * 0x8000 + (addr - $8000).
+            phys_a = 0x20 * 0x8000 + 0x0000  # 0x100000
+            phys_b = 0x22 * 0x8000 + 0x0000  # 0x110000
+            phys_c = 0x30 * 0x8000 + 0x0000  # 0x180000
+            assert placements.get(phys_a, b"") == b"\xa1\xa2\xa3\xa4", (
+                f"region_a bytes missing/misplaced at physical 0x{phys_a:06x}"
+            )
+            assert placements.get(phys_b, b"") == b"\xb1\xb2\xb3\xb4", (
+                f"region_b bytes missing/misplaced at physical 0x{phys_b:06x}"
+            )
+            assert placements.get(phys_c, b"") == b"\xc1\xc2\xc3\xc4", (
+                f"region_c bytes missing/misplaced at physical 0x{phys_c:06x}"
+            )
+
+            # Each sentinel must appear exactly once across the whole IPS.
+            assert content.count(b"\xa1\xa2\xa3\xa4") == 1
+            assert content.count(b"\xb1\xb2\xb3\xb4") == 1
+            assert content.count(b"\xc1\xc2\xc3\xc4") == 1
+
+    def test_multi_region_cross_region_symbol_reference_in_module(self) -> None:
+        """A `dw label_in_other_region` inside a pinned multi-region
+        module patches with the target's *absolute* logical address —
+        not an offset, not a region-relative value.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "xref.s"
+            mod.write_text(
+                "*=0x208000\nregion_a:\n    .dw far_target & 0xFFFF\n*=0x308000\nfar_target:\n    .db 0x99\n"
+            )
+            assert Program().assemble_as_object(str(mod), tmp / "xref.o") == 0
+
+            main = tmp / "main.s"
+            main.write_text('*=0x008000\n.import "xref"\n')
+            ips = tmp / "out.ips"
+            program = Program()
+            program.add_module_path(tmp)
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            phys_a = 0x20 * 0x8000  # 0x100000
+            placements = {phys: data for phys, data in self._parse_ips_records(ips.read_bytes())}
+            patched = placements.get(phys_a)
+            assert patched is not None and len(patched) >= 2
+            operand = patched[0] | (patched[1] << 8)
+            assert operand == 0x308000 & 0xFFFF, (
+                f"cross-region operand patched as {operand:#x}, expected {0x308000 & 0xFFFF:#x}"
+            )
+
     def test_pinned_module_import_does_not_advance_importer_pc(self) -> None:
         """A `.import` of a pinned (`*=`) module must not consume PC.
 
@@ -722,8 +886,9 @@ far_label:
             before = scope.labels.get("before")
             after = scope.labels.get("after")
             assert before is not None and after is not None
-            before_v = before.logical_value if hasattr(before, "logical_value") else before
-            after_v = after.logical_value if hasattr(after, "logical_value") else after
+            before_v = getattr(before, "logical_value", before)
+            after_v = getattr(after, "logical_value", after)
+            assert isinstance(before_v, int) and isinstance(after_v, int)
             # Only the inline 0xAA byte separates `before` and `after`.
             assert after_v - before_v == 1, (
                 f"pinned-module .import advanced importer PC; after-before = {after_v - before_v}"
@@ -776,9 +941,10 @@ far_label:
             # Two labels with one inline byte between them — and crucially
             # NOT separated by the (4-byte) module size. The loser must
             # not advance the importer's PC.
-            assert (after.logical_value if hasattr(after, "logical_value") else after) - (
-                before.logical_value if hasattr(before, "logical_value") else before
-            ) == 1, "loser .import must consume zero PC space"
+            before_v = getattr(before, "logical_value", before)
+            after_v = getattr(after, "logical_value", after)
+            assert isinstance(before_v, int) and isinstance(after_v, int)
+            assert after_v - before_v == 1, "loser .import must consume zero PC space"
 
             # Module payload still appears once, at the winning *=0x009000 site.
             assert ips.read_bytes().count(b"\xcc\xcc\xcc\xcc") == 1

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -688,6 +688,39 @@ far_label:
             target = linker.symbol_map["far_label"] & 0xFFFF
             assert patched[0] | (patched[1] << 8) == target
 
+    def test_multiple_intra_region_expression_relocations_get_distinct_offsets(self) -> None:
+        """Three references to the same forward label must record three offsets.
+
+        Regression: ObjectWriter.relocation_offset() used to read only
+        _region_bytes_emitted, which only advances on write_block. Inside
+        a single region, every reloc emitted before the next *= boundary
+        therefore reported the same offset (the last flushed position),
+        and the linker patched only one of them — the other call sites
+        kept the compile-time placeholder and jumped to garbage.
+        """
+        source = """\
+caller1:
+    jsr.w target
+caller2:
+    jsr.w target
+caller3:
+    jsr.w target
+target:
+    rts
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asm = Path(tmpdir) / "fanout.s"
+            obj = Path(tmpdir) / "fanout.o"
+            asm.write_text(source)
+            assert Program().assemble_as_object(str(asm), obj) == 0
+            o = ObjectFile.from_file(str(obj))
+            offsets = sorted(off for r in o.regions for off, expr, _ in r.expression_relocations if expr == "target")
+            assert len(offsets) == 3, f"expected 3 expression relocations, got {len(offsets)}: {offsets}"
+            assert len(set(offsets)) == 3, f"expected 3 distinct offsets, got {offsets}"
+            # Each jsr.w is 3 bytes (opcode + 2-byte operand). Reloc points
+            # to the operand byte, so offsets are 1, 4, 7.
+            assert offsets == [1, 4, 7]
+
     def test_multi_region_module_writes_multiple_ips_blocks(self) -> None:
         """Linking a multi-region module emits one IPS block per region.
 

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -613,3 +613,99 @@ helper:
             result = program.link_as_sfc(empty_obj, sfc_file)
             assert result == 0
             assert sfc_file.exists()
+
+    def test_multi_region_module_compiles_to_separate_regions(self) -> None:
+        """A module with two `*=` directives produces two regions in the .o."""
+        source = """*=0x008000
+first_label:
+    nop
+*=0x018000
+second_label:
+    nop
+    nop
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asm = Path(tmpdir) / "multi.s"
+            obj = Path(tmpdir) / "multi.o"
+            asm.write_text(source)
+            assert Program().assemble_as_object(str(asm), obj) == 0
+
+            o = ObjectFile.from_file(str(obj))
+            assert o.relocatable is False, "explicit *= must mark module as pinned"
+            bases = [r.base_address for r in o.regions]
+            assert 0x008000 in bases
+            assert 0x018000 in bases
+            by_base = {r.base_address: r for r in o.regions}
+            assert by_base[0x008000].code == b"\xea"
+            assert by_base[0x018000].code == b"\xea\xea"
+
+            by_name = {name: address for name, address, _, _ in o.symbols}
+            assert by_name["first_label"] == 0x008000
+            assert by_name["second_label"] == 0x018000
+
+    def test_multi_region_link_keeps_regions_at_declared_bases(self) -> None:
+        """Pinned multi-region modules ignore the linker base_address."""
+        source = """*=0x008000
+entry:
+    nop
+*=0x018000
+data:
+    .db 0x42
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asm = Path(tmpdir) / "mod.s"
+            obj = Path(tmpdir) / "mod.o"
+            asm.write_text(source)
+            assert Program().assemble_as_object(str(asm), obj) == 0
+            o = ObjectFile.from_file(str(obj))
+
+            linker = Linker([o], base_address=0x9000)
+            linked = linker.link()
+            assert {r.base_address for r in linked.regions} == {0x008000, 0x018000}
+            assert linker.symbol_map["entry"] == 0x008000
+            assert linker.symbol_map["data"] == 0x018000
+
+    def test_multi_region_cross_region_symbol_reloc(self) -> None:
+        """A reference from region A to a label in region B patches the right region."""
+        source = """*=0x008000
+entry:
+    .dw far_label & 0xFFFF
+*=0x018000
+far_label:
+    .db 0x77
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asm = Path(tmpdir) / "cross.s"
+            obj = Path(tmpdir) / "cross.o"
+            asm.write_text(source)
+            assert Program().assemble_as_object(str(asm), obj) == 0
+            o = ObjectFile.from_file(str(obj))
+
+            linker = Linker([o], base_address=0)
+            linked = linker.link()
+            by_base = {r.base_address: r for r in linked.regions}
+            patched = by_base[0x008000].code
+            target = linker.symbol_map["far_label"] & 0xFFFF
+            assert patched[0] | (patched[1] << 8) == target
+
+    def test_multi_region_module_writes_multiple_ips_blocks(self) -> None:
+        """Linking a multi-region module emits one IPS block per region."""
+        source = """*=0x008000
+.db 0x11, 0x22
+*=0x018000
+.db 0x33
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asm = Path(tmpdir) / "two.s"
+            obj = Path(tmpdir) / "two.o"
+            asm.write_text(source)
+            assert Program().assemble_as_object(str(asm), obj) == 0
+            linked = Linker([ObjectFile.from_file(str(obj))]).link()
+
+            ips_path = Path(tmpdir) / "out.ips"
+            assert Program().link_as_patch(linked, ips_path) == 0
+            content = ips_path.read_bytes()
+            assert content.startswith(b"PATCH")
+            # Both region bases must show up as IPS block headers (24-bit big-endian).
+            assert b"\x00\x80\x00" in content  # 0x008000
+            assert b"\x01\x80\x00" in content  # 0x018000

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -688,6 +688,72 @@ far_label:
             target = linker.symbol_map["far_label"] & 0xFFFF
             assert patched[0] | (patched[1] << 8) == target
 
+    def test_skipped_import_flushes_pending_block_before_advancing(self) -> None:
+        """Inline bytes around a skipped duplicate .import keep their addresses.
+
+        Regression: when an earlier `.import` was demoted to symbol-only
+        (because a later `.import` of the same module became the winner),
+        the emit driver advanced the PC by the module's size *without*
+        flushing the pending current_block first. The next flush keyed
+        the previously-accumulated bytes against the post-skip address
+        instead of where they were really emitted, so any inline code
+        sitting between two .imports overwrote unrelated ROM downstream.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            mod = tmp / "mod.s"
+            mod.write_text("payload:\n    .db 0xCC, 0xCC, 0xCC, 0xCC\n")
+            assert Program().assemble_as_object(str(mod), tmp / "mod.o") == 0
+
+            # *=0x008000  -> 3 inline bytes (0xAA AA AA) -> first .import
+            # (skipped) -> 2 more inline bytes (0xBB BB) -> *=0x009000 ->
+            # second .import (emits payload). The pre-skip flush bug
+            # would push the BB BB pair past the module size and into
+            # ROM that was meant to stay untouched.
+            main = tmp / "main.s"
+            main.write_text(
+                '*=0x008000\n.db 0xAA, 0xAA, 0xAA\n.import "mod"\n.db 0xBB, 0xBB\n*=0x009000\n.import "mod"\n'
+            )
+            ips = tmp / "out.ips"
+            program = Program()
+            program.add_module_path(tmp)
+            assert program.assemble_as_patch(str(main), ips) == 0
+
+            content = ips.read_bytes()
+            # Module payload appears once, at the second .import site
+            # (SNES 0x009000 → LoROM physical 0x000800).
+            assert content.count(b"\xcc\xcc\xcc\xcc") == 1
+            # Inline AA AA AA must land at SNES 0x008000 → physical 0,
+            # and BB BB at PC 3 + len(mod region) (physical 0x000007 in
+            # LoROM since region is 4 bytes).
+            records = self._parse_ips_records(content)
+            placements = {phys: data for phys, data in records}
+            assert placements.get(0x000000, b"")[:3] == b"\xaa\xaa\xaa"
+            # BB BB must immediately follow the module-sized gap, not
+            # land somewhere far away thanks to a stale current_block_addr.
+            bb_seen = any(b"\xbb\xbb" in data for _, data in records)
+            assert bb_seen, "inline bytes after skipped .import did not land in IPS"
+
+    @staticmethod
+    def _parse_ips_records(content: bytes) -> list[tuple[int, bytes]]:
+        """Walk an IPS file and return [(physical_offset, data), ...]."""
+        out: list[tuple[int, bytes]] = []
+        i = 5  # skip "PATCH"
+        while i < len(content) - 3:
+            if content[i : i + 3] == b"EOF":
+                break
+            offset = int.from_bytes(content[i : i + 3], "big")
+            i += 3
+            size = int.from_bytes(content[i : i + 2], "big")
+            i += 2
+            if size == 0:
+                # RLE record — skip; not produced by a816's IPS writer.
+                i += 3
+                continue
+            out.append((offset, content[i : i + size]))
+            i += size
+        return out
+
     def test_duplicate_import_emits_module_bytes_once_at_last_site(self) -> None:
         """Two .import "foo" statements emit foo's bytes once, at the second site.
 


### PR DESCRIPTION
## Summary
- Bumps `.o` to v6: `ObjectFile.regions: list[Region]`, each region with its own `base_address` and region-relative `relocations` / `expression_relocations` / `lines`. Modules with multiple `*=` directives now survive linking instead of collapsing into one impossible-to-place blob (FF4 modules spanning `*=0x0AF000` through `*=0x318000` were the trigger — relocation offsets were leaking the physical address `set_position` puts into `resolver.pc` and indexing past a 225 KB `bytearray` at offset ~1.3M).
- `ObjectWriter` opens a region per `*=` and exposes `relocation_offset()`; reloc emit sites in `cpu_65c816.py` and `parse/nodes.py` (`Long`/`Word`/`Byte`/`Opcode`) key offsets off bytes-emitted in the active region rather than `resolver.pc`.
- `LinkedModuleNode` rebuilt around `regions` with `emit_blocks()`. Relocatable modules (no `*=`) shift by `delta = import_pc - regions[0].base_address`; pinned modules honor their compile-time absolutes and ignore the import site. Linker walks regions, patches per-region, emits one IPS/SFC block per region.
- v5 .o files rejected with a clear error — back-compat is a non-goal.

## Test plan
- [x] `hatch run tests:all` (pytest + ruff + mypy) — 564 passing, 1 skipped.
- [x] New end-to-end tests: multi-region compile produces N regions, pinned link keeps declared bases, cross-region symbol reloc patches the right region, multi-region IPS emits one block per region with the right 24-bit header.
- [x] Round-trip + v5 rejection in `test_object_file.py`.
- [x] Out-of-tree FF4 modules build — verify the IndexError / 1.3M-offset reloc warning is gone and the produced ROM matches expected at the divergent regions.