### PR TITLE
Bump release workflow to Node 24 actions

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,22 +1,22 @@
-  on:
-    push:
-      tags:
-        - 'v*'
-  jobs:
-    binaries:
-      runs-on: windows-latest
-      steps:
-        - uses: actions/checkout@v4
-        - name: Setup Python 3.12
-          uses: actions/setup-python@v5
-          with:
-            python-version: '3.12'
-        - name: Install hatch
-          run: pip install -r requirements.txt
-        - name: Make release
-          run: make release
-          env:
-            HATCH_INDEX_AUTH: ${{ secrets.HATCH_INDEX_AUTH }}
-            HATCH_INDEX_USER: ${{ secrets.HATCH_INDEX_USER }}
-            VERSION: ${{ github.ref_name }}
-            GH_TOKEN: ${{ github.token }}
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  binaries:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install hatch
+        run: pip install -r requirements.txt
+      - name: Make release
+        run: make release
+        env:
+          HATCH_INDEX_AUTH: ${{ secrets.HATCH_INDEX_AUTH }}
+          HATCH_INDEX_USER: ${{ secrets.HATCH_INDEX_USER }}
+          VERSION: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` → `@v5` (Node 24)
- `actions/setup-python@v5` → `@v6` (Node 24)
- drop the stray top-level indent — `on:` now sits at column 0 like the schema expects

Silences the Node 20 deprecation warnings GitHub now emits on every release run.

## Test plan
- [ ] next \`v*\` tag fires \`binaries.yml\` cleanly (no Node 20 warning, release publishes)