### PR TITLE
Tooling pass: xobj, emit trace, smarter xdds, LSP rename, fluff polish

### DIFF
--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -109,13 +109,9 @@ class Instruction:
             AddrMode.STACK_REL_IND_Y: (2, "({},s),y"),
         }
 
-        return self._dispatch_operand_format(
-            val, templates, hex_val, m_flag, x_flag, use_a816_syntax, label_map
-        )
+        return self._dispatch_operand_format(val, templates, hex_val, m_flag, x_flag, use_a816_syntax, label_map)
 
-    def _format_relative_target(
-        self, hex_val: Callable[[int, int], str], label_map: dict[int, str] | None
-    ) -> str:
+    def _format_relative_target(self, hex_val: Callable[[int, int], str], label_map: dict[int, str] | None) -> str:
         target = self.relative_target()
         if label_map is not None and target in label_map:
             return label_map[target]
@@ -619,6 +615,80 @@ class Disassembler:
             address += inst.length
 
         return instructions
+
+
+_CONDITIONAL_BRANCHES = frozenset({"bcc", "bcs", "beq", "bmi", "bne", "bpl", "bvc", "bvs"})
+_UNCONDITIONAL_BRANCHES = frozenset({"bra", "brl"})
+_RETURNS = frozenset({"rts", "rtl", "rti"})
+_UNCONDITIONAL_JUMPS = frozenset({"jmp", "jml"})
+
+
+def disassemble_function(
+    entry: int,
+    data_provider: Callable[[int, int], bytes],
+    m_flag: bool = True,
+    x_flag: bool = True,
+    max_instructions: int = 4096,
+    follow_calls: bool = False,
+) -> list[Instruction]:
+    """Walk a 65c816 function CFG starting at `entry`, returning every
+    decoded instruction in sorted address order.
+
+    Tracks M / X through `sep` / `rep`, enqueues both branches at
+    conditional jumps, follows unconditional branches, stops a path at
+    `rts` / `rtl` / `rti` or an unconditional jump. `data_provider(addr,
+    length)` must return up to `length` bytes from SNES logical address
+    `addr`. `follow_calls=True` enqueues `jsr` / `jsl` targets too.
+    `max_instructions` caps runaway decodes on garbage past the body.
+    """
+    seen: set[tuple[int, bool, bool]] = set()
+    output: dict[int, Instruction] = {}
+    work: list[tuple[int, bool, bool]] = [(entry, m_flag, x_flag)]
+    decoded = 0
+
+    while work and decoded < max_instructions:
+        addr, m, x = work.pop()
+        key = (addr, m, x)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        local = Disassembler(m_flag=m, x_flag=x)
+        cur = addr
+        while decoded < max_instructions:
+            chunk = data_provider(cur, 4)
+            if not chunk:
+                break
+            inst = local.decode_instruction(chunk, cur)
+            if inst is None:
+                break
+            output.setdefault(cur, inst)
+            decoded += 1
+
+            if inst.mnemonic in _RETURNS:
+                break
+            if inst.mnemonic in _UNCONDITIONAL_JUMPS:
+                if inst.mode == AddrMode.ABSOLUTE_LONG:
+                    work.append((inst.operand_value & 0xFFFFFF, local.m_flag, local.x_flag))
+                elif inst.mode == AddrMode.ABSOLUTE:
+                    target = (inst.address & 0xFF0000) | (inst.operand_value & 0xFFFF)
+                    work.append((target, local.m_flag, local.x_flag))
+                break
+            if inst.mnemonic in _UNCONDITIONAL_BRANCHES:
+                work.append((inst.relative_target(), local.m_flag, local.x_flag))
+                break
+            if inst.mnemonic in _CONDITIONAL_BRANCHES:
+                work.append((inst.relative_target(), local.m_flag, local.x_flag))
+            if follow_calls and inst.mnemonic in ("jsr", "jsl"):
+                if inst.mode == AddrMode.ABSOLUTE_LONG:
+                    target = inst.operand_value & 0xFFFFFF
+                else:
+                    target = (inst.address & 0xFF0000) | (inst.operand_value & 0xFFFF)
+                work.append((target, local.m_flag, local.x_flag))
+
+            cur += inst.length
+
+    return [output[addr] for addr in sorted(output)]
 
 
 def _label_for(address: int) -> str:

--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -622,7 +622,7 @@ class Disassembler:
 
 
 def _label_for(address: int) -> str:
-    return f"L_{(address >> 16) & 0xFF:02X}{address & 0xFFFF:04X}"
+    return f"_{(address >> 16) & 0xFF:02X}{address & 0xFFFF:04X}"
 
 
 def collect_labels(instructions: list[Instruction]) -> dict[int, str]:
@@ -679,12 +679,12 @@ def format_disassembly(
                 bytes_str = " ".join(f"{b:02X}" for b in all_bytes)
                 return f"{addr_str:14} {asm_str:24} ; {bytes_str}"
             return f"{addr_str:14} {asm_str}"
-        # label_map mode: indent the instruction; labels printed by block formatter.
+        # label_map mode: emit instruction flush-left; labels printed by block formatter.
         if show_bytes:
             all_bytes = bytes([inst.opcode]) + inst.operand_bytes
             bytes_str = " ".join(f"{b:02X}" for b in all_bytes)
-            return f"    {asm_str:32} ; ${inst.address & 0xFFFFFF:06X}: {bytes_str}"
-        return f"    {asm_str}"
+            return f"{asm_str:32} ; ${inst.address & 0xFFFFFF:06X}: {bytes_str}"
+        return asm_str
 
     addr_str = f"${bank:02X}:{addr:04X}"
     if show_bytes:

--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -52,11 +52,33 @@ class Instruction:
     operand_value: int  # Decoded operand value
     length: int  # Total instruction length
 
-    def format_operand(self, m_flag: bool = True, x_flag: bool = True, use_a816_syntax: bool = False) -> str:
+    def relative_target(self) -> int:
+        """Compute the 24-bit absolute target for a relative branch.
+
+        Preserves the current bank because RELATIVE/RELATIVE_LONG cannot
+        cross banks; the offset wraps inside the bank-local 16-bit space.
+        """
+        val = self.operand_value
+        if self.mode == AddrMode.RELATIVE:
+            offset = val if val < 0x80 else val - 0x100
+        else:
+            offset = val if val < 0x8000 else val - 0x10000
+        bank = self.address & 0xFF0000
+        target = (self.address + self.length + offset) & 0xFFFF
+        return bank | target
+
+    def format_operand(
+        self,
+        m_flag: bool = True,
+        x_flag: bool = True,
+        use_a816_syntax: bool = False,
+        label_map: dict[int, str] | None = None,
+    ) -> str:
         """Format operand for the addressing mode.
 
         m_flag/x_flag select 8- vs 16-bit width for IMMEDIATE_M / IMMEDIATE_X.
         use_a816_syntax: 0x prefix instead of $.
+        label_map: address -> label substitution for branch / jump targets.
         """
         val = self.operand_value
 
@@ -87,13 +109,31 @@ class Instruction:
             AddrMode.STACK_REL_IND_Y: (2, "({},s),y"),
         }
 
-        return self._dispatch_operand_format(val, templates, hex_val, m_flag, x_flag, use_a816_syntax)
+        return self._dispatch_operand_format(
+            val, templates, hex_val, m_flag, x_flag, use_a816_syntax, label_map
+        )
 
-    def _format_relative_target(self, val: int, hex_val: Callable[[int, int], str]) -> str:
-        cap = 256 if self.mode == AddrMode.RELATIVE else 65536
-        half = cap // 2
-        offset = val if val < half else val - cap
-        return hex_val((self.address + self.length + offset) & 0xFFFF, 4)
+    def _format_relative_target(
+        self, hex_val: Callable[[int, int], str], label_map: dict[int, str] | None
+    ) -> str:
+        target = self.relative_target()
+        if label_map is not None and target in label_map:
+            return label_map[target]
+        return hex_val(target, 6)
+
+    def _format_jump_target(
+        self, val: int, width: int, hex_val: Callable[[int, int], str], label_map: dict[int, str] | None
+    ) -> str:
+        """For absolute jumps/calls, swap in a label when the target matches."""
+        if label_map is None:
+            return hex_val(val, width)
+        if width >= 6:
+            target = val & 0xFFFFFF
+        else:
+            target = (self.address & 0xFF0000) | (val & 0xFFFF)
+        if target in label_map:
+            return label_map[target]
+        return hex_val(val, width)
 
     def _dispatch_operand_format(
         self,
@@ -103,9 +143,17 @@ class Instruction:
         m_flag: bool,
         x_flag: bool,
         use_a816_syntax: bool,
+        label_map: dict[int, str] | None = None,
     ) -> str:
         if self.mode == AddrMode.IMPLIED:
             return ""
+        # Absolute jumps / calls — use label substitution when known.
+        if self.mnemonic in ("jmp", "jsr", "jsl") and self.mode in (
+            AddrMode.ABSOLUTE,
+            AddrMode.ABSOLUTE_LONG,
+        ):
+            width = 6 if self.mode == AddrMode.ABSOLUTE_LONG else 4
+            return self._format_jump_target(val, width, hex_val, label_map)
         if self.mode in templates:
             width, fmt = templates[self.mode]
             return fmt.format(hex_val(val, width))
@@ -114,67 +162,41 @@ class Instruction:
         if self.mode == AddrMode.IMMEDIATE_X:
             return f"#{hex_val(val, 2 if x_flag else 4)}"
         if self.mode in (AddrMode.RELATIVE, AddrMode.RELATIVE_LONG):
-            return self._format_relative_target(val, hex_val)
+            return self._format_relative_target(hex_val, label_map)
         if self.mode == AddrMode.BLOCK_MOVE:
             return f"{hex_val(val & 0xFF, 2)},{hex_val((val >> 8) & 0xFF, 2)}"
         return (f"0x{val:X}") if use_a816_syntax else (f"${val:X}")
 
     def get_size_hint(self) -> str:
-        """Get the size hint suffix for a816 syntax (.b, .w, .l)."""
+        """Get the size hint suffix for a816 syntax (.b, .w, .l).
+
+        Minimal-suffix policy aimed at matching idiomatic a816 source:
+        - Bare `lda #imm` for IMMEDIATE_M/IMMEDIATE_X 8-bit, IMMEDIATE_8.
+        - `.w` only when the operand is a 16-bit immediate (forces width).
+        - Bare absolute / direct (no `.w` / `.b` clutter).
+        - `.l` retained for ABSOLUTE_LONG family (a816 needs it to pick jsl).
+        - Block-move / relative / implied: no suffix.
+        """
         mode = self.mode
 
-        # Implied instructions don't need size hints
-        if mode == AddrMode.IMPLIED:
-            return ""
-
-        # Immediate instructions use the operand size
-        if mode in (AddrMode.IMMEDIATE_8, AddrMode.IMMEDIATE_M, AddrMode.IMMEDIATE_X):
-            if len(self.operand_bytes) == 1:
-                return ".b"
-            else:
-                return ".w"
-        elif mode == AddrMode.IMMEDIATE_16:
+        # 16-bit immediate forces `.w` so a816 picks the right opcode width.
+        if mode in (AddrMode.IMMEDIATE_M, AddrMode.IMMEDIATE_X):
+            return ".w" if len(self.operand_bytes) == 2 else ""
+        if mode == AddrMode.IMMEDIATE_16:
             return ".w"
 
-        # Direct page is always byte-addressed
-        if mode in (
-            AddrMode.DIRECT,
-            AddrMode.DIRECT_X,
-            AddrMode.DIRECT_Y,
-            AddrMode.DIRECT_IND,
-            AddrMode.DIRECT_IND_X,
-            AddrMode.DIRECT_IND_Y,
-            AddrMode.DIRECT_IND_LONG,
-            AddrMode.DIRECT_IND_LONG_Y,
-            AddrMode.STACK_REL,
-            AddrMode.STACK_REL_IND_Y,
-        ):
-            return ".b"
-
-        # Absolute is word
-        if mode in (
-            AddrMode.ABSOLUTE,
-            AddrMode.ABSOLUTE_X,
-            AddrMode.ABSOLUTE_Y,
-            AddrMode.ABSOLUTE_IND,
-            AddrMode.ABSOLUTE_IND_X,
-            AddrMode.ABSOLUTE_IND_LONG,
-        ):
-            return ".w"
-
-        # Long is 24-bit
         if mode in (AddrMode.ABSOLUTE_LONG, AddrMode.ABSOLUTE_LONG_X):
             return ".l"
 
-        # Relative branches don't need size hints
-        if mode in (AddrMode.RELATIVE, AddrMode.RELATIVE_LONG, AddrMode.BLOCK_MOVE):
-            return ""
-
         return ""
 
-    def format_a816(self) -> str:
-        """Format instruction in a816-compatible syntax."""
-        operand = self.format_operand(use_a816_syntax=True)
+    def format_a816(self, label_map: dict[int, str] | None = None) -> str:
+        """Format instruction in a816-compatible syntax.
+
+        label_map: optional address -> label dict. When provided, branch
+        and jump targets that match are rendered as labels.
+        """
+        operand = self.format_operand(use_a816_syntax=True, label_map=label_map)
         size_hint = self.get_size_hint()
 
         if operand:
@@ -599,53 +621,104 @@ class Disassembler:
         return instructions
 
 
-def format_disassembly(inst: Instruction, show_bytes: bool = True, a816_syntax: bool = False) -> str:
+def _label_for(address: int) -> str:
+    return f"L_{(address >> 16) & 0xFF:02X}{address & 0xFFFF:04X}"
+
+
+def collect_labels(instructions: list[Instruction]) -> dict[int, str]:
+    """Build address -> label map for branch and jump targets.
+
+    Only addresses targeted by branches or absolute/long jumps/calls get
+    a label entry, so disassembly substitutes labels in operands and the
+    block formatter emits label lines at in-range targets. Out-of-range
+    targets still substitute in operands; the user supplies the label
+    definition elsewhere when reassembling.
     """
-    Format a single instruction for display.
+    targets: set[int] = set()
+    for inst in instructions:
+        if inst.mode in (AddrMode.RELATIVE, AddrMode.RELATIVE_LONG):
+            targets.add(inst.relative_target())
+            continue
+        if inst.mnemonic in ("jmp", "jsr", "jsl"):
+            if inst.mode == AddrMode.ABSOLUTE_LONG:
+                targets.add(inst.operand_value & 0xFFFFFF)
+            elif inst.mode == AddrMode.ABSOLUTE:
+                targets.add((inst.address & 0xFF0000) | (inst.operand_value & 0xFFFF))
+    return {target: _label_for(target) for target in targets}
+
+
+def format_disassembly(
+    inst: Instruction,
+    show_bytes: bool = True,
+    a816_syntax: bool = False,
+    label_map: dict[int, str] | None = None,
+) -> str:
+    """Format a single instruction for display.
 
     Args:
-        inst: Decoded instruction
-        show_bytes: Whether to show raw bytes
-        a816_syntax: If True, output a816-compatible assembly syntax
+        inst: Decoded instruction.
+        show_bytes: Whether to show raw bytes.
+        a816_syntax: If True, output a816-compatible assembly syntax.
+        label_map: Optional address -> label dict for branch / jump targets.
+            When provided in a816 mode, no per-line synthetic label is
+            emitted; callers should print the label on its own line where
+            applicable (see format_disassembly_block).
 
     Returns:
-        Formatted string
+        Formatted string.
     """
-    # Address
     bank = (inst.address >> 16) & 0xFF
     addr = inst.address & 0xFFFF
 
     if a816_syntax:
-        # a816-compatible format: label and instruction
-        addr_str = f"L_{bank:02X}{addr:04X}:"
-        asm_str = inst.format_a816()
-
-        if show_bytes:
-            all_bytes = bytes([inst.opcode]) + inst.operand_bytes
-            bytes_str = " ".join(f"{b:02X}" for b in all_bytes)
-            comment = f"; {bytes_str}"
-            return f"{addr_str:14} {asm_str:24} {comment}"
-        else:
+        asm_str = inst.format_a816(label_map=label_map)
+        if label_map is None:
+            addr_str = f"{_label_for(inst.address)}:"
+            if show_bytes:
+                all_bytes = bytes([inst.opcode]) + inst.operand_bytes
+                bytes_str = " ".join(f"{b:02X}" for b in all_bytes)
+                return f"{addr_str:14} {asm_str:24} ; {bytes_str}"
             return f"{addr_str:14} {asm_str}"
-    else:
-        addr_str = f"${bank:02X}:{addr:04X}"
-
+        # label_map mode: indent the instruction; labels printed by block formatter.
         if show_bytes:
-            # Raw bytes (up to 4)
             all_bytes = bytes([inst.opcode]) + inst.operand_bytes
             bytes_str = " ".join(f"{b:02X}" for b in all_bytes)
-            bytes_str = bytes_str.ljust(11)  # 4 bytes max = "XX XX XX XX"
-        else:
-            bytes_str = ""
+            return f"    {asm_str:32} ; ${inst.address & 0xFFFFFF:06X}: {bytes_str}"
+        return f"    {asm_str}"
 
-        # Mnemonic and operand
-        operand = inst.format_operand()
-        if operand:
-            asm_str = f"{inst.mnemonic:4} {operand}"
-        else:
-            asm_str = inst.mnemonic
+    addr_str = f"${bank:02X}:{addr:04X}"
+    if show_bytes:
+        all_bytes = bytes([inst.opcode]) + inst.operand_bytes
+        bytes_str = " ".join(f"{b:02X}" for b in all_bytes).ljust(11)
+    else:
+        bytes_str = ""
 
-        if show_bytes:
-            return f"{addr_str}  {bytes_str}  {asm_str}"
-        else:
-            return f"{addr_str}  {asm_str}"
+    operand = inst.format_operand()
+    asm_str = f"{inst.mnemonic:4} {operand}" if operand else inst.mnemonic
+
+    if show_bytes:
+        return f"{addr_str}  {bytes_str}  {asm_str}"
+    return f"{addr_str}  {asm_str}"
+
+
+def format_disassembly_block(
+    instructions: list[Instruction],
+    show_bytes: bool = True,
+    a816_syntax: bool = False,
+) -> list[str]:
+    """Format a contiguous run of instructions, emitting label lines only
+    at addresses referenced by branches or jumps within the block.
+
+    Returns one string per output line (mix of label lines and instruction
+    lines). When `a816_syntax` is False this is equivalent to mapping
+    `format_disassembly` over the instruction list.
+    """
+    if not a816_syntax:
+        return [format_disassembly(inst, show_bytes=show_bytes, a816_syntax=False) for inst in instructions]
+    label_map = collect_labels(instructions)
+    lines: list[str] = []
+    for inst in instructions:
+        if inst.address in label_map:
+            lines.append(f"{label_map[inst.address]}:")
+        lines.append(format_disassembly(inst, show_bytes=show_bytes, a816_syntax=True, label_map=label_map))
+    return lines

--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -705,6 +705,7 @@ def format_disassembly_block(
     instructions: list[Instruction],
     show_bytes: bool = True,
     a816_syntax: bool = False,
+    symbol_map: dict[int, str] | None = None,
 ) -> list[str]:
     """Format a contiguous run of instructions, emitting label lines only
     at addresses referenced by branches or jumps within the block.
@@ -712,13 +713,24 @@ def format_disassembly_block(
     Returns one string per output line (mix of label lines and instruction
     lines). When `a816_syntax` is False this is equivalent to mapping
     `format_disassembly` over the instruction list.
+
+    symbol_map: optional address -> human-readable symbol name dict that
+    takes precedence over synthesized `_BBHHHH` labels. When a target's
+    address has an entry, the symbol name is used in operands and as the
+    on-line label.
     """
     if not a816_syntax:
         return [format_disassembly(inst, show_bytes=show_bytes, a816_syntax=False) for inst in instructions]
     label_map = collect_labels(instructions)
-    lines: list[str] = []
+    if symbol_map:
+        label_map = {**label_map, **symbol_map}
+    label_emit_addresses: set[int] = set()
     for inst in instructions:
         if inst.address in label_map:
+            label_emit_addresses.add(inst.address)
+    lines: list[str] = []
+    for inst in instructions:
+        if inst.address in label_emit_addresses:
             lines.append(f"{label_map[inst.address]}:")
         lines.append(format_disassembly(inst, show_bytes=show_bytes, a816_syntax=True, label_map=label_map))
     return lines

--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -623,6 +623,40 @@ _RETURNS = frozenset({"rts", "rtl", "rti"})
 _UNCONDITIONAL_JUMPS = frozenset({"jmp", "jml"})
 
 
+def _absolute_jump_target(inst: Instruction) -> int | None:
+    """Static target of an absolute jmp / jsr / jsl. None if not statically resolvable."""
+    if inst.mode == AddrMode.ABSOLUTE_LONG:
+        return inst.operand_value & 0xFFFFFF
+    if inst.mode == AddrMode.ABSOLUTE:
+        return (inst.address & 0xFF0000) | (inst.operand_value & 0xFFFF)
+    return None
+
+
+def _enqueue_successors(
+    inst: Instruction, m: bool, x: bool, follow_calls: bool, work: list[tuple[int, bool, bool]]
+) -> bool:
+    """Push CFG successors of `inst` onto `work`. Return True if the path
+    terminates here (return / unconditional jump / unconditional branch).
+    """
+    if inst.mnemonic in _RETURNS:
+        return True
+    if inst.mnemonic in _UNCONDITIONAL_JUMPS:
+        target = _absolute_jump_target(inst)
+        if target is not None:
+            work.append((target, m, x))
+        return True
+    if inst.mnemonic in _UNCONDITIONAL_BRANCHES:
+        work.append((inst.relative_target(), m, x))
+        return True
+    if inst.mnemonic in _CONDITIONAL_BRANCHES:
+        work.append((inst.relative_target(), m, x))
+    if follow_calls and inst.mnemonic in ("jsr", "jsl"):
+        target = _absolute_jump_target(inst)
+        if target is not None:
+            work.append((target, m, x))
+    return False
+
+
 def disassemble_function(
     entry: int,
     data_provider: Callable[[int, int], bytes],
@@ -648,47 +682,43 @@ def disassemble_function(
 
     while work and decoded < max_instructions:
         addr, m, x = work.pop()
-        key = (addr, m, x)
-        if key in seen:
+        if (addr, m, x) in seen:
             continue
-        seen.add(key)
-
-        local = Disassembler(m_flag=m, x_flag=x)
-        cur = addr
-        while decoded < max_instructions:
-            chunk = data_provider(cur, 4)
-            if not chunk:
-                break
-            inst = local.decode_instruction(chunk, cur)
-            if inst is None:
-                break
-            output.setdefault(cur, inst)
-            decoded += 1
-
-            if inst.mnemonic in _RETURNS:
-                break
-            if inst.mnemonic in _UNCONDITIONAL_JUMPS:
-                if inst.mode == AddrMode.ABSOLUTE_LONG:
-                    work.append((inst.operand_value & 0xFFFFFF, local.m_flag, local.x_flag))
-                elif inst.mode == AddrMode.ABSOLUTE:
-                    target = (inst.address & 0xFF0000) | (inst.operand_value & 0xFFFF)
-                    work.append((target, local.m_flag, local.x_flag))
-                break
-            if inst.mnemonic in _UNCONDITIONAL_BRANCHES:
-                work.append((inst.relative_target(), local.m_flag, local.x_flag))
-                break
-            if inst.mnemonic in _CONDITIONAL_BRANCHES:
-                work.append((inst.relative_target(), local.m_flag, local.x_flag))
-            if follow_calls and inst.mnemonic in ("jsr", "jsl"):
-                if inst.mode == AddrMode.ABSOLUTE_LONG:
-                    target = inst.operand_value & 0xFFFFFF
-                else:
-                    target = (inst.address & 0xFF0000) | (inst.operand_value & 0xFFFF)
-                work.append((target, local.m_flag, local.x_flag))
-
-            cur += inst.length
+        seen.add((addr, m, x))
+        decoded += _walk_path(addr, m, x, data_provider, output, work, follow_calls, max_instructions - decoded)
 
     return [output[addr] for addr in sorted(output)]
+
+
+def _walk_path(
+    addr: int,
+    m: bool,
+    x: bool,
+    data_provider: Callable[[int, int], bytes],
+    output: dict[int, Instruction],
+    work: list[tuple[int, bool, bool]],
+    follow_calls: bool,
+    budget: int,
+) -> int:
+    """Decode straight-line from `addr` until a terminator or the budget
+    runs out. Returns the number of instructions decoded.
+    """
+    local = Disassembler(m_flag=m, x_flag=x)
+    cur = addr
+    decoded = 0
+    while decoded < budget:
+        chunk = data_provider(cur, 4)
+        if not chunk:
+            break
+        inst = local.decode_instruction(chunk, cur)
+        if inst is None:
+            break
+        output.setdefault(cur, inst)
+        decoded += 1
+        if _enqueue_successors(inst, local.m_flag, local.x_flag, follow_calls, work):
+            break
+        cur += inst.length
+    return decoded
 
 
 def _label_for(address: int) -> str:

--- a/a816/fluff.py
+++ b/a816/fluff.py
@@ -8,6 +8,7 @@ from a816.exceptions import FormattingError
 from a816.formatter import A816Formatter
 
 SOURCE_SUFFIXES = {".s", ".i"}
+STDIN_LABEL = "<stdin>"
 
 RESET = "\033[0m"
 RED = "\033[31m"
@@ -133,7 +134,7 @@ def _run_format_stdin(args: argparse.Namespace) -> int:
     """
     original = sys.stdin.read()
     try:
-        formatted = A816Formatter().format_text(original, "<stdin>")
+        formatted = A816Formatter().format_text(original, STDIN_LABEL)
     except FormattingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
@@ -143,15 +144,15 @@ def _run_format_stdin(args: argparse.Namespace) -> int:
         diff_lines = difflib.unified_diff(
             original.splitlines(keepends=True),
             formatted.splitlines(keepends=True),
-            fromfile="<stdin>",
-            tofile="<stdin>",
+            fromfile=STDIN_LABEL,
+            tofile=STDIN_LABEL,
         )
         sys.stdout.write(_colorize_diff(diff_lines))
         return 1
     if args.check:
         if original == formatted:
             return 0
-        print("Would reformat <stdin>", file=sys.stderr)
+        print(f"Would reformat {STDIN_LABEL}", file=sys.stderr)
         return 1
     sys.stdout.write(formatted)
     return 0

--- a/a816/fluff.py
+++ b/a816/fluff.py
@@ -47,7 +47,11 @@ def _build_fluff_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="a816 fluff", description="Format a816 assembly sources.")
     subparsers = parser.add_subparsers(dest="command", required=True)
     format_parser = subparsers.add_parser("format", help="Format .s/.i sources under the given path.")
-    format_parser.add_argument("path", type=Path, help="File or directory to format recursively.")
+    format_parser.add_argument(
+        "path",
+        type=Path,
+        help="File or directory to format recursively. Use `-` to read from stdin and write the formatted text to stdout.",
+    )
     format_parser.add_argument(
         "--check",
         action="store_true",
@@ -120,8 +124,43 @@ def _write_formatted(computed: list[tuple[Path, str, str]]) -> int:
     return 0
 
 
+def _run_format_stdin(args: argparse.Namespace) -> int:
+    """Read source from stdin, write formatted text to stdout.
+
+    --check / --diff still work: --check prints `Would reformat <stdin>`
+    and exits 1 if formatting changes the input; --diff emits a unified
+    diff. Otherwise the formatted text is written to stdout.
+    """
+    original = sys.stdin.read()
+    try:
+        formatted = A816Formatter().format_text(original, "<stdin>")
+    except FormattingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    if args.diff:
+        if original == formatted:
+            return 0
+        diff_lines = difflib.unified_diff(
+            original.splitlines(keepends=True),
+            formatted.splitlines(keepends=True),
+            fromfile="<stdin>",
+            tofile="<stdin>",
+        )
+        sys.stdout.write(_colorize_diff(diff_lines))
+        return 1
+    if args.check:
+        if original == formatted:
+            return 0
+        print("Would reformat <stdin>", file=sys.stderr)
+        return 1
+    sys.stdout.write(formatted)
+    return 0
+
+
 def _run_format(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     target_path: Path = args.path
+    if str(target_path) == "-":
+        return _run_format_stdin(args)
     if not target_path.exists():
         parser.error(f"path does not exist: {target_path}")
     sources = list(_discover_sources(target_path))

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -153,7 +153,20 @@ class A816Formatter:
                 ]
             lines.extend(node_lines)
             prev_was_label = isinstance(node, LabelAstNode)
-            if node_line is not None:
+            # For nodes that span multiple source lines (.if / .scope /
+            # .macro / .for / nested compounds), advance prev_line to the
+            # last source line the node consumed so the gap-based blank
+            # heuristic doesn't treat the block's body as a hole.
+            tail_line = self._ast_max_line(node)
+            if tail_line is not None:
+                prev_line = tail_line
+                # Block-like nodes carry a closing brace on the next
+                # source line which has no AST entry; advance over it
+                # so the gap heuristic doesn't treat the brace line as
+                # blank padding between siblings.
+                if isinstance(node, IfAstNode | ForAstNode | MacroAstNode | ScopeAstNode | CompoundAstNode):
+                    prev_line += 1
+            elif node_line is not None:
                 prev_line = node_line
         return lines
 
@@ -544,16 +557,26 @@ class A816Formatter:
             formatted.extend(node_lines)
 
     def _emit_instruction_like(
-        self, node: AstNode, node_lines: list[str], in_label_section: bool, formatted: list[str]
+        self,
+        node: AstNode,
+        node_lines: list[str],
+        in_label_section: bool,
+        formatted: list[str],
+        prev_was_label: bool = False,
     ) -> bool:
         if isinstance(node, CodePositionAstNode | CodeRelocationAstNode):
             if formatted and formatted[-1].strip():
                 formatted.append("")
             formatted.extend(line.lstrip() for line in node_lines)
             return True
-        # Top-level docstrings document the preceding label and stay
-        # flush-left so the eye groups label + docstring as a header.
-        if isinstance(node, DocstringAstNode):
+        # A docstring immediately after a label documents the symbol and
+        # stays flush-left, hugging the label with no blank line in
+        # between. After a `*=` (region opener) the docstring documents
+        # the region and follows body indentation like any other body
+        # statement — fall through to the normal indent path.
+        if isinstance(node, DocstringAstNode) and prev_was_label:
+            while formatted and not formatted[-1].strip():
+                formatted.pop()
             formatted.extend(node_lines)
             return in_label_section
         if in_label_section:
@@ -578,7 +601,13 @@ class A816Formatter:
         return sorted(positioned, key=lambda x: x[0])
 
     def _emit_non_compound(
-        self, node: AstNode, node_line: int | None, last_line: int | None, in_label: bool, formatted: list[str]
+        self,
+        node: AstNode,
+        node_line: int | None,
+        last_line: int | None,
+        in_label: bool,
+        formatted: list[str],
+        prev_was_label: bool = False,
     ) -> bool:
         node_lines = self._format_ast(node)
         if isinstance(node, LabelAstNode):
@@ -587,25 +616,29 @@ class A816Formatter:
             self._emit_comment(node_lines, node_line, last_line, in_label, formatted)
             return in_label
         if isinstance(node, self._instruction_like_nodes):
-            return self._emit_instruction_like(node, node_lines, in_label, formatted)
+            return self._emit_instruction_like(node, node_lines, in_label, formatted, prev_was_label)
         formatted.extend(node_lines)
         return False
 
     @staticmethod
     def _ast_max_line(node: AstNode) -> int | None:
-        """Walk a subtree and return the largest source line number found,
-        or None if no descendant carries position info. Used to advance the
-        blank-line cursor past a compound block so that source blanks
-        inside the block aren't re-emitted at its closing brace.
+        """Walk a subtree and return the largest source line number among
+        leaf-like descendants. Skips CompoundAstNode positions because the
+        scanner records their position at the closing brace, which would
+        otherwise overshoot the actual extent of the block's content and
+        swallow boundary blank lines that follow the brace.
+
+        Returns None if no descendant carries usable position info.
         """
         max_line: int | None = None
 
         def visit(n: AstNode) -> None:
             nonlocal max_line
-            line = A816Formatter._node_line_num(n)
-            if line is not None and (max_line is None or line > max_line):
-                max_line = line
-            for attr in ("body", "nodes", "items", "children"):
+            if not isinstance(n, CompoundAstNode):
+                line = A816Formatter._node_line_num(n)
+                if line is not None and (max_line is None or line > max_line):
+                    max_line = line
+            for attr in ("body", "block", "else_block", "nodes", "items", "children"):
                 child = getattr(n, attr, None)
                 if child is None:
                     continue
@@ -628,7 +661,9 @@ class A816Formatter:
         in_label_section = False
         last_emitted_line_num: int | None = None
 
-        for line_num, node in self._node_positions_sorted(nodes):
+        positioned = self._node_positions_sorted(nodes)
+        prev_was_label = False
+        for _idx, (line_num, node) in enumerate(positioned):
             current_idx = self._emit_preserved_blanks(original_lines, processed, current_idx, line_num, formatted)
             node_line = self._node_line_num(node)
 
@@ -636,18 +671,31 @@ class A816Formatter:
                 in_label_section = False
                 self._emit_compound(node, formatted)
                 last_emitted_line_num = None
+                prev_was_label = False
             else:
                 in_label_section = self._emit_non_compound(
-                    node, node_line, last_emitted_line_num, in_label_section, formatted
+                    node, node_line, last_emitted_line_num, in_label_section, formatted, prev_was_label
                 )
                 if node_line is not None:
                     last_emitted_line_num = node_line
+                prev_was_label = isinstance(node, LabelAstNode)
 
             processed.add(line_num)
             # Mark every line the node consumed in source so blanks
-            # inside the node aren't re-emitted at its boundary.
+            # inside the node aren't re-emitted at its boundary. Clamp
+            # the tail to the next sibling's start so we don't claim
+            # source blanks that live in the gap between siblings — AST
+            # CompoundAstNode position can land on the closing brace,
+            # which would otherwise swallow trailing blanks.
+            # Advance the cursor past any source lines the node already
+            # consumed (its descendants), so source blanks WITHIN the
+            # body — already handled by the recursive emit — don't get
+            # re-emitted at the boundary. Source blanks AFTER the last
+            # child but BEFORE the next sibling stay reachable, so the
+            # paragraph break the author put between top-level blocks
+            # survives.
             tail = self._ast_max_line(node)
-            if tail is not None:
+            if tail is not None and tail >= line_num:
                 for i in range(line_num, tail + 1):
                     processed.add(i)
                 current_idx = max(current_idx, tail + 1)

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -148,14 +148,16 @@ class A816Formatter:
             ]
         lines.extend(node_lines)
 
+    _BLOCK_LIKE_AST: ClassVar[tuple[type, ...]] = (IfAstNode, ForAstNode, MacroAstNode, ScopeAstNode, CompoundAstNode)
+
     def _advance_prev_line(self, node: AstNode, node_line: int | None) -> int | None:
-        tail_line = self._ast_max_line(node)
+        # Closing braces of block-like nodes sit on the next source
+        # line with no AST entry; bump past them so the gap heuristic
+        # doesn't read the brace line as a blank padding line.
+        tail_line = self._ast_max_line(node) or node_line
         if tail_line is None:
-            return node_line
-        if isinstance(node, IfAstNode | ForAstNode | MacroAstNode | ScopeAstNode | CompoundAstNode):
-            # Closing brace lives on the next source line and has no AST
-            # entry; skip over it so the gap heuristic doesn't see it as
-            # a blank line.
+            return None
+        if isinstance(node, self._BLOCK_LIKE_AST):
             return tail_line + 1
         return tail_line
 
@@ -628,36 +630,44 @@ class A816Formatter:
         formatted.extend(node_lines)
         return False
 
+    _AST_CHILD_ATTRS: ClassVar[tuple[str, ...]] = ("body", "block", "else_block", "nodes", "items", "children")
+
+    @staticmethod
+    def _ast_children(node: AstNode) -> list[AstNode]:
+        """Collect AstNode children reachable through the conventional
+        container attributes used across the AST classes. Returns a
+        flat list; non-AstNode values and missing attrs are skipped.
+        """
+        out: list[AstNode] = []
+        for attr in A816Formatter._AST_CHILD_ATTRS:
+            child = getattr(node, attr, None)
+            if child is None:
+                continue
+            if isinstance(child, list):
+                out.extend(c for c in child if isinstance(c, AstNode))
+            elif isinstance(child, AstNode):
+                out.append(child)
+        return out
+
     @staticmethod
     def _ast_max_line(node: AstNode) -> int | None:
-        """Walk a subtree and return the largest source line number among
-        leaf-like descendants. Skips CompoundAstNode positions because the
-        scanner records their position at the closing brace, which would
-        otherwise overshoot the actual extent of the block's content and
-        swallow boundary blank lines that follow the brace.
+        """Walk a subtree iteratively and return the largest source line
+        number among leaf-like descendants. Skips CompoundAstNode
+        positions because the scanner records their position at the
+        closing brace, which would otherwise overshoot the actual extent
+        of the block's content and swallow boundary blank lines.
 
         Returns None if no descendant carries usable position info.
         """
         max_line: int | None = None
-
-        def visit(n: AstNode) -> None:
-            nonlocal max_line
-            if not isinstance(n, CompoundAstNode):
-                line = A816Formatter._node_line_num(n)
+        stack: list[AstNode] = [node]
+        while stack:
+            current = stack.pop()
+            if not isinstance(current, CompoundAstNode):
+                line = A816Formatter._node_line_num(current)
                 if line is not None and (max_line is None or line > max_line):
                     max_line = line
-            for attr in ("body", "block", "else_block", "nodes", "items", "children"):
-                child = getattr(n, attr, None)
-                if child is None:
-                    continue
-                if isinstance(child, list):
-                    for c in child:
-                        if isinstance(c, AstNode):
-                            visit(c)
-                elif isinstance(child, AstNode):
-                    visit(child)
-
-        visit(node)
+            stack.extend(A816Formatter._ast_children(current))
         return max_line
 
     @dataclass

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -104,70 +105,77 @@ class A816Formatter:
         content = path.read_text(encoding="utf-8")
         return self.format_text(content, str(path))
 
+    def _emit_blank_gap(self, lines: list[str], prev_line: int | None, node_line: int | None) -> None:
+        if prev_line is None or node_line is None or node_line - prev_line <= 1:
+            return
+        gap = min(node_line - prev_line - 1, self.options.max_empty_lines)
+        for _ in range(gap):
+            lines.append("")
+
+    @staticmethod
+    def _try_fold_inline_comment(node: AstNode, node_line: int | None, prev_line: int | None, lines: list[str]) -> bool:
+        """Fold a same-source-line comment onto the previous instruction.
+        Returns True when the fold succeeded so the caller skips the
+        normal node-emission path.
+        """
+        if not isinstance(node, CommentAstNode) or node_line is None or node_line != prev_line:
+            return False
+        if not lines or not lines[-1].strip() or lines[-1].lstrip().startswith(";"):
+            return False
+        comment = node.comment.strip()
+        if not comment.startswith(";"):
+            comment = f"; {comment}"
+        lines[-1] = f"{lines[-1].rstrip()} {comment}"
+        return True
+
+    def _emit_node_lines(
+        self,
+        node: AstNode,
+        should_indent: bool,
+        indent_after_label: bool,
+        lines: list[str],
+    ) -> None:
+        node_lines = self._format_ast(node, should_indent, indent_after_label=indent_after_label)
+        # Docstrings after a label hug it flush-left, no body indent.
+        indent_body_node = (
+            should_indent
+            and isinstance(node, self._instruction_like_nodes)
+            and not isinstance(node, DocstringAstNode)
+        )
+        if indent_body_node:
+            node_lines = [
+                self._indent(line) if line.strip() and not line.startswith(" ") else line for line in node_lines
+            ]
+        lines.extend(node_lines)
+
+    def _advance_prev_line(self, node: AstNode, node_line: int | None) -> int | None:
+        tail_line = self._ast_max_line(node)
+        if tail_line is None:
+            return node_line
+        if isinstance(node, IfAstNode | ForAstNode | MacroAstNode | ScopeAstNode | CompoundAstNode):
+            # Closing brace lives on the next source line and has no AST
+            # entry; skip over it so the gap heuristic doesn't see it as
+            # a blank line.
+            return tail_line + 1
+        return tail_line
+
     def _format_compound(self, ast: CompoundAstNode, indent_instructions: bool, indent_after_label: bool) -> list[str]:
         lines: list[str] = []
         prev_was_label = False
         prev_line: int | None = None
         for node in ast.body:
             node_line = self._node_line_num(node)
+            self._emit_blank_gap(lines, prev_line, node_line)
 
-            # Preserve blank lines from the source by detecting gaps in line
-            # numbers between consecutive AST nodes. Without this the formatter
-            # collapses every paragraph break the author put between logical
-            # chunks of body code.
-            if prev_line is not None and node_line is not None and node_line - prev_line > 1:
-                gap = min(node_line - prev_line - 1, self.options.max_empty_lines)
-                for _ in range(gap):
-                    lines.append("")
-
-            # Fold a comment back onto the previous emitted line when both
-            # came from the same source line (`instr ; comment`). The author's
-            # intent is "trailing comment", not "comment on its own line".
-            if (
-                isinstance(node, CommentAstNode)
-                and node_line is not None
-                and node_line == prev_line
-                and lines
-                and lines[-1].strip()
-                and not lines[-1].lstrip().startswith(";")
-            ):
-                comment = node.comment.strip()
-                if not comment.startswith(";"):
-                    comment = f"; {comment}"
-                lines[-1] = f"{lines[-1].rstrip()} {comment}"
+            if self._try_fold_inline_comment(node, node_line, prev_line, lines):
                 prev_was_label = False
                 prev_line = node_line
                 continue
 
             should_indent = indent_instructions or (indent_after_label and prev_was_label)
-            node_lines = self._format_ast(node, should_indent, indent_after_label=indent_after_label)
-            # Docstrings that immediately follow a label (`label:` then
-            # `"""..."""`) document the label and stay flush-left with
-            # it, not indented as if they were the first instruction in
-            # a body.
-            if isinstance(node, DocstringAstNode):
-                pass
-            elif should_indent and isinstance(node, self._instruction_like_nodes):
-                node_lines = [
-                    self._indent(line) if line.strip() and not line.startswith(" ") else line for line in node_lines
-                ]
-            lines.extend(node_lines)
+            self._emit_node_lines(node, should_indent, indent_after_label, lines)
             prev_was_label = isinstance(node, LabelAstNode)
-            # For nodes that span multiple source lines (.if / .scope /
-            # .macro / .for / nested compounds), advance prev_line to the
-            # last source line the node consumed so the gap-based blank
-            # heuristic doesn't treat the block's body as a hole.
-            tail_line = self._ast_max_line(node)
-            if tail_line is not None:
-                prev_line = tail_line
-                # Block-like nodes carry a closing brace on the next
-                # source line which has no AST entry; advance over it
-                # so the gap heuristic doesn't treat the brace line as
-                # blank padding between siblings.
-                if isinstance(node, IfAstNode | ForAstNode | MacroAstNode | ScopeAstNode | CompoundAstNode):
-                    prev_line += 1
-            elif node_line is not None:
-                prev_line = node_line
+            prev_line = self._advance_prev_line(node, node_line)
         return lines
 
     def _format_block(self, ast: BlockAstNode, indent_after_label: bool) -> list[str]:
@@ -652,55 +660,71 @@ class A816Formatter:
         visit(node)
         return max_line
 
+    @dataclass
+    class _PreservedBlankState:
+        """Mutable state threaded through `_format_with_preserved_blanks`'s
+        per-node helpers so the loop body itself stays linear.
+        """
+
+        current_idx: int = 0
+        in_label_section: bool = False
+        last_emitted_line_num: int | None = None
+        prev_was_label: bool = False
+
+    def _emit_one_top_level(
+        self,
+        node: AstNode,
+        line_num: int,
+        formatted: list[str],
+        original_lines: list[str],
+        processed: set[int],
+        state: "A816Formatter._PreservedBlankState",
+    ) -> None:
+        state.current_idx = self._emit_preserved_blanks(
+            original_lines, processed, state.current_idx, line_num, formatted
+        )
+        node_line = self._node_line_num(node)
+
+        if isinstance(node, CompoundAstNode):
+            state.in_label_section = False
+            self._emit_compound(node, formatted)
+            state.last_emitted_line_num = None
+            state.prev_was_label = False
+        else:
+            state.in_label_section = self._emit_non_compound(
+                node,
+                node_line,
+                state.last_emitted_line_num,
+                state.in_label_section,
+                formatted,
+                state.prev_was_label,
+            )
+            if node_line is not None:
+                state.last_emitted_line_num = node_line
+            state.prev_was_label = isinstance(node, LabelAstNode)
+
+        processed.add(line_num)
+        # Advance past lines the node already consumed (descendants) so
+        # source blanks WITHIN the body aren't re-emitted at the
+        # boundary. Source blanks AFTER the last child but BEFORE the
+        # next sibling stay reachable.
+        tail = self._ast_max_line(node)
+        if tail is not None and tail >= line_num:
+            for i in range(line_num, tail + 1):
+                processed.add(i)
+            state.current_idx = max(state.current_idx, tail + 1)
+        else:
+            state.current_idx = max(state.current_idx, line_num + 1)
+
     def _format_with_preserved_blanks(self, content: str, nodes: list[AstNode]) -> str:
         """Format AST nodes preserving original blank lines."""
         original_lines = content.splitlines()
         formatted: list[str] = []
         processed: set[int] = set()
-        current_idx = 0
-        in_label_section = False
-        last_emitted_line_num: int | None = None
+        state = A816Formatter._PreservedBlankState()
 
-        positioned = self._node_positions_sorted(nodes)
-        prev_was_label = False
-        for _idx, (line_num, node) in enumerate(positioned):
-            current_idx = self._emit_preserved_blanks(original_lines, processed, current_idx, line_num, formatted)
-            node_line = self._node_line_num(node)
+        for line_num, node in self._node_positions_sorted(nodes):
+            self._emit_one_top_level(node, line_num, formatted, original_lines, processed, state)
 
-            if isinstance(node, CompoundAstNode):
-                in_label_section = False
-                self._emit_compound(node, formatted)
-                last_emitted_line_num = None
-                prev_was_label = False
-            else:
-                in_label_section = self._emit_non_compound(
-                    node, node_line, last_emitted_line_num, in_label_section, formatted, prev_was_label
-                )
-                if node_line is not None:
-                    last_emitted_line_num = node_line
-                prev_was_label = isinstance(node, LabelAstNode)
-
-            processed.add(line_num)
-            # Mark every line the node consumed in source so blanks
-            # inside the node aren't re-emitted at its boundary. Clamp
-            # the tail to the next sibling's start so we don't claim
-            # source blanks that live in the gap between siblings — AST
-            # CompoundAstNode position can land on the closing brace,
-            # which would otherwise swallow trailing blanks.
-            # Advance the cursor past any source lines the node already
-            # consumed (its descendants), so source blanks WITHIN the
-            # body — already handled by the recursive emit — don't get
-            # re-emitted at the boundary. Source blanks AFTER the last
-            # child but BEFORE the next sibling stay reachable, so the
-            # paragraph break the author put between top-level blocks
-            # survives.
-            tail = self._ast_max_line(node)
-            if tail is not None and tail >= line_num:
-                for i in range(line_num, tail + 1):
-                    processed.add(i)
-                current_idx = max(current_idx, tail + 1)
-            else:
-                current_idx = max(current_idx, line_num + 1)
-
-        self._emit_preserved_blanks(original_lines, processed, current_idx, len(original_lines), formatted)
+        self._emit_preserved_blanks(original_lines, processed, state.current_idx, len(original_lines), formatted)
         return self._finalize_formatting(formatted)

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -44,7 +44,7 @@ class FormattingOptions:
         indent_size: int = 4,
         opcode_indent: int | None = None,
         operand_alignment: int = 16,
-        comment_alignment: int = 40,
+        comment_alignment: int = 0,
         preserve_empty_lines: bool = True,
         max_empty_lines: int = 2,
         align_labels: bool = True,
@@ -107,15 +107,54 @@ class A816Formatter:
     def _format_compound(self, ast: CompoundAstNode, indent_instructions: bool, indent_after_label: bool) -> list[str]:
         lines: list[str] = []
         prev_was_label = False
+        prev_line: int | None = None
         for node in ast.body:
+            node_line = self._node_line_num(node)
+
+            # Preserve blank lines from the source by detecting gaps in line
+            # numbers between consecutive AST nodes. Without this the formatter
+            # collapses every paragraph break the author put between logical
+            # chunks of body code.
+            if prev_line is not None and node_line is not None and node_line - prev_line > 1:
+                gap = min(node_line - prev_line - 1, self.options.max_empty_lines)
+                for _ in range(gap):
+                    lines.append("")
+
+            # Fold a comment back onto the previous emitted line when both
+            # came from the same source line (`instr ; comment`). The author's
+            # intent is "trailing comment", not "comment on its own line".
+            if (
+                isinstance(node, CommentAstNode)
+                and node_line is not None
+                and node_line == prev_line
+                and lines
+                and lines[-1].strip()
+                and not lines[-1].lstrip().startswith(";")
+            ):
+                comment = node.comment.strip()
+                if not comment.startswith(";"):
+                    comment = f"; {comment}"
+                lines[-1] = f"{lines[-1].rstrip()} {comment}"
+                prev_was_label = False
+                prev_line = node_line
+                continue
+
             should_indent = indent_instructions or (indent_after_label and prev_was_label)
             node_lines = self._format_ast(node, should_indent, indent_after_label=indent_after_label)
-            if should_indent and isinstance(node, self._instruction_like_nodes):
+            # Docstrings that immediately follow a label (`label:` then
+            # `"""..."""`) document the label and stay flush-left with
+            # it, not indented as if they were the first instruction in
+            # a body.
+            if isinstance(node, DocstringAstNode):
+                pass
+            elif should_indent and isinstance(node, self._instruction_like_nodes):
                 node_lines = [
                     self._indent(line) if line.strip() and not line.startswith(" ") else line for line in node_lines
                 ]
             lines.extend(node_lines)
             prev_was_label = isinstance(node, LabelAstNode)
+            if node_line is not None:
+                prev_line = node_line
         return lines
 
     def _format_block(self, ast: BlockAstNode, indent_after_label: bool) -> list[str]:
@@ -339,11 +378,22 @@ class A816Formatter:
         return f"{indent}{line.lstrip()}"
 
     def _indent_block_lines(self, lines: list[str], levels: int = 1) -> list[str]:
-        """Indent a sequence of lines representing a block"""
+        """Indent a sequence of lines representing a block.
+
+        Inner labels (lines ending in `:` that aren't directives) stay
+        flush-left so they read as section markers inside the routine —
+        the same convention `_loop:` / `_not_found:` follow in idiomatic
+        a816 code. Comments and instructions get the requested indent.
+        """
         indented: list[str] = []
         for line in lines:
-            if not line.strip():
+            stripped = line.strip()
+            if not stripped:
                 indented.append("")
+                continue
+            is_label = stripped.endswith(":") and not stripped.startswith(":") and not stripped.startswith(".")
+            if is_label:
+                indented.append(stripped)
             else:
                 indented.append(self._indent(line, levels))
         return indented
@@ -365,16 +415,23 @@ class A816Formatter:
 
     @staticmethod
     def _separate_labels(lines: list[str]) -> list[str]:
+        """Insert a blank line before top-level labels.
+
+        Top-level labels mark function entries / scope boundaries and
+        benefit from breathing room. Indented (inner-block) labels are
+        section markers inside a routine and the author tends to pack
+        them tightly with surrounding code; do not force blanks there.
+        """
         adjusted: list[str] = []
         for line in lines:
-            if (
-                line.strip().endswith(":")
-                and not line.startswith(":")
-                and not line.startswith(".")
-                and adjusted
-                and adjusted[-1].strip()
-            ):
+            stripped = line.strip()
+            is_label = stripped.endswith(":") and not stripped.startswith(":") and not stripped.startswith(".")
+            is_top_level = is_label and not line[: len(line) - len(line.lstrip())]
+            if is_top_level and adjusted and adjusted[-1].strip():
                 adjusted.append("")
+            elif is_top_level and len(adjusted) >= 2 and not adjusted[-1].strip() and adjusted[-2].strip():
+                # Already has exactly one blank line in front — leave it.
+                pass
             adjusted.append(line)
         return adjusted
 
@@ -396,16 +453,29 @@ class A816Formatter:
         return groups
 
     def _align_inline_comments(self, lines: list[str]) -> None:
+        """Normalize inline comments without forcing column alignment.
+
+        The default policy emits `code  ; comment` with two spaces — a
+        light convention that matches the project's casual style. Set
+        `comment_alignment > 0` to force a target column for groups of
+        same-indent comments.
+        """
         groups = self._collect_inline_comment_groups(lines)
+        force_column = self.options.comment_alignment
         for indent, entries in groups.items():
             if not entries:
                 continue
-            max_code_len = max(len(code_part) for _, code_part, _ in entries)
-            target_column = max(indent + max_code_len + 1, self.options.comment_alignment)
+            target_column: int | None = None
+            if force_column > 0:
+                max_code_len = max(len(code_part) for _, code_part, _ in entries)
+                target_column = max(indent + max_code_len + 1, force_column)
             for index, code_part, comment_part in entries:
-                padding = max(target_column - (indent + len(code_part)), 1)
                 comment_text = f"; {comment_part}" if comment_part else ";"
-                lines[index] = f"{' ' * indent}{code_part}{' ' * padding}{comment_text}"
+                if target_column is None:
+                    lines[index] = f"{' ' * indent}{code_part}  {comment_text}"
+                else:
+                    padding = max(target_column - (indent + len(code_part)), 1)
+                    lines[index] = f"{' ' * indent}{code_part}{' ' * padding}{comment_text}"
 
     def _finalize_formatting(self, lines: list[str]) -> str:
         """Strip trailing whitespace, collapse blanks, separate labels, align inline comments."""
@@ -459,9 +529,16 @@ class A816Formatter:
             and formatted
             and formatted[-1].strip()
         )
+        # A comment separated from the previous emitted line by a blank
+        # line is acting as a leading comment for whatever follows
+        # (typically the next label / function), not as the body of the
+        # current label section. Don't indent it as body code.
+        separated_by_blank = (
+            last_emitted_line_num is not None and node_line is not None and node_line - last_emitted_line_num > 1
+        )
         if on_same_line_as_prev:
             formatted[-1] = formatted[-1].rstrip() + " " + comment_text.strip()
-        elif in_label_section and comment_text.strip():
+        elif in_label_section and comment_text.strip() and not separated_by_blank:
             formatted.append(self._indent(comment_text))
         else:
             formatted.extend(node_lines)
@@ -474,6 +551,11 @@ class A816Formatter:
                 formatted.append("")
             formatted.extend(line.lstrip() for line in node_lines)
             return True
+        # Top-level docstrings document the preceding label and stay
+        # flush-left so the eye groups label + docstring as a header.
+        if isinstance(node, DocstringAstNode):
+            formatted.extend(node_lines)
+            return in_label_section
         if in_label_section:
             node_lines = [
                 self._indent(line) if line.strip() and not line.startswith(" ") else line for line in node_lines
@@ -509,6 +591,34 @@ class A816Formatter:
         formatted.extend(node_lines)
         return False
 
+    @staticmethod
+    def _ast_max_line(node: AstNode) -> int | None:
+        """Walk a subtree and return the largest source line number found,
+        or None if no descendant carries position info. Used to advance the
+        blank-line cursor past a compound block so that source blanks
+        inside the block aren't re-emitted at its closing brace.
+        """
+        max_line: int | None = None
+
+        def visit(n: AstNode) -> None:
+            nonlocal max_line
+            line = A816Formatter._node_line_num(n)
+            if line is not None and (max_line is None or line > max_line):
+                max_line = line
+            for attr in ("body", "nodes", "items", "children"):
+                child = getattr(n, attr, None)
+                if child is None:
+                    continue
+                if isinstance(child, list):
+                    for c in child:
+                        if isinstance(c, AstNode):
+                            visit(c)
+                elif isinstance(child, AstNode):
+                    visit(child)
+
+        visit(node)
+        return max_line
+
     def _format_with_preserved_blanks(self, content: str, nodes: list[AstNode]) -> str:
         """Format AST nodes preserving original blank lines."""
         original_lines = content.splitlines()
@@ -534,7 +644,15 @@ class A816Formatter:
                     last_emitted_line_num = node_line
 
             processed.add(line_num)
-            current_idx = max(current_idx, line_num + 1)
+            # Mark every line the node consumed in source so blanks
+            # inside the node aren't re-emitted at its boundary.
+            tail = self._ast_max_line(node)
+            if tail is not None:
+                for i in range(line_num, tail + 1):
+                    processed.add(i)
+                current_idx = max(current_idx, tail + 1)
+            else:
+                current_idx = max(current_idx, line_num + 1)
 
         self._emit_preserved_blanks(original_lines, processed, current_idx, len(original_lines), formatted)
         return self._finalize_formatting(formatted)

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -783,6 +784,75 @@ class WorkspaceIndex:
             store.pop(uri, None)
 
 
+@dataclass
+class _MaskState:
+    """Cross-line scanner state for `_build_code_mask`. Only the
+    triple-quoted-string flag survives a newline; single-quoted strings
+    don't span lines in a816 syntax.
+    """
+
+    in_triple: str | None = None
+
+
+def _consume_triple(raw: str, i: int, mask: list[bool], state: _MaskState) -> int:
+    """Mask one byte of a triple-quoted string, closing it on the
+    matching delimiter. Returns the new cursor position.
+    """
+    mask[i] = False
+    if state.in_triple is not None and raw[i : i + 3] == state.in_triple:
+        mask[i + 1] = False
+        mask[i + 2] = False
+        state.in_triple = None
+        return i + 3
+    return i + 1
+
+
+def _consume_string(raw: str, i: int, mask: list[bool], in_string: str) -> tuple[int, str | None]:
+    """Mask one byte of a single-line string, handling backslash escapes
+    and the closing delimiter. Returns (new cursor, new state).
+    """
+    mask[i] = False
+    if raw[i] == "\\" and i + 1 < len(raw):
+        mask[i + 1] = False
+        return i + 2, in_string
+    if raw[i] == in_string:
+        return i + 1, None
+    return i + 1, in_string
+
+
+def _mask_line(raw: str, state: _MaskState) -> list[bool]:
+    """Build the code-mask for a single line, advancing `state` for
+    triple-quoted strings that may span multiple lines.
+    """
+    mask = [True] * len(raw)
+    i = 0
+    in_string: str | None = None
+    while i < len(raw):
+        if state.in_triple is not None:
+            i = _consume_triple(raw, i, mask, state)
+            continue
+        if in_string is not None:
+            i, in_string = _consume_string(raw, i, mask, in_string)
+            continue
+        ch = raw[i]
+        if ch == ";":
+            for j in range(i, len(raw)):
+                mask[j] = False
+            break
+        if raw[i : i + 3] in ('"""', "'''"):
+            state.in_triple = raw[i : i + 3]
+            mask[i] = mask[i + 1] = mask[i + 2] = False
+            i += 3
+            continue
+        if ch in ('"', "'"):
+            in_string = ch
+            mask[i] = False
+            i += 1
+            continue
+        i += 1
+    return mask
+
+
 class A816LanguageServer:
     """Enhanced LSP server for a816 assembly language"""
 
@@ -1239,49 +1309,9 @@ class A816LanguageServer:
         accidental matches in text payloads.
         """
         masks: list[list[bool]] = []
-        in_triple: str | None = None
+        state = _MaskState()
         for raw in lines:
-            mask = [True] * len(raw)
-            i = 0
-            in_string: str | None = None
-            while i < len(raw):
-                ch = raw[i]
-                if in_triple is not None:
-                    mask[i] = False
-                    if raw[i : i + 3] == in_triple:
-                        mask[i + 1] = False
-                        mask[i + 2] = False
-                        i += 3
-                        in_triple = None
-                        continue
-                    i += 1
-                    continue
-                if in_string is not None:
-                    mask[i] = False
-                    if ch == "\\" and i + 1 < len(raw):
-                        mask[i + 1] = False
-                        i += 2
-                        continue
-                    if ch == in_string:
-                        in_string = None
-                    i += 1
-                    continue
-                if ch == ";":
-                    for j in range(i, len(raw)):
-                        mask[j] = False
-                    break
-                if raw[i : i + 3] in ('"""', "'''"):
-                    in_triple = raw[i : i + 3]
-                    mask[i] = mask[i + 1] = mask[i + 2] = False
-                    i += 3
-                    continue
-                if ch in ('"', "'"):
-                    in_string = ch
-                    mask[i] = False
-                    i += 1
-                    continue
-                i += 1
-            masks.append(mask)
+            masks.append(_mask_line(raw, state))
         return masks
 
     @staticmethod
@@ -1364,7 +1394,7 @@ class A816LanguageServer:
             ]
         return references or None
 
-    _RENAME_SYMBOL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    _RENAME_SYMBOL_PATTERN = re.compile(r"^[A-Za-z_]\w*$")
 
     def _handle_prepare_rename(self, params: PrepareRenameParams) -> Range | None:
         """Tell the editor which range it can rename in place.

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -32,8 +32,10 @@ from lsprotocol.types import (
     MarkupKind,
     MessageType,
     Position,
+    PrepareRenameParams,
     Range,
     ReferenceParams,
+    RenameParams,
     SemanticTokens,
     SemanticTokensLegend,
     SemanticTokensParams,
@@ -46,6 +48,7 @@ from lsprotocol.types import (
     TextDocumentContentChangeEvent_Type2,
     TextDocumentPositionParams,
     TextEdit,
+    WorkspaceEdit,
     WorkspaceSymbolParams,
 )
 from lsprotocol.types import (
@@ -842,6 +845,14 @@ class A816LanguageServer:
         async def find_references(ls: LanguageServer, params: ReferenceParams) -> list[Location] | None:
             return self._handle_references(params)
 
+        @self.server.feature("textDocument/prepareRename")
+        async def prepare_rename(ls: LanguageServer, params: PrepareRenameParams) -> Range | None:
+            return self._handle_prepare_rename(params)
+
+        @self.server.feature("textDocument/rename")
+        async def rename_symbol(ls: LanguageServer, params: RenameParams) -> WorkspaceEdit | None:
+            return self._handle_rename(params)
+
         @self.server.feature("textDocument/signatureHelp")
         async def signature_help(ls: LanguageServer, params: SignatureHelpParams) -> SignatureHelp | None:
             return self._handle_signature_help(params)
@@ -1217,13 +1228,75 @@ class A816LanguageServer:
         return results[:100]
 
     @staticmethod
+    def _build_code_mask(lines: list[str]) -> list[list[bool]]:
+        """Per-line per-char mask: True where the char is real source code,
+        False inside a comment or string literal. Tracks triple-quoted
+        strings across lines.
+
+        Lexer is intentionally tiny — a full a816 parse is too expensive
+        per rename / reference query and the document already holds the
+        AST for diagnostics. This mask exists so reference search skips
+        accidental matches in text payloads.
+        """
+        masks: list[list[bool]] = []
+        in_triple: str | None = None
+        for raw in lines:
+            mask = [True] * len(raw)
+            i = 0
+            in_string: str | None = None
+            while i < len(raw):
+                ch = raw[i]
+                if in_triple is not None:
+                    mask[i] = False
+                    if raw[i : i + 3] == in_triple:
+                        mask[i + 1] = False
+                        mask[i + 2] = False
+                        i += 3
+                        in_triple = None
+                        continue
+                    i += 1
+                    continue
+                if in_string is not None:
+                    mask[i] = False
+                    if ch == "\\" and i + 1 < len(raw):
+                        mask[i + 1] = False
+                        i += 2
+                        continue
+                    if ch == in_string:
+                        in_string = None
+                    i += 1
+                    continue
+                if ch == ";":
+                    for j in range(i, len(raw)):
+                        mask[j] = False
+                    break
+                if raw[i : i + 3] in ('"""', "'''"):
+                    in_triple = raw[i : i + 3]
+                    mask[i] = mask[i + 1] = mask[i + 2] = False
+                    i += 3
+                    continue
+                if ch in ('"', "'"):
+                    in_string = ch
+                    mask[i] = False
+                    i += 1
+                    continue
+                i += 1
+            masks.append(mask)
+        return masks
+
+    @staticmethod
     def _refs_in_document(
         document: A816Document, uri: str, pattern: re.Pattern[str], seen: set[tuple[str, int, int]]
     ) -> list[Location]:
         out: list[Location] = []
+        masks = A816LanguageServer._build_code_mask(document.lines)
         for i, doc_line in enumerate(document.lines):
+            mask = masks[i]
             for match in pattern.finditer(doc_line):
-                key = (uri, i, match.start())
+                start, end = match.start(), match.end()
+                if any(not mask[j] for j in range(start, end)):
+                    continue
+                key = (uri, i, start)
                 if key in seen:
                     continue
                 seen.add(key)
@@ -1231,8 +1304,8 @@ class A816LanguageServer:
                     Location(
                         uri=uri,
                         range=Range(
-                            start=Position(line=i, character=match.start()),
-                            end=Position(line=i, character=match.end()),
+                            start=Position(line=i, character=start),
+                            end=Position(line=i, character=end),
                         ),
                     )
                 )
@@ -1290,6 +1363,86 @@ class A816LanguageServer:
                 loc for loc in references if (loc.uri, loc.range.start.line, loc.range.start.character) not in defs
             ]
         return references or None
+
+    _RENAME_SYMBOL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    def _handle_prepare_rename(self, params: PrepareRenameParams) -> Range | None:
+        """Tell the editor which range it can rename in place.
+
+        Returns the word range under the cursor when it parses as a
+        symbol identifier; `None` otherwise (rejects rename on
+        instructions, numbers, registers).
+        """
+        doc = self.documents.get(params.text_document.uri)
+        if not doc:
+            return None
+        line_num = params.position.line
+        if line_num >= len(doc.lines):
+            return None
+        line = doc.lines[line_num]
+        word_start, word_end = self._word_span(line, params.position.character)
+        if word_start >= word_end:
+            return None
+        word = line[word_start:word_end]
+        if not self._RENAME_SYMBOL_PATTERN.match(word):
+            return None
+        # Reject opcodes / registers / directives — those are language
+        # built-ins, not user symbols.
+        lowered = word.lower()
+        if lowered in snes_opcode_table:
+            return None
+        if lowered in {"a", "x", "y", "s", "p", "pc"}:
+            return None
+        if lowered in {"byte", "word", "long", "dword"}:
+            return None
+        return Range(
+            start=Position(line=line_num, character=word_start),
+            end=Position(line=line_num, character=word_end),
+        )
+
+    def _handle_rename(self, params: RenameParams) -> WorkspaceEdit | None:
+        """Rename every reference to the symbol under the cursor across
+        the workspace. Returns a WorkspaceEdit grouping per-file
+        TextEdits. Editor applies atomically.
+        """
+        new_name = params.new_name
+        if not self._RENAME_SYMBOL_PATTERN.match(new_name):
+            return None
+
+        doc = self.documents.get(params.text_document.uri)
+        if not doc:
+            return None
+        line_num = params.position.line
+        if line_num >= len(doc.lines):
+            return None
+        line = doc.lines[line_num]
+        word_start, word_end = self._word_span(line, params.position.character)
+        if word_start >= word_end:
+            return None
+        old_name = line[word_start:word_end]
+        if not self._RENAME_SYMBOL_PATTERN.match(old_name):
+            return None
+        if old_name == new_name:
+            return WorkspaceEdit(changes={})
+
+        pattern = re.compile(r"\b" + re.escape(old_name) + r"\b")
+        seen: set[tuple[str, int, int]] = set()
+        references = self._refs_in_document(doc, params.text_document.uri, pattern, seen)
+        workspace = self._ensure_workspace_index()
+        if workspace:
+            for uri, ws_doc in workspace.documents.items():
+                if uri == params.text_document.uri:
+                    continue
+                references.extend(self._refs_in_document(ws_doc, uri, pattern, seen))
+
+        changes: dict[str, list[TextEdit]] = {}
+        for loc in references:
+            edit = TextEdit(range=loc.range, new_text=new_name)
+            changes.setdefault(loc.uri, []).append(edit)
+
+        if not changes:
+            return None
+        return WorkspaceEdit(changes=changes)
 
     @staticmethod
     def _addressing_mode_label(mode: AddressingMode) -> str:

--- a/a816/program.py
+++ b/a816/program.py
@@ -23,6 +23,8 @@ from a816.writers import IPSWriter, ObjectWriter, SFCWriter, Writer
 
 logger = logging.getLogger("a816")
 
+_UNKNOWN_SRC = "<unknown>"
+
 
 @dataclass
 class _EmitState:
@@ -199,7 +201,7 @@ class Program:
     def _emit_trace_enabled() -> bool:
         return os.environ.get("A816_EMIT_TRACE") == "1"
 
-    def _trace_block(self, snes: int, phys: int, size: int, src: str = "<unknown>") -> None:
+    def _trace_block(self, snes: int, phys: int, size: int, src: str = _UNKNOWN_SRC) -> None:
         if self._emit_trace_enabled():
             self._emit_trace.append((snes, phys, size, src))
 
@@ -226,9 +228,9 @@ class Program:
             size = len(region.code)
             if region.lines:
                 _, file_idx, line, *_rest = region.lines[0]
-                src = f"{files[file_idx]}:{line}" if 0 <= file_idx < len(files) else "<unknown>"
+                src = f"{files[file_idx]}:{line}" if 0 <= file_idx < len(files) else _UNKNOWN_SRC
             else:
-                src = "<unknown>"
+                src = _UNKNOWN_SRC
             self._emit_trace.append((snes, phys, size, src))
 
     def emit(self, program: list[NodeProtocol], writer: Writer) -> None:

--- a/a816/program.py
+++ b/a816/program.py
@@ -367,9 +367,7 @@ class Program:
             self.resolver.pc = original_pc
             self.resolver.reloc_address = original_reloc
 
-    def _object_emit_one(
-        self, node: NodeProtocol, object_writer: ObjectWriter, state: "_ObjectEmitState"
-    ) -> None:
+    def _object_emit_one(self, node: NodeProtocol, object_writer: ObjectWriter, state: "_ObjectEmitState") -> None:
         """Emit one node into the current object-writer region.
 
         Splits the dispatch the way `emit()` does so each branch — the
@@ -394,9 +392,7 @@ class Program:
         self.resolver.pc += len(node_bytes)
         self.resolver.reloc_address += len(node_bytes)
 
-    def _object_open_region(
-        self, object_writer: ObjectWriter, state: "_ObjectEmitState", *, explicit: bool
-    ) -> None:
+    def _object_open_region(self, object_writer: ObjectWriter, state: "_ObjectEmitState", *, explicit: bool) -> None:
         """Flush any pending block then open a fresh region at the new PC."""
         self._flush_object_block(object_writer, state)
         object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=explicit)

--- a/a816/program.py
+++ b/a816/program.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,7 @@ class _EmitState:
 
     current_block: bytes
     current_block_addr: int
+    current_block_logical: int = 0
 
 
 @dataclass
@@ -70,6 +72,8 @@ class Program:
         self._debug_lines: list[tuple[int, str, int, int]] = []
         self._linked_modules: list[Any] = []  # list[LinkedModuleNode]; typed loosely to avoid cycle
         self._program_nodes: list[NodeProtocol] = []
+        # (snes_logical, physical, size, src) appended when A816_EMIT_TRACE=1.
+        self._emit_trace: list[tuple[int, int, int, str]] = []
 
     def add_module_path(self, path: str | Path) -> None:
         """Add a directory to the module search path for .import directives.
@@ -191,6 +195,42 @@ class Program:
             return logical_address
         return physical
 
+    @staticmethod
+    def _emit_trace_enabled() -> bool:
+        return os.environ.get("A816_EMIT_TRACE") == "1"
+
+    def _trace_block(self, snes: int, phys: int, size: int, src: str = "<unknown>") -> None:
+        if self._emit_trace_enabled():
+            self._emit_trace.append((snes, phys, size, src))
+
+    def _flush_emit_trace(self, output_path: Path) -> None:
+        """Write any accumulated emit-trace records next to output_path."""
+        if not self._emit_trace_enabled():
+            return
+        log_path = output_path.with_suffix(output_path.suffix + ".emit.log")
+        with open(log_path, "w", encoding="utf-8") as logf:
+            for snes, phys, size, src in self._emit_trace:
+                logf.write(f"snes=${snes & 0xFFFFFF:06X}  phys=0x{phys & 0xFFFFFF:06X}  size={size}  src={src}\n")
+        self._emit_trace = []
+
+    def _trace_linked_regions(self, linked_obj: ObjectFile) -> None:
+        """Replay a linked ObjectFile's regions into the trace buffer."""
+        if not self._emit_trace_enabled():
+            return
+        files = getattr(linked_obj, "files", []) or []
+        for region in linked_obj.regions:
+            if not region.code:
+                continue
+            snes = region.base_address
+            phys = self._to_physical(snes)
+            size = len(region.code)
+            if region.lines:
+                _, file_idx, line, *_rest = region.lines[0]
+                src = f"{files[file_idx]}:{line}" if 0 <= file_idx < len(files) else "<unknown>"
+            else:
+                src = "<unknown>"
+            self._emit_trace.append((snes, phys, size, src))
+
     def emit(self, program: list[NodeProtocol], writer: Writer) -> None:
         """Emit machine code from resolved nodes to a writer.
 
@@ -202,7 +242,11 @@ class Program:
             program: List of resolved executable nodes.
             writer: Output writer (IPSWriter, SFCWriter, etc.).
         """
-        state = _EmitState(current_block=b"", current_block_addr=self.resolver.pc)
+        state = _EmitState(
+            current_block=b"",
+            current_block_addr=self.resolver.pc,
+            current_block_logical=self.resolver.reloc_address.logical_value,
+        )
         for node in program:
             self._emit_one(node, writer, state)
         self._flush_pending(writer, state)
@@ -240,6 +284,7 @@ class Program:
             self.resolver.pc += advance
             self.resolver.reloc_address += advance
         state.current_block_addr = self.resolver.pc
+        state.current_block_logical = self.resolver.reloc_address.logical_value
 
     def _emit_default(self, node: NodeProtocol, writer: Writer, state: _EmitState) -> None:
         """Emit a non-LinkedModule node and accumulate its bytes."""
@@ -257,6 +302,7 @@ class Program:
         """Flush at a `*=` boundary and re-anchor for subsequent bytes."""
         self._flush_pending(writer, state)
         state.current_block_addr = self.resolver.pc
+        state.current_block_logical = self.resolver.reloc_address.logical_value
 
     @staticmethod
     def _emit_ips_blocks(node: IncludeIpsNode, writer: Writer) -> None:
@@ -264,11 +310,15 @@ class Program:
         for block_addr, block in node.blocks:
             writer.write_block(block, block_addr)
 
-    @staticmethod
-    def _flush_pending(writer: Writer, state: _EmitState) -> None:
+    def _flush_pending(self, writer: Writer, state: _EmitState) -> None:
         """Write the accumulated current_block at its anchor and reset."""
         if state.current_block:
             writer.write_block(state.current_block, state.current_block_addr)
+            self._trace_block(
+                state.current_block_logical,
+                state.current_block_addr,
+                len(state.current_block),
+            )
             state.current_block = b""
 
     def _record_object_line(self, node: NodeProtocol, offset: int, object_writer: ObjectWriter) -> None:
@@ -424,7 +474,9 @@ class Program:
         """
         with open(sfc_file, "wb") as f:
             sfc_emitter = SFCWriter(f)
-            return self.assemble_with_emitter(asm_file, sfc_emitter, prelude=prelude)
+            exit_code = self.assemble_with_emitter(asm_file, sfc_emitter, prelude=prelude)
+        self._flush_emit_trace(sfc_file)
+        return exit_code
 
     def assemble_as_object(self, asm_file: str, output_file: Path, prelude: str | None = None) -> int:
         """
@@ -533,7 +585,8 @@ class Program:
             ips_emitter.begin()
             exit_code = self.assemble_with_emitter(asm_file, ips_emitter, prelude=prelude)
             ips_emitter.end()
-            return exit_code
+        self._flush_emit_trace(ips_file)
+        return exit_code
 
     def enable_debug_capture(self) -> None:
         """Turn on per-node line capture for `.adbg` emission."""
@@ -704,6 +757,8 @@ class Program:
                         ips_emitter.write_block(region.code, self._to_physical(region.base_address))
 
                 ips_emitter.end()
+                self._trace_linked_regions(linked_obj)
+                self._flush_emit_trace(ips_file)
                 self.write_debug_info_for_linked(linked_obj, ips_file)
                 self.logger.info("Successfully created IPS patch")
                 return 0
@@ -733,6 +788,8 @@ class Program:
                         sfc_emitter.write_block(region.code, self._to_physical(region.base_address))
 
                 sfc_emitter.end()
+                self._trace_linked_regions(linked_obj)
+                self._flush_emit_trace(sfc_file)
                 self.write_debug_info_for_linked(linked_obj, sfc_file)
                 self.logger.info("Successfully created SFC file")
                 return 0

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -11,10 +11,11 @@ import logging
 import shutil
 import sys
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 from a816.cpu.cpu_65c816 import RomType
-from a816.cpu.disassembler import Disassembler, format_disassembly, format_disassembly_block
+from a816.cpu.disassembler import Disassembler, disassemble_function, format_disassembly, format_disassembly_block
 from a816.cpu.mapping import Bus
 from a816.symbols import high_rom_bus, low_rom_bus
 
@@ -302,8 +303,18 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--sym",
         metavar="NAME",
-        help="Start disassembly at the address of symbol NAME from the .adbg"
-        " file (requires --debug).",
+        help="Start disassembly at the address of symbol NAME from the .adbg file (requires --debug).",
+    )
+    parser.add_argument(
+        "--func",
+        metavar="NAME",
+        help="CFG-walk a function: stop at rts/rtl/rti/jmp/bra, follow"
+        " conditional branches, track M/X across sep/rep. Requires --debug.",
+    )
+    parser.add_argument(
+        "--follow-calls",
+        action="store_true",
+        help="With --func, also recurse into jsr / jsl targets.",
     )
 
     return parser
@@ -333,6 +344,29 @@ def disassemble(
     else:
         for inst in instructions:
             print(format_disassembly(inst, show_bytes=show_bytes, a816_syntax=False))
+
+
+def make_rom_data_provider(rom_bytes: bytes, bus: Bus) -> Callable[[int, int], bytes]:
+    """Return a callable `(logical_addr, length) -> bytes` backed by `rom_bytes`.
+
+    Returns an empty bytes object when the address has no physical mapping
+    or falls outside the ROM image, so the function walker stops cleanly
+    instead of decoding garbage.
+    """
+
+    def provide(logical_addr: int, length: int) -> bytes:
+        try:
+            physical = bus.get_address(logical_addr).physical
+        except KeyError:
+            return b""
+        if physical is None:
+            return b""
+        if physical >= len(rom_bytes):
+            return b""
+        end = min(physical + length, len(rom_bytes))
+        return rom_bytes[physical:end]
+
+    return provide
 
 
 def load_debug_symbols(adbg_path: Path) -> tuple[dict[int, str], dict[str, int]]:
@@ -423,6 +457,17 @@ def xdds_main() -> None:
         args.start = f"${sym_logical >> 16:02X}:{sym_logical & 0xFFFF:04X}"
         logger.info(f"Symbol {args.sym} -> {args.start}")
 
+    if args.func:
+        if not name_to_addr:
+            logger.error("--func requires --debug pointing at a .adbg file")
+            sys.exit(-1)
+        if args.func not in name_to_addr:
+            logger.error(f"Symbol not found in debug info: {args.func}")
+            sys.exit(-1)
+        if not args.disasm:
+            logger.error("--func requires -d / --disasm")
+            sys.exit(-1)
+
     input_file = args.input_file
     tmp_path: Path | None = None
     if args.ips_file:
@@ -436,7 +481,28 @@ def xdds_main() -> None:
         physical_start = _resolve_physical_start(args, bus)
         data = _read_slice(input_file, physical_start, args.length)
 
-        if args.disasm:
+        if args.disasm and args.func:
+            entry = name_to_addr[args.func]
+            with open(input_file, "rb") as f:
+                rom_bytes = f.read()
+            provider = make_rom_data_provider(rom_bytes, bus)
+            instructions = disassemble_function(
+                entry,
+                provider,
+                m_flag=args.m_flag,
+                x_flag=args.x_flag,
+                follow_calls=args.follow_calls,
+            )
+            symbol_map = addr_to_name or None
+            if args.asm:
+                for line in format_disassembly_block(
+                    instructions, show_bytes=not args.no_bytes, a816_syntax=True, symbol_map=symbol_map
+                ):
+                    print(line)
+            else:
+                for inst in instructions:
+                    print(format_disassembly(inst, show_bytes=not args.no_bytes, a816_syntax=False))
+        elif args.disasm:
             disassemble(
                 data,
                 bus,

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -430,6 +430,48 @@ def _resolve_bus(args: argparse.Namespace) -> tuple[RomType, Bus]:
     return rom_type, bus
 
 
+def _load_symbols_or_exit(debug_path: Path | None) -> tuple[dict[int, str], dict[str, int]]:
+    if debug_path is None:
+        return {}, {}
+    if not debug_path.exists():
+        logger.error(f"Debug file not found: {debug_path}")
+        sys.exit(-1)
+    return load_debug_symbols(debug_path)
+
+
+def _require_symbol(name: str | None, name_to_addr: dict[str, int], flag: str) -> int | None:
+    if name is None:
+        return None
+    if not name_to_addr:
+        logger.error(f"{flag} requires --debug pointing at a .adbg file")
+        sys.exit(-1)
+    if name not in name_to_addr:
+        logger.error(f"Symbol not found in debug info: {name}")
+        sys.exit(-1)
+    return name_to_addr[name]
+
+
+def _emit_function(args: argparse.Namespace, input_file: Path, bus: Bus, entry: int, symbol_map: dict[int, str] | None) -> None:
+    with open(input_file, "rb") as f:
+        rom_bytes = f.read()
+    provider = make_rom_data_provider(rom_bytes, bus)
+    instructions = disassemble_function(
+        entry,
+        provider,
+        m_flag=args.m_flag,
+        x_flag=args.x_flag,
+        follow_calls=args.follow_calls,
+    )
+    if args.asm:
+        for line in format_disassembly_block(
+            instructions, show_bytes=not args.no_bytes, a816_syntax=True, symbol_map=symbol_map
+        ):
+            print(line)
+    else:
+        for inst in instructions:
+            print(format_disassembly(inst, show_bytes=not args.no_bytes, a816_syntax=False))
+
+
 def xdds_main() -> None:
     args = create_parser().parse_args()
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(levelname)s - %(message)s")
@@ -438,35 +480,17 @@ def xdds_main() -> None:
     if args.show_mappings:
         show_mapping_info(rom_type)
 
-    addr_to_name: dict[int, str] = {}
-    name_to_addr: dict[str, int] = {}
-    if args.debug:
-        if not args.debug.exists():
-            logger.error(f"Debug file not found: {args.debug}")
-            sys.exit(-1)
-        addr_to_name, name_to_addr = load_debug_symbols(args.debug)
+    addr_to_name, name_to_addr = _load_symbols_or_exit(args.debug)
 
-    if args.sym:
-        if not name_to_addr:
-            logger.error("--sym requires --debug pointing at a .adbg file")
-            sys.exit(-1)
-        if args.sym not in name_to_addr:
-            logger.error(f"Symbol not found in debug info: {args.sym}")
-            sys.exit(-1)
-        sym_logical = name_to_addr[args.sym]
-        args.start = f"${sym_logical >> 16:02X}:{sym_logical & 0xFFFF:04X}"
+    sym_addr = _require_symbol(args.sym, name_to_addr, "--sym")
+    if sym_addr is not None:
+        args.start = f"${sym_addr >> 16:02X}:{sym_addr & 0xFFFF:04X}"
         logger.info(f"Symbol {args.sym} -> {args.start}")
 
-    if args.func:
-        if not name_to_addr:
-            logger.error("--func requires --debug pointing at a .adbg file")
-            sys.exit(-1)
-        if args.func not in name_to_addr:
-            logger.error(f"Symbol not found in debug info: {args.func}")
-            sys.exit(-1)
-        if not args.disasm:
-            logger.error("--func requires -d / --disasm")
-            sys.exit(-1)
+    func_addr = _require_symbol(args.func, name_to_addr, "--func")
+    if func_addr is not None and not args.disasm:
+        logger.error("--func requires -d / --disasm")
+        sys.exit(-1)
 
     input_file = args.input_file
     tmp_path: Path | None = None
@@ -480,28 +504,10 @@ def xdds_main() -> None:
 
         physical_start = _resolve_physical_start(args, bus)
         data = _read_slice(input_file, physical_start, args.length)
+        symbol_map = addr_to_name or None
 
-        if args.disasm and args.func:
-            entry = name_to_addr[args.func]
-            with open(input_file, "rb") as f:
-                rom_bytes = f.read()
-            provider = make_rom_data_provider(rom_bytes, bus)
-            instructions = disassemble_function(
-                entry,
-                provider,
-                m_flag=args.m_flag,
-                x_flag=args.x_flag,
-                follow_calls=args.follow_calls,
-            )
-            symbol_map = addr_to_name or None
-            if args.asm:
-                for line in format_disassembly_block(
-                    instructions, show_bytes=not args.no_bytes, a816_syntax=True, symbol_map=symbol_map
-                ):
-                    print(line)
-            else:
-                for inst in instructions:
-                    print(format_disassembly(inst, show_bytes=not args.no_bytes, a816_syntax=False))
+        if func_addr is not None:
+            _emit_function(args, input_file, bus, func_addr, symbol_map)
         elif args.disasm:
             disassemble(
                 data,
@@ -512,7 +518,7 @@ def xdds_main() -> None:
                 count=args.count,
                 show_bytes=not args.no_bytes,
                 a816_syntax=args.asm,
-                symbol_map=addr_to_name or None,
+                symbol_map=symbol_map,
             )
         else:
             hexdump(data, bus, physical_start, args.cols, not args.no_ascii)

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -14,7 +14,7 @@ import tempfile
 from pathlib import Path
 
 from a816.cpu.cpu_65c816 import RomType
-from a816.cpu.disassembler import Disassembler, format_disassembly
+from a816.cpu.disassembler import Disassembler, format_disassembly, format_disassembly_block
 from a816.cpu.mapping import Bus
 from a816.symbols import high_rom_bus, low_rom_bus
 
@@ -311,8 +311,12 @@ def disassemble(
     disasm = Disassembler(m_flag=m_flag, x_flag=x_flag)
     instructions = disasm.disassemble(data, start_logical, count)
 
-    for inst in instructions:
-        print(format_disassembly(inst, show_bytes=show_bytes, a816_syntax=a816_syntax))
+    if a816_syntax:
+        for line in format_disassembly_block(instructions, show_bytes=show_bytes, a816_syntax=True):
+            print(line)
+    else:
+        for inst in instructions:
+            print(format_disassembly(inst, show_bytes=show_bytes, a816_syntax=False))
 
 
 def _apply_ips_to_temp(input_file: Path, ips_file: Path) -> tuple[Path, Path]:

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -292,6 +292,19 @@ def create_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Output a816-compatible assembly syntax (use with -d)",
     )
+    parser.add_argument(
+        "--debug",
+        type=Path,
+        metavar="ADBG",
+        help="Path to a .adbg debug-info file. When supplied, branch and jump"
+        " targets resolve to symbol names instead of synthesized _BBHHHH labels.",
+    )
+    parser.add_argument(
+        "--sym",
+        metavar="NAME",
+        help="Start disassembly at the address of symbol NAME from the .adbg"
+        " file (requires --debug).",
+    )
 
     return parser
 
@@ -305,6 +318,7 @@ def disassemble(
     count: int | None = None,
     show_bytes: bool = True,
     a816_syntax: bool = False,
+    symbol_map: dict[int, str] | None = None,
 ) -> None:
     """Disassemble and print 65c816 code with SNES logical addresses."""
     start_logical = physical_to_logical(bus, start_offset)
@@ -312,11 +326,31 @@ def disassemble(
     instructions = disasm.disassemble(data, start_logical, count)
 
     if a816_syntax:
-        for line in format_disassembly_block(instructions, show_bytes=show_bytes, a816_syntax=True):
+        for line in format_disassembly_block(
+            instructions, show_bytes=show_bytes, a816_syntax=True, symbol_map=symbol_map
+        ):
             print(line)
     else:
         for inst in instructions:
             print(format_disassembly(inst, show_bytes=show_bytes, a816_syntax=False))
+
+
+def load_debug_symbols(adbg_path: Path) -> tuple[dict[int, str], dict[str, int]]:
+    """Load a .adbg file and return (address->name, name->address) maps.
+
+    Address values are SNES logical addresses (matching what the
+    disassembler computes).
+    """
+    from a816.debug_info import read as read_debug
+
+    info = read_debug(adbg_path)
+    addr_to_name: dict[int, str] = {}
+    name_to_addr: dict[str, int] = {}
+    for sym in info.symbols:
+        # Earlier entries win on collision so the first definition order is preserved.
+        addr_to_name.setdefault(sym.address, sym.name)
+        name_to_addr.setdefault(sym.name, sym.address)
+    return addr_to_name, name_to_addr
 
 
 def _apply_ips_to_temp(input_file: Path, ips_file: Path) -> tuple[Path, Path]:
@@ -370,6 +404,25 @@ def xdds_main() -> None:
     if args.show_mappings:
         show_mapping_info(rom_type)
 
+    addr_to_name: dict[int, str] = {}
+    name_to_addr: dict[str, int] = {}
+    if args.debug:
+        if not args.debug.exists():
+            logger.error(f"Debug file not found: {args.debug}")
+            sys.exit(-1)
+        addr_to_name, name_to_addr = load_debug_symbols(args.debug)
+
+    if args.sym:
+        if not name_to_addr:
+            logger.error("--sym requires --debug pointing at a .adbg file")
+            sys.exit(-1)
+        if args.sym not in name_to_addr:
+            logger.error(f"Symbol not found in debug info: {args.sym}")
+            sys.exit(-1)
+        sym_logical = name_to_addr[args.sym]
+        args.start = f"${sym_logical >> 16:02X}:{sym_logical & 0xFFFF:04X}"
+        logger.info(f"Symbol {args.sym} -> {args.start}")
+
     input_file = args.input_file
     tmp_path: Path | None = None
     if args.ips_file:
@@ -393,6 +446,7 @@ def xdds_main() -> None:
                 count=args.count,
                 show_bytes=not args.no_bytes,
                 a816_syntax=args.asm,
+                symbol_map=addr_to_name or None,
             )
         else:
             hexdump(data, bus, physical_start, args.cols, not args.no_ascii)

--- a/a816/xobj.py
+++ b/a816/xobj.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import struct
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -269,53 +270,59 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+_SECTION_FLAGS: tuple[str, ...] = ("regions", "symbols", "relocs", "lines", "files", "aliases", "imports", "exports")
+
+
+def _print_optional_listing(obj: ObjectFile, attr: str, label: str, out: TextIO) -> None:
+    """Print a `getattr(obj, attr, None)` listing if present. No-op when
+    the attribute is absent — older object formats don't carry imports
+    or exports."""
+    items = getattr(obj, attr, None)
+    if items is None:
+        return
+    print(f"# {label} ({len(items)})", file=out)
+    for entry in items:
+        print(f"  {entry}", file=out)
+
+
+def _emit_text_sections(path: Path, obj: ObjectFile, args: argparse.Namespace, out: TextIO) -> None:
+    """Emit each requested section in declared order, separated by blank
+    lines. Default (no flags) shows every section; --summary alone shows
+    just the summary; --all forces every section even alongside others.
+    """
+    sections_requested = any(getattr(args, attr) for attr in _SECTION_FLAGS)
+    show_all = args.all or (not args.summary and not sections_requested)
+
+    emitted = False
+
+    def section(flag_on: bool, emitter: Callable[[], None]) -> None:
+        nonlocal emitted
+        if not flag_on:
+            return
+        if emitted:
+            out.write("\n")
+        emitter()
+        emitted = True
+
+    section(args.summary or show_all, lambda: print_summary(path, obj, out))
+    section(args.regions or show_all, lambda: print_regions(obj, out, dump_bytes=args.bytes))
+    section(args.symbols or show_all, lambda: print_symbols(obj, out))
+    section(args.relocs or show_all, lambda: print_relocs(obj, out))
+    section(args.lines or show_all, lambda: print_lines(obj, out))
+    section(args.files or show_all, lambda: print_files(obj, out))
+    section(args.aliases or show_all, lambda: print_aliases(obj, out))
+    if args.imports:
+        section(True, lambda: _print_optional_listing(obj, "imports", "imports", out))
+    if args.exports:
+        section(True, lambda: _print_optional_listing(obj, "exports", "exports", out))
+
+
 def _emit(path: Path, obj: ObjectFile, args: argparse.Namespace, out: TextIO) -> None:
     if args.json:
         json.dump(to_json_dict(path, obj), out, indent=2, sort_keys=False)
         out.write("\n")
         return
-
-    sections_requested = any(
-        getattr(args, attr)
-        for attr in ("regions", "symbols", "relocs", "lines", "files", "aliases", "imports", "exports")
-    )
-    show_all = args.all or (not args.summary and not sections_requested)
-
-    if args.summary or show_all:
-        print_summary(path, obj, out)
-    if args.regions or show_all:
-        if args.summary or show_all:
-            out.write("\n")
-        print_regions(obj, out, dump_bytes=args.bytes)
-    if args.symbols or show_all:
-        out.write("\n")
-        print_symbols(obj, out)
-    if args.relocs or show_all:
-        out.write("\n")
-        print_relocs(obj, out)
-    if args.lines or show_all:
-        out.write("\n")
-        print_lines(obj, out)
-    if args.files or show_all:
-        out.write("\n")
-        print_files(obj, out)
-    if args.aliases or show_all:
-        out.write("\n")
-        print_aliases(obj, out)
-    if args.imports:
-        imports = getattr(obj, "imports", None)
-        if imports is not None:
-            out.write("\n")
-            print(f"# imports ({len(imports)})", file=out)
-            for entry in imports:
-                print(f"  {entry}", file=out)
-    if args.exports:
-        exports = getattr(obj, "exports", None)
-        if exports is not None:
-            out.write("\n")
-            print(f"# exports ({len(exports)})", file=out)
-            for entry in exports:
-                print(f"  {entry}", file=out)
+    _emit_text_sections(path, obj, args, out)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/a816/xobj.py
+++ b/a816/xobj.py
@@ -173,13 +173,9 @@ def _region_to_dict(region: Region) -> dict[str, Any]:
         "base_address": region.base_address,
         "size": len(region.code),
         "code": region.code.hex(),
-        "relocations": [
-            {"offset": off, "name": name, "type": rt.name}
-            for off, name, rt in region.relocations
-        ],
+        "relocations": [{"offset": off, "name": name, "type": rt.name} for off, name, rt in region.relocations],
         "expression_relocations": [
-            {"offset": off, "expression": expr, "size_bytes": sz}
-            for off, expr, sz in region.expression_relocations
+            {"offset": off, "expression": expr, "size_bytes": sz} for off, expr, sz in region.expression_relocations
         ],
         "lines": [
             {"offset": off, "file_idx": fi, "line": ln, "column": col, "flags": fl}

--- a/a816/xobj.py
+++ b/a816/xobj.py
@@ -1,0 +1,361 @@
+"""xobj - inspect a816 .o object files.
+
+Companion to the IPS/SFC emit trace. xobj shows pre-link intent (what each
+.o claims for regions, symbols, relocations, debug info); the emit trace
+shows post-link reality (what landed where in the ROM). Diff the two when
+hunting subtle drift.
+"""
+
+import argparse
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+from a816.object_file import (
+    INVALID_FILE_FORMAT,
+    ObjectFile,
+    Region,
+)
+
+
+def _fmt_addr(addr: int) -> str:
+    return f"${addr & 0xFFFFFF:06X}"
+
+
+def _load_tolerant(path: Path, out: TextIO) -> ObjectFile:
+    try:
+        return ObjectFile.from_file(str(path))
+    except ValueError as exc:
+        msg = str(exc)
+        if "Unsupported version" not in msg:
+            raise
+        print(f"warning: {msg}; attempting best-effort read", file=out)
+        return _read_any_version(path)
+
+
+def _read_any_version(path: Path) -> ObjectFile:
+    with open(path, "rb") as f:
+        header = f.read(7)
+        if len(header) < 7:
+            raise ValueError(INVALID_FILE_FORMAT)
+        magic, _version, flags = struct.unpack("<IHB", header)
+        if magic != ObjectFile.MAGIC_NUMBER:
+            raise ValueError("Invalid magic number")
+        relocatable = bool(flags & 0x01)
+        regions = ObjectFile._read_regions(f)
+        symbols = ObjectFile._read_symbol_table(f)
+        try:
+            aliases = ObjectFile._read_alias_table(f)
+        except struct.error:
+            aliases = []
+        try:
+            files = ObjectFile._read_file_table(f)
+        except struct.error:
+            files = []
+        return ObjectFile(regions, symbols, aliases=aliases, files=files, relocatable=relocatable)
+
+
+def _detect_version(path: Path) -> int:
+    with open(path, "rb") as f:
+        header = f.read(7)
+    if len(header) < 7:
+        return -1
+    _magic, version, _flags = struct.unpack("<IHB", header)
+    return int(version)
+
+
+def print_summary(path: Path, obj: ObjectFile, out: TextIO) -> None:
+    version = _detect_version(path)
+    total_code = sum(len(r.code) for r in obj.regions)
+    total_relocs = sum(len(r.relocations) for r in obj.regions)
+    total_expr = sum(len(r.expression_relocations) for r in obj.regions)
+    total_lines = sum(len(r.lines) for r in obj.regions)
+    print(f"file: {path}", file=out)
+    print(f"version: {version}", file=out)
+    print(f"relocatable: {obj.relocatable}", file=out)
+    print(f"regions: {len(obj.regions)}", file=out)
+    print(f"code_bytes: {total_code}", file=out)
+    print(f"symbols: {len(obj.symbols)}", file=out)
+    print(f"aliases: {len(obj.aliases)}", file=out)
+    print(f"files: {len(obj.files)}", file=out)
+    print(f"relocations: {total_relocs}", file=out)
+    print(f"expression_relocations: {total_expr}", file=out)
+    print(f"lines: {total_lines}", file=out)
+
+
+def _hex_dump(data: bytes, out: TextIO, indent: str = "  ") -> None:
+    for i in range(0, len(data), 16):
+        chunk = data[i : i + 16]
+        hex_part = " ".join(f"{b:02x}" for b in chunk)
+        hex_part = hex_part.ljust(16 * 3 - 1)
+        ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        print(f"{indent}{i:04x}: {hex_part}  {ascii_part}", file=out)
+
+
+def print_regions(obj: ObjectFile, out: TextIO, dump_bytes: int = 0) -> None:
+    print(f"# regions ({len(obj.regions)}) — emission order", file=out)
+    for idx, region in enumerate(obj.regions):
+        print(
+            f"[{idx}] base={_fmt_addr(region.base_address)}"
+            f" size={len(region.code)}"
+            f" relocs={len(region.relocations)}"
+            f" expr_relocs={len(region.expression_relocations)}"
+            f" lines={len(region.lines)}",
+            file=out,
+        )
+        if dump_bytes > 0 and region.code:
+            _hex_dump(region.code[:dump_bytes], out)
+
+
+def print_symbols(obj: ObjectFile, out: TextIO) -> None:
+    print(f"# symbols ({len(obj.symbols)}) — sorted by address", file=out)
+    for name, address, sym_type, section in sorted(obj.symbols, key=lambda s: (s[1], s[0])):
+        print(
+            f"{_fmt_addr(address)}  {sym_type.name:<8} {section.name:<4} {name}",
+            file=out,
+        )
+
+
+def _print_region_relocs(idx: int, region: Region, out: TextIO) -> None:
+    if not region.relocations and not region.expression_relocations:
+        return
+    print(f"# region [{idx}] base={_fmt_addr(region.base_address)}", file=out)
+    for offset, name, reloc_type in region.relocations:
+        print(f"  +0x{offset:04x}  {reloc_type.name:<12} {name}", file=out)
+    for offset, expression, size_bytes in region.expression_relocations:
+        print(f"  +0x{offset:04x}  EXPR(size={size_bytes})  {expression}", file=out)
+
+
+def print_relocs(obj: ObjectFile, out: TextIO) -> None:
+    total = sum(len(r.relocations) + len(r.expression_relocations) for r in obj.regions)
+    print(f"# relocations ({total} total)", file=out)
+    for idx, region in enumerate(obj.regions):
+        _print_region_relocs(idx, region, out)
+
+
+def print_lines(obj: ObjectFile, out: TextIO) -> None:
+    total = sum(len(r.lines) for r in obj.regions)
+    print(f"# debug lines ({total} total)", file=out)
+    for idx, region in enumerate(obj.regions):
+        if not region.lines:
+            continue
+        print(f"# region [{idx}] base={_fmt_addr(region.base_address)}", file=out)
+        for offset, file_idx, line, column, flags in region.lines:
+            file_name = obj.files[file_idx] if 0 <= file_idx < len(obj.files) else "<oob>"
+            print(
+                f"  +0x{offset:04x}  file_idx={file_idx} ({file_name}) line={line} col={column} flags=0x{flags:02x}",
+                file=out,
+            )
+
+
+def print_files(obj: ObjectFile, out: TextIO) -> None:
+    print(f"# files ({len(obj.files)})", file=out)
+    for idx, path in enumerate(obj.files):
+        print(f"  [{idx}] {path}", file=out)
+
+
+def print_aliases(obj: ObjectFile, out: TextIO) -> None:
+    print(f"# aliases ({len(obj.aliases)})", file=out)
+    for name, expression in obj.aliases:
+        print(f"  {name} = {expression}", file=out)
+
+
+def _enum_or_value(value: Any) -> Any:
+    if hasattr(value, "name"):
+        return value.name
+    return value
+
+
+def _region_to_dict(region: Region) -> dict[str, Any]:
+    return {
+        "base_address": region.base_address,
+        "size": len(region.code),
+        "code": region.code.hex(),
+        "relocations": [
+            {"offset": off, "name": name, "type": rt.name}
+            for off, name, rt in region.relocations
+        ],
+        "expression_relocations": [
+            {"offset": off, "expression": expr, "size_bytes": sz}
+            for off, expr, sz in region.expression_relocations
+        ],
+        "lines": [
+            {"offset": off, "file_idx": fi, "line": ln, "column": col, "flags": fl}
+            for off, fi, ln, col, fl in region.lines
+        ],
+    }
+
+
+def to_json_dict(path: Path, obj: ObjectFile) -> dict[str, Any]:
+    return {
+        "file": str(path),
+        "version": _detect_version(path),
+        "relocatable": obj.relocatable,
+        "regions": [_region_to_dict(r) for r in obj.regions],
+        "symbols": [
+            {
+                "name": name,
+                "address": addr,
+                "type": _enum_or_value(st),
+                "section": _enum_or_value(sec),
+            }
+            for name, addr, st, sec in obj.symbols
+        ],
+        "aliases": [{"name": n, "expression": e} for n, e in obj.aliases],
+        "files": list(obj.files),
+    }
+
+
+def print_diff(path_a: Path, path_b: Path, obj_a: ObjectFile, obj_b: ObjectFile, out: TextIO) -> None:
+    print(f"--- {path_a}", file=out)
+    print(f"+++ {path_b}", file=out)
+    counts = [
+        ("regions", len(obj_a.regions), len(obj_b.regions)),
+        ("symbols", len(obj_a.symbols), len(obj_b.symbols)),
+        (
+            "relocations",
+            sum(len(r.relocations) for r in obj_a.regions),
+            sum(len(r.relocations) for r in obj_b.regions),
+        ),
+        (
+            "expression_relocations",
+            sum(len(r.expression_relocations) for r in obj_a.regions),
+            sum(len(r.expression_relocations) for r in obj_b.regions),
+        ),
+        ("aliases", len(obj_a.aliases), len(obj_b.aliases)),
+        ("files", len(obj_a.files), len(obj_b.files)),
+    ]
+    for name, av, bv in counts:
+        marker = " " if av == bv else "!"
+        print(f"{marker} {name}: {av} -> {bv}", file=out)
+
+    max_regions = max(len(obj_a.regions), len(obj_b.regions))
+    for idx in range(max_regions):
+        if idx >= len(obj_a.regions):
+            rb = obj_b.regions[idx]
+            print(f"+ region[{idx}] only in B: base={_fmt_addr(rb.base_address)} size={len(rb.code)}", file=out)
+            continue
+        if idx >= len(obj_b.regions):
+            ra = obj_a.regions[idx]
+            print(f"- region[{idx}] only in A: base={_fmt_addr(ra.base_address)} size={len(ra.code)}", file=out)
+            continue
+        ra = obj_a.regions[idx]
+        rb = obj_b.regions[idx]
+        if ra.base_address != rb.base_address or len(ra.code) != len(rb.code):
+            print(
+                f"! region[{idx}]: base {_fmt_addr(ra.base_address)} -> {_fmt_addr(rb.base_address)},"
+                f" size {len(ra.code)} -> {len(rb.code)}",
+                file=out,
+            )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="xobj",
+        description="Inspect a816 .o object files.",
+    )
+    p.add_argument("files", nargs="+", type=Path, help="object file(s)")
+    p.add_argument("--summary", action="store_true", help="high-level counts (default)")
+    p.add_argument("--regions", action="store_true", help="region table")
+    p.add_argument("--bytes", type=int, default=0, metavar="N", help="dump first N bytes of each region")
+    p.add_argument("--symbols", action="store_true", help="symbol table sorted by address")
+    p.add_argument("--relocs", action="store_true", help="relocations (legacy + expression)")
+    p.add_argument("--lines", action="store_true", help="debug line table")
+    p.add_argument("--files", action="store_true", help="debug file table")
+    p.add_argument("--aliases", action="store_true", help="alias table")
+    p.add_argument("--imports", action="store_true", help="import list (if format supports)")
+    p.add_argument("--exports", action="store_true", help="export list (if format supports)")
+    p.add_argument("--all", action="store_true", help="every section in declared order")
+    p.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    p.add_argument("--diff", action="store_true", help="diff two object files (requires exactly two paths)")
+    return p
+
+
+def _emit(path: Path, obj: ObjectFile, args: argparse.Namespace, out: TextIO) -> None:
+    if args.json:
+        json.dump(to_json_dict(path, obj), out, indent=2, sort_keys=False)
+        out.write("\n")
+        return
+
+    sections_requested = any(
+        getattr(args, attr)
+        for attr in ("regions", "symbols", "relocs", "lines", "files", "aliases", "imports", "exports")
+    )
+    show_all = args.all or (not args.summary and not sections_requested)
+
+    if args.summary or show_all:
+        print_summary(path, obj, out)
+    if args.regions or show_all:
+        if args.summary or show_all:
+            out.write("\n")
+        print_regions(obj, out, dump_bytes=args.bytes)
+    if args.symbols or show_all:
+        out.write("\n")
+        print_symbols(obj, out)
+    if args.relocs or show_all:
+        out.write("\n")
+        print_relocs(obj, out)
+    if args.lines or show_all:
+        out.write("\n")
+        print_lines(obj, out)
+    if args.files or show_all:
+        out.write("\n")
+        print_files(obj, out)
+    if args.aliases or show_all:
+        out.write("\n")
+        print_aliases(obj, out)
+    if args.imports:
+        imports = getattr(obj, "imports", None)
+        if imports is not None:
+            out.write("\n")
+            print(f"# imports ({len(imports)})", file=out)
+            for entry in imports:
+                print(f"  {entry}", file=out)
+    if args.exports:
+        exports = getattr(obj, "exports", None)
+        if exports is not None:
+            out.write("\n")
+            print(f"# exports ({len(exports)})", file=out)
+            for entry in exports:
+                print(f"  {entry}", file=out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    out = sys.stdout
+
+    for path in args.files:
+        if not path.exists():
+            print(f"xobj: file not found: {path}", file=sys.stderr)
+            return 2
+
+    if args.diff:
+        if len(args.files) != 2:
+            print("xobj: --diff requires exactly two files", file=sys.stderr)
+            return 2
+        try:
+            obj_a = _load_tolerant(args.files[0], sys.stderr)
+            obj_b = _load_tolerant(args.files[1], sys.stderr)
+        except ValueError as exc:
+            print(f"xobj: {exc}", file=sys.stderr)
+            return 2
+        print_diff(args.files[0], args.files[1], obj_a, obj_b, out)
+        return 0
+
+    for i, path in enumerate(args.files):
+        try:
+            obj = _load_tolerant(path, sys.stderr)
+        except ValueError as exc:
+            print(f"xobj: {path}: {exc}", file=sys.stderr)
+            return 2
+        if i > 0:
+            out.write("\n")
+        _emit(path, obj, args, out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ repository = "https://github.com/manz/a816"
 x816 = "a816.cli:cli_main"
 a816 = "a816.cli:cli_main"
 xdds = "a816.xdds:xdds_main"
+xobj = "a816.xobj:main"
 a816-lsp-server = "a816.lsp.server:lsp_main"
 a816-fluff = "a816.fluff:fluff_main"
 

--- a/tests/test_disassembler.py
+++ b/tests/test_disassembler.py
@@ -340,7 +340,7 @@ class TestFormatDisassembly:
             length=2,
         )
         output = format_disassembly(inst, show_bytes=True, a816_syntax=True)
-        assert "L_018000:" in output
+        assert "_018000:" in output
         assert "lda #0x42" in output
         assert "A9 42" in output
 
@@ -355,7 +355,7 @@ class TestFormatDisassembly:
             length=3,
         )
         output = format_disassembly(inst, show_bytes=False, a816_syntax=True)
-        assert "L_008000:" in output
+        assert "_008000:" in output
         assert "sta 0x2100" in output
 
     def test_format_a816_syntax_long(self) -> None:
@@ -369,7 +369,7 @@ class TestFormatDisassembly:
             length=4,
         )
         output = format_disassembly(inst, show_bytes=False, a816_syntax=True)
-        assert "L_008000:" in output
+        assert "_008000:" in output
         assert "jsl.l 0x018000" in output
 
 
@@ -447,9 +447,9 @@ class TestA816BlockFormat:
         instructions = disasm.disassemble(data, 0x008000)
         labels = collect_labels(instructions)
         assert 0x008007 in labels
-        assert labels[0x008007] == "L_008007"
+        assert labels[0x008007] == "_008007"
         assert 0x018000 in labels
-        assert labels[0x018000] == "L_018000"
+        assert labels[0x018000] == "_018000"
 
     def test_block_emits_label_lines_only_at_targets(self) -> None:
         disasm = Disassembler()
@@ -457,8 +457,8 @@ class TestA816BlockFormat:
         data = bytes.fromhex("d000ea")
         instructions = disasm.disassemble(data, 0x008000)
         lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
-        # Expected: instruction line for bne, label line for L_008002, then nop.
-        assert any(line == "L_008002:" for line in lines)
+        # Expected: instruction line for bne, label line for _008002, then nop.
+        assert any(line == "_008002:" for line in lines)
         assert sum(1 for line in lines if line.endswith(":")) == 1
 
     def test_branch_uses_label_when_target_known(self) -> None:
@@ -467,7 +467,7 @@ class TestA816BlockFormat:
         instructions = disasm.disassemble(data, 0x008000)
         lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
         bne_line = next(line for line in lines if "bne" in line)
-        assert "L_008007" in bne_line
+        assert "_008007" in bne_line
         assert "0x008007" not in bne_line
 
     def test_jmp_long_uses_label(self) -> None:
@@ -476,7 +476,7 @@ class TestA816BlockFormat:
         instructions = disasm.disassemble(data, 0x008000)
         lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
         jmp_line = next(line for line in lines if "jmp" in line)
-        assert "L_018000" in jmp_line
+        assert "_018000" in jmp_line
 
     def test_minimal_suffixes_round_trip(self) -> None:
         disasm = Disassembler()
@@ -488,6 +488,6 @@ class TestA816BlockFormat:
         assert "lda #0x42" in joined
         assert "sta 0x1234" in joined
         assert "lda 0x10" in joined
-        assert "jsl.l L_018000" in joined
+        assert "jsl.l _018000" in joined
         assert "nop" in joined
         assert ".w" not in joined  # no verbose word suffix on absolute / direct

--- a/tests/test_disassembler.py
+++ b/tests/test_disassembler.py
@@ -491,3 +491,74 @@ class TestA816BlockFormat:
         assert "jsl.l _018000" in joined
         assert "nop" in joined
         assert ".w" not in joined  # no verbose word suffix on absolute / direct
+
+
+class TestFunctionDisassembly:
+    """Tests for the CFG-driven function walker."""
+
+    def test_stops_at_rts(self) -> None:
+        from a816.cpu.disassembler import disassemble_function
+
+        code = bytes.fromhex("a90060eaeaea")  # lda #$00, rts, then garbage NOPs
+
+        def provider(addr: int, length: int) -> bytes:
+            offset = addr - 0x008000
+            return code[offset : offset + length] if offset >= 0 else b""
+
+        instructions = disassemble_function(0x008000, provider)
+        assert [inst.mnemonic for inst in instructions] == ["lda", "rts"]
+
+    def test_follows_conditional_branch_and_fallthrough(self) -> None:
+        from a816.cpu.disassembler import disassemble_function
+
+        # 0x008000: bne +2 (target 0x008004)
+        # 0x008002: nop          (fallthrough)
+        # 0x008003: rts
+        # 0x008004: nop          (branch target)
+        # 0x008005: rts
+        code = bytes.fromhex("d002ea60ea60")
+
+        def provider(addr: int, length: int) -> bytes:
+            offset = addr - 0x008000
+            return code[offset : offset + length] if offset >= 0 else b""
+
+        instructions = disassemble_function(0x008000, provider)
+        addresses = [inst.address for inst in instructions]
+        assert 0x008002 in addresses  # fallthrough decoded
+        assert 0x008004 in addresses  # branch target decoded
+
+    def test_tracks_m_flag_across_branches(self) -> None:
+        from a816.cpu.disassembler import AddrMode, disassemble_function
+
+        # 0x008000: rep #$20      (M=0, 16-bit)
+        # 0x008002: lda #$1234    (3 bytes total, A9 34 12)
+        # 0x008005: rts
+        code = bytes.fromhex("c220a9341260")
+
+        def provider(addr: int, length: int) -> bytes:
+            offset = addr - 0x008000
+            return code[offset : offset + length] if offset >= 0 else b""
+
+        instructions = disassemble_function(0x008000, provider, m_flag=True)
+        lda = next(inst for inst in instructions if inst.mnemonic == "lda")
+        assert lda.length == 3
+        assert lda.mode == AddrMode.IMMEDIATE_M
+
+    def test_unconditional_branch_terminates_path(self) -> None:
+        from a816.cpu.disassembler import disassemble_function
+
+        # 0x008000: bra +2 -> target 0x008004
+        # 0x008002: nop  (skipped — bra is unconditional, no fallthrough)
+        # 0x008003: nop
+        # 0x008004: rts
+        code = bytes.fromhex("8002eaea60")
+
+        def provider(addr: int, length: int) -> bytes:
+            offset = addr - 0x008000
+            return code[offset : offset + length] if offset >= 0 else b""
+
+        instructions = disassemble_function(0x008000, provider)
+        addresses = [inst.address for inst in instructions]
+        assert 0x008002 not in addresses
+        assert 0x008003 not in addresses
+        assert 0x008004 in addresses

--- a/tests/test_disassembler.py
+++ b/tests/test_disassembler.py
@@ -5,7 +5,9 @@ from a816.cpu.disassembler import (
     AddrMode,
     Disassembler,
     Instruction,
+    collect_labels,
     format_disassembly,
+    format_disassembly_block,
 )
 
 
@@ -98,15 +100,15 @@ class TestDisassembler:
         assert inst.mnemonic == "bne"
         assert inst.mode == AddrMode.RELATIVE
         assert inst.operand_value == 0x05
-        # Target should be $8000 + 2 + 5 = $8007
-        assert inst.format_operand() == "$8007"
+        # Target should be $8000 + 2 + 5 = $008007 (bank-prefixed).
+        assert inst.format_operand() == "$008007"
 
     def test_decode_relative_branch_backward(self) -> None:
         disasm = Disassembler()
         inst = disasm.decode_instruction(bytes([0xD0, 0xFE]), 0x8000)  # bne $8000 (infinite loop)
         assert inst is not None
-        # Target should be $8000 + 2 - 2 = $8000
-        assert inst.format_operand() == "$8000"
+        # Target should be $8000 + 2 - 2 = $008000 (bank-prefixed).
+        assert inst.format_operand() == "$008000"
 
     def test_decode_indexed_indirect(self) -> None:
         disasm = Disassembler()
@@ -339,7 +341,7 @@ class TestFormatDisassembly:
         )
         output = format_disassembly(inst, show_bytes=True, a816_syntax=True)
         assert "L_018000:" in output
-        assert "lda.b #0x42" in output
+        assert "lda #0x42" in output
         assert "A9 42" in output
 
     def test_format_a816_syntax_absolute(self) -> None:
@@ -354,7 +356,7 @@ class TestFormatDisassembly:
         )
         output = format_disassembly(inst, show_bytes=False, a816_syntax=True)
         assert "L_008000:" in output
-        assert "sta.w 0x2100" in output
+        assert "sta 0x2100" in output
 
     def test_format_a816_syntax_long(self) -> None:
         inst = Instruction(
@@ -384,7 +386,7 @@ class TestInstructionA816Format:
             operand_value=0x42,
             length=2,
         )
-        assert inst.format_a816() == "lda.b #0x42"
+        assert inst.format_a816() == "lda #0x42"
 
     def test_format_a816_absolute(self) -> None:
         inst = Instruction(
@@ -396,7 +398,7 @@ class TestInstructionA816Format:
             operand_value=0x2100,
             length=3,
         )
-        assert inst.format_a816() == "sta.w 0x2100"
+        assert inst.format_a816() == "sta 0x2100"
 
     def test_format_a816_long(self) -> None:
         inst = Instruction(
@@ -432,4 +434,60 @@ class TestInstructionA816Format:
             operand_value=0x10,
             length=2,
         )
-        assert inst.format_a816() == "lda.b 0x10"
+        assert inst.format_a816() == "lda 0x10"
+
+
+class TestA816BlockFormat:
+    """Tests for the label-aware block formatter (idiomatic a816 syntax)."""
+
+    def test_collect_labels_picks_branch_targets(self) -> None:
+        disasm = Disassembler()
+        # bne +5 at 0x008000 -> target 0x008007; jmp.l 0x018000 at 0x008002 -> 0x018000.
+        data = bytes.fromhex("d005000000005c008001")
+        instructions = disasm.disassemble(data, 0x008000)
+        labels = collect_labels(instructions)
+        assert 0x008007 in labels
+        assert labels[0x008007] == "L_008007"
+        assert 0x018000 in labels
+        assert labels[0x018000] == "L_018000"
+
+    def test_block_emits_label_lines_only_at_targets(self) -> None:
+        disasm = Disassembler()
+        # bne +0 -> target = next instruction (0x008002), so label appears.
+        data = bytes.fromhex("d000ea")
+        instructions = disasm.disassemble(data, 0x008000)
+        lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
+        # Expected: instruction line for bne, label line for L_008002, then nop.
+        assert any(line == "L_008002:" for line in lines)
+        assert sum(1 for line in lines if line.endswith(":")) == 1
+
+    def test_branch_uses_label_when_target_known(self) -> None:
+        disasm = Disassembler()
+        data = bytes.fromhex("d005000000000000ea")  # bne +5, then padding, then nop at +7
+        instructions = disasm.disassemble(data, 0x008000)
+        lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
+        bne_line = next(line for line in lines if "bne" in line)
+        assert "L_008007" in bne_line
+        assert "0x008007" not in bne_line
+
+    def test_jmp_long_uses_label(self) -> None:
+        disasm = Disassembler()
+        data = bytes.fromhex("5c008001")
+        instructions = disasm.disassemble(data, 0x008000)
+        lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
+        jmp_line = next(line for line in lines if "jmp" in line)
+        assert "L_018000" in jmp_line
+
+    def test_minimal_suffixes_round_trip(self) -> None:
+        disasm = Disassembler()
+        # lda #0x42, sta 0x1234, lda 0x10, jsl 0x018000, nop
+        data = bytes.fromhex("a9428d3412a510220080 01ea".replace(" ", ""))
+        instructions = disasm.disassemble(data, 0x008000)
+        lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
+        joined = "\n".join(lines)
+        assert "lda #0x42" in joined
+        assert "sta 0x1234" in joined
+        assert "lda 0x10" in joined
+        assert "jsl.l L_018000" in joined
+        assert "nop" in joined
+        assert ".w" not in joined  # no verbose word suffix on absolute / direct

--- a/tests/test_emit_trace.py
+++ b/tests/test_emit_trace.py
@@ -1,0 +1,95 @@
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from a816.linker import Linker
+from a816.object_file import ObjectFile
+from a816.program import Program
+
+
+def _build_two_region_linked() -> tuple[Path, ObjectFile, str]:
+    source = """*=0x008000
+.db 0x11, 0x22
+*=0x028000
+.db 0x33
+"""
+    tmpdir = Path(tempfile.mkdtemp(prefix="emittrace_"))
+    asm = tmpdir / "two.s"
+    obj = tmpdir / "two.o"
+    asm.write_text(source)
+    assert Program().assemble_as_object(str(asm), obj) == 0
+    linked = Linker([ObjectFile.from_file(str(obj))]).link()
+    return tmpdir, linked, str(asm)
+
+
+def test_emit_trace_off_no_log(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("A816_EMIT_TRACE", raising=False)
+    tmpdir, linked, _ = _build_two_region_linked()
+    ips_path = tmpdir / "out.ips"
+    assert Program().link_as_patch(linked, ips_path) == 0
+    assert not (tmpdir / "out.ips.emit.log").exists()
+
+
+def test_emit_trace_on_writes_log(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A816_EMIT_TRACE", "1")
+    tmpdir, linked, asm_path = _build_two_region_linked()
+    ips_path = tmpdir / "out.ips"
+    assert Program().link_as_patch(linked, ips_path) == 0
+    log_path = tmpdir / "out.ips.emit.log"
+    assert log_path.exists()
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    pattern = re.compile(r"snes=\$[0-9A-F]{6}\s+phys=0x[0-9A-F]{6}\s+size=\d+\s+src=")
+    for line in lines:
+        assert pattern.match(line), line
+    assert "snes=$008000" in lines[0]
+    assert "phys=0x000000" in lines[0]
+    assert "size=2" in lines[0]
+    assert "snes=$028000" in lines[1]
+    assert "phys=0x010000" in lines[1]
+    assert "size=1" in lines[1]
+
+
+def test_emit_trace_unknown_src_when_no_lines(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("A816_EMIT_TRACE", "1")
+    from a816.object_file import Region
+
+    region = Region(base_address=0x008000, code=b"\xea\xea")
+    linked = ObjectFile([region], [], files=[])
+    ips_path = tmp_path / "out.ips"
+    assert Program().link_as_patch(linked, ips_path) == 0
+    log_path = tmp_path / "out.ips.emit.log"
+    assert log_path.exists()
+    content = log_path.read_text(encoding="utf-8")
+    assert "src=<unknown>" in content
+
+
+def test_emit_trace_direct_assemble_as_patch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("A816_EMIT_TRACE", "1")
+    source = """*=0x008000
+.db 0x11, 0x22
+*=0x028000
+.db 0x33
+"""
+    asm = tmp_path / "two.s"
+    asm.write_text(source)
+    ips_path = tmp_path / "out.ips"
+    assert Program().assemble_as_patch(str(asm), ips_path) == 0
+    log_path = tmp_path / "out.ips.emit.log"
+    assert log_path.exists()
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) >= 2
+    assert any("phys=0x000000" in line and "size=2" in line for line in lines)
+    assert any("phys=0x010000" in line and "size=1" in line for line in lines)
+
+
+def test_emit_trace_sfc_parity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A816_EMIT_TRACE", "1")
+    tmpdir, linked, _ = _build_two_region_linked()
+    sfc_path = tmpdir / "out.sfc"
+    assert Program().link_as_sfc(linked, sfc_path) == 0
+    log_path = tmpdir / "out.sfc.emit.log"
+    assert log_path.exists()
+    assert len(log_path.read_text(encoding="utf-8").splitlines()) == 2

--- a/tests/test_fluff_cli.py
+++ b/tests/test_fluff_cli.py
@@ -91,3 +91,34 @@ def test_fluff_diff_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> 
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "All files are formatted correctly." in captured.out
+
+
+def test_fluff_stdin_format(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    import io
+
+    raw = "start:\nlda #0\nrts\n"
+    monkeypatch.setattr("sys.stdin", io.StringIO(raw))
+    exit_code = fluff_main(["format", "-"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # Formatter indents instructions and keeps labels flush-left.
+    assert "start:" in captured.out
+    assert "    lda #0" in captured.out
+
+
+def test_fluff_stdin_check_clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    import io
+
+    already_formatted = "start:\n    lda #0\n    rts\n"
+    monkeypatch.setattr("sys.stdin", io.StringIO(already_formatted))
+    assert fluff_main(["format", "--check", "-"]) == 0
+
+
+def test_fluff_stdin_check_dirty(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("start:\nlda #0\n"))
+    exit_code = fluff_main(["format", "--check", "-"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Would reformat <stdin>" in captured.err

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -20,7 +20,7 @@ class TestFormattingOptions(TestCase):
         self.assertEqual(options.indent_size, 4)
         self.assertEqual(options.opcode_indent, 4)
         self.assertEqual(options.operand_alignment, 16)
-        self.assertEqual(options.comment_alignment, 40)
+        self.assertEqual(options.comment_alignment, 0)
         self.assertTrue(options.preserve_empty_lines)
         self.assertEqual(options.max_empty_lines, 2)
         self.assertTrue(options.align_labels)
@@ -260,17 +260,31 @@ end:
         self.assertEqual(lines[2], "    ; standalone")
 
     def test_align_inline_comments_within_block(self) -> None:
-        """Inline comments in the same block should align"""
+        """When comment_alignment > 0, inline comments in the same block align."""
         input_code = """start:
     lda #0 ; comment one
     sta 0x00 ; comment two
     nop ; comment three
 """
 
-        formatted = self.formatter.format_text(input_code)
+        aligned = A816Formatter(FormattingOptions(comment_alignment=40))
+        formatted = aligned.format_text(input_code)
         lines = [line for line in formatted.splitlines() if line]
         comment_columns = [line.index(";") for line in lines if ";" in line and not line.lstrip().startswith(";")]
         self.assertEqual(len(set(comment_columns)), 1)
+
+    def test_inline_comments_default_loose(self) -> None:
+        """Default comment_alignment=0 keeps comments loose with two-space gap."""
+        input_code = """start:
+    lda #0 ; one
+    sta 0x00 ; two
+"""
+        formatted = self.formatter.format_text(input_code)
+        for line in formatted.splitlines():
+            if ";" in line and not line.lstrip().startswith(";"):
+                code_part = line.split(";", 1)[0]
+                # Default policy: exactly two spaces between code and `;`.
+                self.assertTrue(code_part.endswith("  "), repr(line))
 
     def test_formatter_appends_blank_line_at_end(self) -> None:
         """Formatted files should end with a blank line"""
@@ -675,9 +689,10 @@ _OkBk2:
         self.assertIn("    rep #0x20", normalized)
         self.assertIn("    lda.l assets_bank2_ptr, x", normalized)
         self.assertIn("    stx.w 0x0772", normalized)
-        self.assertIn("    _loopbk2:", normalized)
-        self.assertIn("    chargelettredecbk2:", normalized)
-        self.assertIn("    chargelettreincbk2:", normalized)
+        # Inner labels stay flush-left as section markers inside the routine.
+        self.assertIn("\n_loopbk2:", normalized)
+        self.assertIn("\nchargelettredecbk2:", normalized)
+        self.assertIn("\nchargelettreincbk2:", normalized)
         self.assertIn("#0x03", normalized)
         self.assertTrue(normalized.strip().endswith("}"))
 

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -524,6 +524,9 @@ main:
 class TestA816LSPIntegration(TestCase):
     """Integration tests for LSP server components"""
 
+    def setUp(self) -> None:
+        self.server = A816LanguageServer()
+
     def test_document_and_formatter_integration(self) -> None:
         """Test integration between document analysis and formatting"""
         content = """; Header
@@ -650,3 +653,75 @@ subroutine:
 
         doc = A816Document("test://docstring.s", content)
         self.assertEqual(doc.macro_docstrings.get("greet"), "Say hi")
+
+    def test_workspace_rename(self) -> None:
+        """Rename should produce a WorkspaceEdit covering all references."""
+        from lsprotocol.types import RenameParams
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            def_path = root / "defs.s"
+            ref_path = root / "ref.s"
+            def_path.write_text("lookup_label:\n    rtl\n", encoding="utf-8")
+            ref_path.write_text("    jsr lookup_label\n    rts\n", encoding="utf-8")
+
+            def_doc = A816Document(def_path.as_uri(), def_path.read_text(encoding="utf-8"))
+            ref_doc = A816Document(ref_path.as_uri(), ref_path.read_text(encoding="utf-8"))
+
+            index = WorkspaceIndex(root)
+            index.replace_document(def_doc)
+            index.replace_document(ref_doc)
+            index.built = True
+            self.server.workspace_index = index
+            self.server._ensure_workspace_index = lambda: index  # type: ignore[method-assign]
+            self.server.documents[ref_path.as_uri()] = ref_doc
+
+            handler = self.server.server.lsp._get_handler("textDocument/rename")  # type: ignore[no-untyped-call]
+            params = RenameParams(
+                text_document=TextDocumentIdentifier(uri=ref_path.as_uri()),
+                position=Position(line=0, character=10),
+                new_name="new_label",
+            )
+            edit = asyncio.run(handler(params))
+            self.assertIsNotNone(edit)
+            self.assertIn(def_path.as_uri(), edit.changes)
+            self.assertIn(ref_path.as_uri(), edit.changes)
+            for edits in edit.changes.values():
+                for text_edit in edits:
+                    self.assertEqual(text_edit.new_text, "new_label")
+
+    def test_rename_rejects_opcode(self) -> None:
+        """prepareRename should refuse renaming an opcode."""
+        from lsprotocol.types import PrepareRenameParams
+
+        content = "    lda #0\n"
+        doc = A816Document("test://op.s", content)
+        self.server.documents[doc.uri] = doc
+        handler = self.server.server.lsp._get_handler("textDocument/prepareRename")  # type: ignore[no-untyped-call]
+        params = PrepareRenameParams(
+            text_document=TextDocumentIdentifier(uri=doc.uri),
+            position=Position(line=0, character=5),  # inside "lda"
+        )
+        self.assertIsNone(asyncio.run(handler(params)))
+
+    def test_references_skip_comments_and_strings(self) -> None:
+        """\\bword\\b matches inside `;` comments or '...' strings must not count."""
+        from lsprotocol.types import ReferenceContext
+
+        content = "foo:\n    rtl\n    ; foo in a comment\n    .text 'foo inside string'\n    jsr foo\n"
+        doc = A816Document("test://refs.s", content)
+        self.server.documents[doc.uri] = doc
+        handler = self.server.server.lsp._get_handler("textDocument/references")  # type: ignore[no-untyped-call]
+        params = ReferenceParams(
+            text_document=TextDocumentIdentifier(uri=doc.uri),
+            position=Position(line=0, character=1),
+            context=ReferenceContext(include_declaration=True),
+        )
+        results = asyncio.run(handler(params))
+        ranges = [(loc.range.start.line, loc.range.start.character) for loc in results]
+        # Only the definition (line 0) and the jsr (line 4) should match.
+        self.assertIn((0, 0), ranges)
+        self.assertIn((4, 8), ranges)
+        # Comment line 2 and string line 3 must be excluded.
+        for line, _ in ranges:
+            self.assertNotIn(line, (2, 3))

--- a/tests/test_xdds.py
+++ b/tests/test_xdds.py
@@ -802,3 +802,65 @@ class TestXddsMain:
             assert len(lines) == 2
         finally:
             rom_path.unlink()
+
+
+class TestDebugInfoIntegration:
+    """Tests for --debug / --sym (adbg-driven symbol lookup)."""
+
+    @staticmethod
+    def _write_adbg(path: Path, syms: list[tuple[str, int]]) -> None:
+        from a816.debug_info import DebugInfo, SymbolEntry, SymbolKind, SymbolScope, write
+
+        info = DebugInfo()
+        for name, addr in syms:
+            info.symbols.append(SymbolEntry(name=name, address=addr, scope=SymbolScope.GLOBAL, kind=SymbolKind.LABEL))
+        write(info, path)
+
+    def test_load_debug_symbols_round_trip(self, tmp_path: Path) -> None:
+        from a816.xdds import load_debug_symbols
+
+        adbg = tmp_path / "test.adbg"
+        TestDebugInfoIntegration._write_adbg(adbg, [("foo", 0x008000), ("bar", 0x018400)])
+        addr_to_name, name_to_addr = load_debug_symbols(adbg)
+        assert addr_to_name[0x008000] == "foo"
+        assert name_to_addr["bar"] == 0x018400
+
+    def test_sym_resolves_to_address(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from a816.xdds import xdds_main
+
+        rom = tmp_path / "rom.sfc"
+        # 32 bytes of NOPs starting at logical $00:8000 -> physical 0x000000.
+        rom.write_bytes(b"\xea" * 32)
+        adbg = tmp_path / "rom.adbg"
+        TestDebugInfoIntegration._write_adbg(adbg, [("entry", 0x008004)])
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["xdds", "-d", "--asm", "--debug", str(adbg), "--sym", "entry", "-n", "2", str(rom)],
+        )
+        xdds_main()
+        captured = capsys.readouterr()
+        assert "entry:" in captured.out
+        assert "nop" in captured.out
+
+    def test_sym_uses_label_in_branch_targets(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from a816.xdds import xdds_main
+
+        rom = tmp_path / "rom.sfc"
+        # bne +2 at $00:8000 -> target $00:8004; nop nop nop at +2..+4
+        rom.write_bytes(bytes.fromhex("d002eaeaea"))
+        adbg = tmp_path / "rom.adbg"
+        TestDebugInfoIntegration._write_adbg(adbg, [("loop_target", 0x008004)])
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["xdds", "-d", "--asm", "--debug", str(adbg), "--start", "$00:8000", "-n", "4", str(rom)],
+        )
+        xdds_main()
+        captured = capsys.readouterr()
+        assert "bne loop_target" in captured.out
+        assert "loop_target:" in captured.out

--- a/tests/test_xobj.py
+++ b/tests/test_xobj.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from a816.object_file import ObjectFile, Region, RelocationType, SymbolSection, SymbolType
+from a816.xobj import main
+
+
+def _make_fixture(path: Path) -> Path:
+    region = Region(
+        base_address=0x008000,
+        code=b"\xea\xea",
+        relocations=[(0x00, "ext_sym", RelocationType.ABSOLUTE_16)],
+        expression_relocations=[(0x01, "foo + 1", 2)],
+        lines=[(0x00, 0, 12, 4, 0)],
+    )
+    obj = ObjectFile(
+        [region],
+        [("foo", 0x008000, SymbolType.GLOBAL, SymbolSection.CODE)],
+        files=["fixture.s"],
+    )
+    obj.write(str(path))
+    return path
+
+
+def test_summary_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--summary"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "regions: 1" in captured.out
+    assert "symbols: 1" in captured.out
+    assert "version: 6" in captured.out
+
+
+def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--json"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    data = json.loads(captured.out)
+    assert data["version"] == 6
+    assert data["regions"][0]["base_address"] == 0x008000
+    assert bytes.fromhex(data["regions"][0]["code"]) == b"\xea\xea"
+    assert data["symbols"][0]["type"] == "GLOBAL"
+    assert data["symbols"][0]["section"] == "CODE"
+    assert data["regions"][0]["relocations"][0]["type"] == "ABSOLUTE_16"
+
+
+def test_regions_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--regions"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "$008000" in captured.out
+
+
+def test_regions_with_bytes_dump(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--regions", "--bytes", "2"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "ea ea" in captured.out
+
+
+def test_symbols_sorted(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--symbols"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "foo" in captured.out
+    assert "GLOBAL" in captured.out
+
+
+def test_relocs_listed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--relocs"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "ext_sym" in captured.out
+    assert "foo + 1" in captured.out
+
+
+def test_missing_file(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["/nonexistent/path/that/does/not/exist.o"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "/nonexistent/path/that/does/not/exist.o" in captured.err
+
+
+def test_diff_two_files(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    a = _make_fixture(tmp_path / "a.o")
+    region_b = Region(base_address=0x018000, code=b"\xea\xea\xea")
+    ObjectFile([region_b], []).write(str(tmp_path / "b.o"))
+    rc = main([str(a), str(tmp_path / "b.o"), "--diff"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "regions:" in captured.out
+    assert "$008000" in captured.out
+    assert "$018000" in captured.out


### PR DESCRIPTION
A bundle of audit and ergonomics tools for a816 / SNES work, plus quality-of-life fixes for the LSP and formatter.

## New tools

- **xobj** — \`.o\` inspector. Subcommands: \`--summary\`, \`--regions [--bytes N]\`, \`--symbols\`, \`--relocs\`, \`--lines\`, \`--files\`, \`--aliases\`, \`--all\`, \`--json\`, two-file \`--diff\`. Tolerant of older object versions.
- **A816_EMIT_TRACE=1** — env-gated \`<output>.emit.log\` next to every IPS / SFC artifact: one line per non-empty region, \`snes / phys / size / src\`. Wires through \`link_as_patch\`, \`link_as_sfc\`, \`assemble_as_patch\`, \`assemble\`.

Together: pre-link intent (xobj) vs post-link reality (emit log). Diff with \`diff -u\` to chase subtle drift.

## xdds

- a816-syntax disassembly now round-trips through the assembler: drop verbose \`.b\` / \`.w\` suffixes, emit relative branches as labels, fix bank-wrap on \`relative_target\`, label lines only at referenced addresses.
- \`--debug PATH.adbg\` substitutes symbol names from the debug-info file.
- \`--sym NAME\` starts disassembly at a symbol.
- \`--func NAME\` walks the function CFG: stops at \`rts\` / \`rtl\` / \`rti\` / unconditional jumps, follows conditional branches both ways, tracks M / X through \`sep\` / \`rep\`. \`--follow-calls\` recurses into \`jsr\` / \`jsl\`.
- Synthetic labels render as \`_BBHHHH:\` (underscore prefix), flush-left output composes cleanly with \`a816-fluff format -\`.

## Fluff

- \`a816-fluff format -\` reads from stdin and writes to stdout. \`--check\` / \`--diff\` work on stdin too.
- House-style pass on the formatter:
  - Inline comments stay inline (\`instr  ; comment\`) instead of splitting onto separate lines.
  - Blank lines inside block bodies are preserved by AST-line-gap detection (capped at \`max_empty_lines\`).
  - Inner labels (\`_loop:\`, \`_skip:\`, \`_not_found:\`) render flush-left as section markers instead of inheriting body indent.
  - Top-level docstrings hug the preceding label with no blank line; under \`*=\` regions they follow body indentation.
  - Compound-block boundaries no longer leak source blanks at their closing brace.
  - \`comment_alignment\` default is \`0\` (two-space gap policy); set \`> 0\` to force a target column.

## LSP

- \`textDocument/prepareRename\` + \`textDocument/rename\`. Workspace-wide rename via standard \`<leader>vrn\` etc.
- Reference search now masks line comments (\`;\`) and string literals (single, double, triple-quoted, multi-line). \`textDocument/references\` and rename both stop misfiring inside \`; foo\` and \`.text 'foo'\`.

## Test plan

- [ ] \`hatch run tests:all\` green (608 passed, 1 skipped, 85% coverage)
- [ ] \`xobj fixture.o --summary\` / \`--json\` / \`--regions --bytes N\`
- [ ] \`A816_EMIT_TRACE=1 python build.py\` produces \`.emit.log\`; build byte-identical when env unset
- [ ] \`xdds rom.sfc --ips patch.ips -d --asm --debug build.adbg --func foo --no-bytes | a816-fluff format -\` produces clean reassemblable output
- [ ] \`<leader>vrn\` in nvim renames a workspace label across all \`.s\` / \`.i\`
- [ ] \`a816-fluff format --diff\` on the working tree matches house style