### PR TITLE
Split PyPI publish from Windows nuitka binary into parallel jobs

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,8 +2,28 @@ on:
   push:
     tags:
       - 'v*'
+
 jobs:
+  pypi:
+    name: Publish wheel to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install hatch
+        run: pip install -r requirements.txt
+      - name: Publish wheel
+        run: make publish
+        env:
+          HATCH_INDEX_AUTH: ${{ secrets.HATCH_INDEX_AUTH }}
+          HATCH_INDEX_USER: ${{ secrets.HATCH_INDEX_USER }}
+          VERSION: ${{ github.ref_name }}
+
   binaries:
+    name: Build Windows binary and create GitHub release
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -13,10 +33,8 @@ jobs:
           python-version: '3.12'
       - name: Install hatch
         run: pip install -r requirements.txt
-      - name: Make release
-        run: make release
+      - name: Build binary and publish release
+        run: make binary-release
         env:
-          HATCH_INDEX_AUTH: ${{ secrets.HATCH_INDEX_AUTH }}
-          HATCH_INDEX_USER: ${{ secrets.HATCH_INDEX_USER }}
           VERSION: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ publish: wheels ## Publish wheels on pypi
 release: publish binary ## Builds a windows binary and creates a release
 	$(Q) gh release create $(VERSION) --generate-notes a816.zip
 
+.PHONY: binary-release
+binary-release: binary ## Builds the windows binary and attaches it to an existing GH release (or creates one)
+	$(Q) gh release create $(VERSION) --generate-notes a816.zip || gh release upload $(VERSION) a816.zip --clobber
+
 .PHONY: help
 help: ## Display help
 	@grep -hE '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
\`make release\` previously ran on \`windows-latest\` and did everything: build the wheel, push to PyPI, build the Nuitka binary, create the GH release. That meant the wheel publish was blocked behind the slow Windows pipeline (~4 min) and ran on the wrong OS for the cheap part.

## Changes

- \`pypi\` job on \`ubuntu-latest\` runs \`make publish\` (wheel build + \`hatch publish\`).
- \`binaries\` job on \`windows-latest\` runs new \`make binary-release\` (Nuitka build + \`gh release create\` / \`upload\`).
- New Makefile target \`binary-release\` decoupled from the publish step. Falls back to \`gh release upload --clobber\` if the release already exists (re-run or other job got there first).

Both jobs run in parallel from the same \`v*\` tag push. PyPI release lands in seconds; the .exe attachment shows up when Windows finishes.

## Test plan
- [ ] Tag \`v1.1.0a9\` (or whatever next alpha is): wheel appears on PyPI within ~1 min, GH release with binary lands a few minutes later
- [ ] Re-running the binaries job alone (workflow_dispatch, future) doesn't break because of \`gh release upload --clobber\` fallback