### PR TITLE
Handle C-style block comments in formatter and LSP code-mask

### DIFF
--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -211,6 +211,12 @@ class A816Formatter:
 
     def _format_comment(self, ast: CommentAstNode) -> list[str]:
         comment = ast.comment.strip()
+        # C-style block comments emit verbatim (one output line per
+        # source line) so the closing `*/` keeps its position; the prior
+        # behavior turned `/* multi\nline */` into `; /* multi\nline */`
+        # which broke the second line.
+        if comment.startswith("/*") and comment.endswith("*/"):
+            return comment.splitlines()
         if not comment.startswith(";"):
             comment = f"; {comment}"
         return [comment]

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -786,12 +786,26 @@ class WorkspaceIndex:
 
 @dataclass
 class _MaskState:
-    """Cross-line scanner state for `_build_code_mask`. Only the
-    triple-quoted-string flag survives a newline; single-quoted strings
-    don't span lines in a816 syntax.
+    """Cross-line scanner state for `_build_code_mask`. The
+    triple-quoted-string flag and the C-style block-comment flag both
+    survive a newline; single-quoted strings don't span lines in a816
+    syntax.
     """
 
     in_triple: str | None = None
+    in_block_comment: bool = False
+
+
+def _consume_block_comment(raw: str, i: int, mask: list[bool], state: _MaskState) -> int:
+    """Mask bytes inside a `/* ... */` block comment. Closes the block
+    on `*/`. Returns the new cursor position.
+    """
+    mask[i] = False
+    if i + 1 < len(raw) and raw[i] == "*" and raw[i + 1] == "/":
+        mask[i + 1] = False
+        state.in_block_comment = False
+        return i + 2
+    return i + 1
 
 
 def _consume_triple(raw: str, i: int, mask: list[bool], state: _MaskState) -> int:
@@ -828,6 +842,9 @@ def _mask_line(raw: str, state: _MaskState) -> list[bool]:
     i = 0
     in_string: str | None = None
     while i < len(raw):
+        if state.in_block_comment:
+            i = _consume_block_comment(raw, i, mask, state)
+            continue
         if state.in_triple is not None:
             i = _consume_triple(raw, i, mask, state)
             continue
@@ -839,6 +856,11 @@ def _mask_line(raw: str, state: _MaskState) -> list[bool]:
             for j in range(i, len(raw)):
                 mask[j] = False
             break
+        if raw[i : i + 2] == "/*":
+            state.in_block_comment = True
+            mask[i] = mask[i + 1] = False
+            i += 2
+            continue
         if raw[i : i + 3] in ('"""', "'''"):
             state.in_triple = raw[i : i + 3]
             mask[i] = mask[i + 1] = mask[i + 2] = False

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -834,9 +834,41 @@ def _consume_string(raw: str, i: int, mask: list[bool], in_string: str) -> tuple
     return i + 1, in_string
 
 
+def _consume_line_comment(raw: str, i: int, mask: list[bool]) -> int:
+    """Mask the rest of the line after a `;`. Returns a sentinel position
+    past the line end so `_mask_line`'s loop terminates.
+    """
+    for j in range(i, len(raw)):
+        mask[j] = False
+    return len(raw)
+
+
+def _open_region(raw: str, i: int, mask: list[bool], state: _MaskState) -> tuple[int, str | None]:
+    """Examine the current character and open a comment/string region
+    if one starts here. Returns `(new_i, in_string_delim)` where the
+    delimiter is non-None when a single-line string just opened.
+    """
+    ch = raw[i]
+    if ch == ";":
+        return _consume_line_comment(raw, i, mask), None
+    if raw[i : i + 2] == "/*":
+        state.in_block_comment = True
+        mask[i] = mask[i + 1] = False
+        return i + 2, None
+    if raw[i : i + 3] in ('"""', "'''"):
+        state.in_triple = raw[i : i + 3]
+        mask[i] = mask[i + 1] = mask[i + 2] = False
+        return i + 3, None
+    if ch in ('"', "'"):
+        mask[i] = False
+        return i + 1, ch
+    return i + 1, None
+
+
 def _mask_line(raw: str, state: _MaskState) -> list[bool]:
     """Build the code-mask for a single line, advancing `state` for
-    triple-quoted strings that may span multiple lines.
+    triple-quoted strings and `/* ... */` block comments that may span
+    multiple lines.
     """
     mask = [True] * len(raw)
     i = 0
@@ -851,27 +883,7 @@ def _mask_line(raw: str, state: _MaskState) -> list[bool]:
         if in_string is not None:
             i, in_string = _consume_string(raw, i, mask, in_string)
             continue
-        ch = raw[i]
-        if ch == ";":
-            for j in range(i, len(raw)):
-                mask[j] = False
-            break
-        if raw[i : i + 2] == "/*":
-            state.in_block_comment = True
-            mask[i] = mask[i + 1] = False
-            i += 2
-            continue
-        if raw[i : i + 3] in ('"""', "'''"):
-            state.in_triple = raw[i : i + 3]
-            mask[i] = mask[i + 1] = mask[i + 2] = False
-            i += 3
-            continue
-        if ch in ('"', "'"):
-            in_string = ch
-            mask[i] = False
-            i += 1
-            continue
-        i += 1
+        i, in_string = _open_region(raw, i, mask, state)
     return mask
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -756,3 +756,16 @@ _OkBk2:
         # All paragraph lines should have the same leading whitespace.
         leading = [len(line) - len(line.lstrip()) for line in para]
         assert len(set(leading)) == 1, f"Paragraph lines had mixed indents: {leading}"
+
+    def test_c_style_block_comment_preserved(self) -> None:
+        """`/* ... */` comments span multiple lines and must round-trip
+        verbatim — the formatter previously prefixed only the first line
+        with `;`, breaking the closing `*/` line."""
+        src = "/* multi\nline\ncomment */\nfoo:\n    rts\n"
+        formatted = self.formatter.format_text(src)
+        # No semicolon prefix, every line preserved.
+        assert "; /*" not in formatted
+        assert "/* multi" in formatted
+        assert "comment */" in formatted
+        # Idempotence: formatting again is a no-op.
+        assert self.formatter.format_text(formatted) == formatted

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -725,3 +725,34 @@ subroutine:
         # Comment line 2 and string line 3 must be excluded.
         for line, _ in ranges:
             self.assertNotIn(line, (2, 3))
+
+    def test_references_skip_block_comments(self) -> None:
+        """`/* foo */` and multi-line block comments must be excluded from
+        reference search like single-line `;` comments are.
+        """
+        from lsprotocol.types import ReferenceContext
+
+        content = (
+            "foo:\n"
+            "    rtl\n"
+            "/* foo in a single-line block comment */\n"
+            "/* multi\n"
+            "   line foo block\n"
+            "   comment */\n"
+            "    jsr foo\n"
+        )
+        doc = A816Document("test://refs.s", content)
+        self.server.documents[doc.uri] = doc
+        handler = self.server.server.lsp._get_handler("textDocument/references")  # type: ignore[no-untyped-call]
+        params = ReferenceParams(
+            text_document=TextDocumentIdentifier(uri=doc.uri),
+            position=Position(line=0, character=1),
+            context=ReferenceContext(include_declaration=True),
+        )
+        results = asyncio.run(handler(params))
+        ranges = [(loc.range.start.line, loc.range.start.character) for loc in results]
+        # Definition (line 0) and call site (line 6) only.
+        assert (0, 0) in ranges
+        assert (6, 8) in ranges
+        for line, _ in ranges:
+            assert line not in (2, 3, 4, 5), f"matched inside block comment line {line}"


### PR DESCRIPTION
a816 supports \`/* ... */\` block comments (scanner_states.py:355) which may span multiple source lines. Two consumers were broken:

## Formatter

\`A816Formatter._format_comment\` produced a single-line emit for the whole token: \`; /* multi\nline\ncomment */\` had \`;\` only on the first line, leaving \`line\` and \`comment */\` as bare lines the parser then choked on. Block comments now round-trip verbatim (one output line per source line) with no \`;\` prefix.

## LSP code-mask

The reference / rename search mask treated block-comment payloads as code, so a label name appearing inside \`/* ... */\` produced false rename hits and bogus go-to-references results. Track an \`in_block_comment\` flag on \`_MaskState\` that survives newlines alongside the existing triple-quoted-string flag.

## Tests

- Formatter: multi-line block comment round-trips identically; idempotent.
- LSP: reference search excludes single-line and multi-line block comment ranges.

\`hatch run tests:all\` green (619 passed, 1 skipped, 85% coverage).