### PR TITLE
Accept multiple paths in `a816-fluff format`

### DIFF
--- a/a816/fluff.py
+++ b/a816/fluff.py
@@ -49,9 +49,14 @@ def _build_fluff_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
     format_parser = subparsers.add_parser("format", help="Format .s/.i sources under the given path.")
     format_parser.add_argument(
-        "path",
+        "paths",
+        nargs="+",
         type=Path,
-        help="File or directory to format recursively. Use `-` to read from stdin and write the formatted text to stdout.",
+        help=(
+            "One or more files or directories to format. Directories are walked"
+            " recursively for .s / .i sources. Use `-` (alone) to read from stdin"
+            " and write the formatted text to stdout."
+        ),
     )
     format_parser.add_argument(
         "--check",
@@ -158,24 +163,50 @@ def _run_format_stdin(args: argparse.Namespace) -> int:
     return 0
 
 
+def _collect_sources(paths: list[Path]) -> tuple[list[Path], int]:
+    """Resolve every input path to a deduplicated list of source files.
+
+    Returns (sources, error_code). error_code is 2 if any path is missing
+    (after also reporting it on stderr), 0 otherwise. Missing paths do
+    not abort the walk so the user sees one report covering every input.
+    """
+    seen: set[Path] = set()
+    sources: list[Path] = []
+    error_code = 0
+    for raw in paths:
+        if not raw.exists():
+            print(f"path not found: {raw}", file=sys.stderr)
+            error_code = 2
+            continue
+        for candidate in _discover_sources(raw):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            sources.append(candidate)
+    return sources, error_code
+
+
 def _run_format(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
-    target_path: Path = args.path
-    if str(target_path) == "-":
+    paths: list[Path] = list(args.paths)
+    has_stdin = any(str(p) == "-" for p in paths)
+    if has_stdin:
+        if len(paths) != 1:
+            parser.error("`-` (stdin) cannot be combined with other paths")
         return _run_format_stdin(args)
-    if not target_path.exists():
-        parser.error(f"path does not exist: {target_path}")
-    sources = list(_discover_sources(target_path))
+
+    sources, missing_err = _collect_sources(paths)
     if not sources:
-        return 0
+        return missing_err
     computed, err = _format_sources(sources, A816Formatter())
     if err is not None:
         return err
     changed = [item for item in computed if item[1] != item[2]]
     if args.diff:
-        return _emit_diff(changed)
+        return _emit_diff(changed) or missing_err
     if args.check:
-        return _emit_check(changed)
-    return _write_formatted(computed)
+        return _emit_check(changed) or missing_err
+    return _write_formatted(computed) or missing_err
 
 
 def fluff_main(argv: Sequence[str] | None = None) -> int:

--- a/tests/test_fluff_cli.py
+++ b/tests/test_fluff_cli.py
@@ -45,9 +45,13 @@ def test_fluff_ignores_non_matching_files(tmp_path: Path) -> None:
     assert file_path.read_text(encoding="utf-8") == "raw content"
 
 
-def test_fluff_missing_path_errors(tmp_path: Path) -> None:
-    with pytest.raises(SystemExit):
-        fluff_main(["format", str(tmp_path / "missing.s")])
+def test_fluff_missing_path_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Missing path reports on stderr and exits 2 without aborting other inputs."""
+    exit_code = fluff_main(["format", str(tmp_path / "missing.s")])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "path not found" in captured.err
+    assert str(tmp_path / "missing.s") in captured.err
 
 
 def test_fluff_check_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -122,3 +126,70 @@ def test_fluff_stdin_check_dirty(monkeypatch: pytest.MonkeyPatch, capsys: pytest
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "Would reformat <stdin>" in captured.err
+
+
+def test_fluff_multi_file_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`format --check a.s b.s` reports both, exits 1 if either is dirty."""
+    a = tmp_path / "a.s"
+    b = tmp_path / "b.s"
+    a.write_text("start:\n    lda #0\n    rts\n", encoding="utf-8")  # already formatted
+    b.write_text("start:\nlda #0 ; bad\n", encoding="utf-8")  # dirty
+
+    exit_code = fluff_main(["format", "--check", str(a), str(b)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Would reformat" in captured.out
+    assert str(b) in captured.out
+
+
+def test_fluff_file_and_dir_mix(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`format src/ extra.s` formats both the directory and the extra file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "in_dir.s").write_text("start:\nlda #0\n", encoding="utf-8")
+    extra = tmp_path / "extra.s"
+    extra.write_text("foo:\n    rts\n", encoding="utf-8")
+
+    exit_code = fluff_main(["format", str(src), str(extra)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # Write happened — check `in_dir.s` got rewritten with formatted output.
+    assert "start:" in (src / "in_dir.s").read_text(encoding="utf-8")
+    assert "Formatted" in captured.out
+
+
+def test_fluff_dedupe_overlapping_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Passing a file inside a directory alongside the directory dedupes it."""
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "kerning.s"
+    f.write_text("foo:\nlda #0\n", encoding="utf-8")
+
+    exit_code = fluff_main(["format", "--check", str(src), str(f)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    # File should appear once in the report, not twice.
+    assert captured.out.count(str(f)) == 1
+    assert "Would reformat 1 file(s)." in captured.out
+
+
+def test_fluff_stdin_mixed_with_path_errors(tmp_path: Path) -> None:
+    f = tmp_path / "f.s"
+    f.write_text("foo:\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        fluff_main(["format", "-", str(f)])
+
+
+def test_fluff_continues_after_missing_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A missing path reports + sets exit 2 but doesn't skip the next input."""
+    real = tmp_path / "real.s"
+    real.write_text("foo:\n    rts\n", encoding="utf-8")
+    missing = tmp_path / "missing.s"
+
+    exit_code = fluff_main(["format", "--check", str(missing), str(real)])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "path not found" in captured.err
+    # Real file was scanned (already formatted, so no warning) — combined exit
+    # remains 2 from the missing input.
+    assert "All files are formatted correctly." in captured.out


### PR DESCRIPTION
\`format\` now takes one or more files / directories (\`paths\`, \`nargs=+\`), matching ruff / black ergonomics. Stdin (\`-\`) remains exactly one path and cannot be combined with files.

## Changes

- CLI: \`path\` → \`paths\` positional, \`nargs=\"+\"\`.
- Driver: dedupe inputs by resolved absolute path (passing a file alongside its parent directory formats it once); aggregate \`Would reformat N file(s).\` across all paths.
- Missing path: report on stderr, contribute exit 2, continue scanning the rest of the inputs so one invocation surfaces every failing path.
- Stdin mixed with files: argparse-level error before any work.

## Downstream

The ff4-modules \`.pre-commit-config.yaml\` simplifies to:

\`\`\`yaml
entry: a816-fluff format --check
pass_filenames: true
\`\`\`

Drops the \`sh -c\` loop wrapper. Bump pin to \`a816==1.1.0a7\`.

## Test plan

- [ ] \`hatch run tests:all\` green (613 passed, 1 skipped, 85% coverage)
- [ ] \`a816-fluff format --check src/foo.s src/bar.s\` reports both
- [ ] \`a816-fluff format src/ extra.s\` formats directory + file
- [ ] \`a816-fluff format src/ src/foo.s\` formats once (dedupe)
- [ ] \`a816-fluff format -\` still works (stdin)
- [ ] \`a816-fluff format - file.s\` errors out