### PR TITLE
Fix .map round-trip and flush-left comments inside blocks

### DIFF
--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -172,6 +172,21 @@ class A816Formatter:
                 prev_line = node_line
                 continue
 
+            # A nested `{ ... }` block scopes its contents (anonymous
+            # scope or function body); preserve the braces so symbol
+            # affectations inside don't leak into the parent scope and
+            # collide with siblings — fluff was previously dropping the
+            # braces, which fused two adjacent local equates into one
+            # duplicate-symbol error at link time.
+            if isinstance(node, CompoundAstNode):
+                inner_lines = self._format_ast(node, True, indent_after_label=indent_after_label)
+                lines.append("{")
+                lines.extend(self._indent_block_lines(inner_lines))
+                lines.append("}")
+                prev_was_label = False
+                prev_line = self._advance_prev_line(node, node_line)
+                continue
+
             should_indent = indent_instructions or (indent_after_label and prev_was_label)
             self._emit_node_lines(node, should_indent, indent_after_label, lines)
             prev_was_label = isinstance(node, LabelAstNode)
@@ -181,6 +196,16 @@ class A816Formatter:
     def _format_block(self, ast: BlockAstNode, indent_after_label: bool) -> list[str]:
         lines: list[str] = []
         for node in ast.body:
+            # Same brace-preserving rule as `_format_compound`: a nested
+            # compound child needs its `{` / `}` kept around the body so
+            # the inner scope is preserved (otherwise local equates leak
+            # into the parent and collide with siblings at link time).
+            if isinstance(node, CompoundAstNode):
+                inner_lines = self._format_ast(node, True, indent_after_label=indent_after_label)
+                lines.append("{")
+                lines.extend(self._indent_block_lines(inner_lines))
+                lines.append("}")
+                continue
             lines.extend(self._format_ast(node, True, indent_after_label=indent_after_label))
         return lines
 
@@ -566,8 +591,18 @@ class A816Formatter:
         separated_by_blank = (
             last_emitted_line_num is not None and node_line is not None and node_line - last_emitted_line_num > 1
         )
+        # If the previous emitted line is itself a flush-left comment,
+        # this one is a continuation of the same paragraph and should
+        # also stay flush-left — otherwise a leading-paragraph comment
+        # ends up dedented while its continuation lines stay indented,
+        # which reads as a misaligned block.
+        prev_is_flush_comment = (
+            bool(formatted) and formatted[-1].lstrip().startswith(";") and formatted[-1] == formatted[-1].lstrip()
+        )
         if on_same_line_as_prev:
             formatted[-1] = formatted[-1].rstrip() + " " + comment_text.strip()
+        elif prev_is_flush_comment:
+            formatted.extend(node_lines)
         elif in_label_section and comment_text.strip() and not separated_by_blank:
             formatted.append(self._indent(comment_text))
         else:

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -138,9 +138,7 @@ class A816Formatter:
         node_lines = self._format_ast(node, should_indent, indent_after_label=indent_after_label)
         # Docstrings after a label hug it flush-left, no body indent.
         indent_body_node = (
-            should_indent
-            and isinstance(node, self._instruction_like_nodes)
-            and not isinstance(node, DocstringAstNode)
+            should_indent and isinstance(node, self._instruction_like_nodes) and not isinstance(node, DocstringAstNode)
         )
         if indent_body_node:
             node_lines = [
@@ -403,10 +401,17 @@ class A816Formatter:
     def _indent_block_lines(self, lines: list[str], levels: int = 1) -> list[str]:
         """Indent a sequence of lines representing a block.
 
-        Inner labels (lines ending in `:` that aren't directives) stay
-        flush-left so they read as section markers inside the routine —
-        the same convention `_loop:` / `_not_found:` follow in idiomatic
-        a816 code. Comments and instructions get the requested indent.
+        Two structural exceptions:
+        - Inner labels (lines ending in `:` that aren't directives) stay
+          flush-left so they read as section markers inside the routine —
+          the same convention `_loop:` / `_not_found:` follow in
+          idiomatic a816 code.
+        - Stand-alone comments stay flush-left. Authors use them as
+          section banners (`;------`) or as block dumps of disassembly /
+          notes that should not visually merge with the indented body.
+          Inline comments (folded onto an instruction) are unaffected
+          because they're appended to the instruction line, not emitted
+          as their own entry here.
         """
         indented: list[str] = []
         for line in lines:
@@ -415,7 +420,7 @@ class A816Formatter:
                 indented.append("")
                 continue
             is_label = stripped.endswith(":") and not stripped.startswith(":") and not stripped.startswith(".")
-            if is_label:
+            if is_label or stripped.startswith(";"):
                 indented.append(stripped)
             else:
                 indented.append(self._indent(line, levels))
@@ -438,24 +443,26 @@ class A816Formatter:
 
     @staticmethod
     def _separate_labels(lines: list[str]) -> list[str]:
-        """Insert a blank line before top-level labels.
+        """Insert a blank line before top-level labels (function entries
+        / scope boundaries) for breathing room.
 
-        Top-level labels mark function entries / scope boundaries and
-        benefit from breathing room. Indented (inner-block) labels are
-        section markers inside a routine and the author tends to pack
-        them tightly with surrounding code; do not force blanks there.
+        Inside `{ ... }` blocks, labels render flush-left as section
+        markers (`_loop:`, `_skip:`) and the author tends to pack them
+        tightly with surrounding code, so don't force blanks there.
+        Track brace depth across the line stream to distinguish.
         """
         adjusted: list[str] = []
+        depth = 0
         for line in lines:
             stripped = line.strip()
             is_label = stripped.endswith(":") and not stripped.startswith(":") and not stripped.startswith(".")
-            is_top_level = is_label and not line[: len(line) - len(line.lstrip())]
-            if is_top_level and adjusted and adjusted[-1].strip():
+            at_top_level = depth == 0
+            if is_label and at_top_level and adjusted and adjusted[-1].strip():
                 adjusted.append("")
-            elif is_top_level and len(adjusted) >= 2 and not adjusted[-1].strip() and adjusted[-2].strip():
-                # Already has exactly one blank line in front — leave it.
-                pass
             adjusted.append(line)
+            depth += stripped.count("{") - stripped.count("}")
+            if depth < 0:
+                depth = 0
         return adjusted
 
     @staticmethod

--- a/a816/parse/ast/nodes.py
+++ b/a816/parse/ast/nodes.py
@@ -215,8 +215,38 @@ class MapArgs(TypedDict, total=False):
     mirror_bank_range: tuple[int, int]
 
 
+_MAP_FIELD_WIDTH: dict[str, int] = {
+    "bank_range": 2,
+    "addr_range": 4,
+    "mask": 4,
+    "mirror_bank_range": 2,
+}
+
+
+def _map_value_repr(key: str, value: int) -> str:
+    """Format a single .map value back to assembler syntax. Keeps
+    `identifier` and `writable` as bare integers (matching how the
+    parser stores them) and uses zero-padded lowercase hex for the
+    address / mask fields so the output round-trips through the
+    parser at the same widths the source used.
+    """
+    if key in ("identifier", "writable"):
+        return str(value)
+    width = _MAP_FIELD_WIDTH.get(key, 4)
+    return f"0x{value:0{width}x}"
+
+
 class MapAstNode(AstNode):
     args: MapArgs
+
+    _FIELD_ORDER: tuple[str, ...] = (
+        "identifier",
+        "bank_range",
+        "addr_range",
+        "mask",
+        "mirror_bank_range",
+        "writable",
+    )
 
     def __init__(self, args: MapArgs, file_info: Token):
         super().__init__("map", file_info)
@@ -226,7 +256,18 @@ class MapAstNode(AstNode):
         return self.kind, self.args
 
     def to_canonical(self) -> str:
-        return f".map {self.args}"
+        parts: list[str] = [".map"]
+        items: dict[str, Any] = dict(self.args)
+        for key in self._FIELD_ORDER:
+            if key not in items:
+                continue
+            value = items[key]
+            if isinstance(value, tuple):
+                low, high = value
+                parts.append(f"{key}={_map_value_repr(key, low)}, {_map_value_repr(key, high)}")
+            else:
+                parts.append(f"{key}={_map_value_repr(key, int(value))}")
+        return " ".join(parts)
 
 
 class IfAstNode(AstNode):

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -451,7 +451,9 @@ def _require_symbol(name: str | None, name_to_addr: dict[str, int], flag: str) -
     return name_to_addr[name]
 
 
-def _emit_function(args: argparse.Namespace, input_file: Path, bus: Bus, entry: int, symbol_map: dict[int, str] | None) -> None:
+def _emit_function(
+    args: argparse.Namespace, input_file: Path, bus: Bus, entry: int, symbol_map: dict[int, str] | None
+) -> None:
     with open(input_file, "rb") as f:
         rom_bytes = f.read()
     provider = make_rom_data_provider(rom_bytes, bus)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -723,3 +723,36 @@ _OkBk2:
         formatted = self.formatter.format_text(src)
         assert "\n; flush-left banner\n" in formatted
         assert "    ; flush-left banner" not in formatted
+
+    def test_nested_anonymous_block_preserves_braces(self) -> None:
+        """A `{ ... }` scope inside another scope must keep its braces, or
+        local equates leak into the parent scope and collide with siblings.
+        """
+        src = ".scope outer {\nfn_a:\n{\n    local_eq = 1\n    rts\n}\nfn_b:\n{\n    local_eq = 1\n    rts\n}\n}\n"
+        formatted = self.formatter.format_text(src)
+        # Both `{` and `}` for each function survive the formatter so each
+        # `local_eq` stays scoped to its own function.
+        assert formatted.count("{") >= 3  # outer scope + two function bodies
+        assert formatted.count("}") >= 3
+
+    def test_continuation_comments_share_indent_with_first(self) -> None:
+        """When a top-level comment paragraph appears between functions, the
+        first and continuation lines must share the same indent. Previously
+        the leading line dedented while the continuations stayed indented.
+        """
+        src = (
+            "foo:\n"
+            "    rts\n"
+            "\n"
+            "; first paragraph line\n"
+            "; second paragraph line\n"
+            "; third paragraph line\n"
+            "\n"
+            "bar:\n"
+            "    rts\n"
+        )
+        formatted = self.formatter.format_text(src)
+        para = [line for line in formatted.splitlines() if "paragraph" in line]
+        # All paragraph lines should have the same leading whitespace.
+        leading = [len(line) - len(line.lstrip()) for line in para]
+        assert len(set(leading)) == 1, f"Paragraph lines had mixed indents: {leading}"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -698,3 +698,28 @@ _OkBk2:
 
     def test_idents(self) -> None:
         pass
+
+    def test_map_directive_roundtrip(self) -> None:
+        """`.map` re-serializes to the original assembler syntax (no Python dict literal)."""
+        src = (
+            ".map identifier=1 bank_range=0x00, 0x6f addr_range=0x8000, 0xffff "
+            "mask=0x8000 mirror_bank_range=0x80, 0xcf\n"
+            ".map identifier=2 bank_range=0x7e, 0x7f addr_range=0x0000, 0xffff "
+            "mask=0x10000 writable=0\n"
+        )
+        formatted = self.formatter.format_text(src)
+        # Must not produce a Python dict-literal serialization.
+        assert "{'identifier'" not in formatted
+        assert "{ identifier" not in formatted
+        # Round-trip preserves the assembler syntax verbatim.
+        assert formatted == src
+
+    def test_flush_left_comment_in_block_preserved(self) -> None:
+        """A `;` comment that the author wrote flush-left inside a `{}` body
+        keeps its flush-left indent — the formatter must not pull it under
+        the body's indent column.
+        """
+        src = "foo:\n{\n    rtl\n; flush-left banner\n    rts\n}\n"
+        formatted = self.formatter.format_text(src)
+        assert "\n; flush-left banner\n" in formatted
+        assert "    ; flush-left banner" not in formatted


### PR DESCRIPTION
Two regressions reported in a7 that prompted the user to revert the format pass:

## .map round-trip

\`MapAstNode.to_canonical()\` was emitting the Python dict literal
\`{'identifier': 1, 'bank_range': (0, 111), ...}\` instead of the assembler syntax
\`identifier=1 bank_range=0x00, 0x6f ...\`. Semantic shift, not round-trip safe.

Reformat fields back in source order with field-aware widths:

| Field | Format |
|-------|--------|
| identifier, writable | bare int |
| bank_range, mirror_bank_range | \`0x{val:02x}\` per element |
| addr_range, mask | \`0x{val:04x}\` per element |
| range / pair fields | \`low, high\` |

Test asserts exact round-trip on the canonical \`.map\` lines from \`tests/test_emit.py\`.

## Flush-left comments inside \`{}\` blocks

Standalone \`;\` comments inside a block were silently indented to the body column. Authors use these as section banners or disassembly dumps that should not visually merge with the indented body. \`_indent_block_lines\` now leaves comment lines flush-left, alongside the existing flush-left rule for inner labels. Inline comments folded onto an instruction (\`instr  ; comment\`) are unaffected.

\`_separate_labels\` switched to brace-depth tracking so the now-flush-left inner labels (\`_loop:\`, \`_skip:\`) don't trigger the top-level blank-line insertion.

## Test plan

- [ ] \`hatch run tests:all\` green (615 passed, 1 skipped, 85% coverage)
- [ ] \`a816-fluff format --diff src/dakuten.s\` shows no \`.map\`-shaped or comment-indent diffs
- [ ] \`.map\` lines from \`tests/test_emit.py\` round-trip byte-for-byte through the formatter