### PR TITLE
Propagate .incbin auto-symbols + scope-qualified labels through .import

### DIFF
--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -483,6 +483,74 @@ def _extract_public_symbols_from_source(source_path: Path) -> list[str]:
     return symbols
 
 
+def _record_public_symbol(symbols: list[str], prefix: str, name: str) -> None:
+    """Append `prefix.name` (or just `name`) to `symbols` unless either
+    segment is private (underscore-prefixed) or the name is empty / a
+    duplicate of something already recorded.
+    """
+    if not name:
+        return
+    if name.startswith("_") or (prefix and prefix.startswith("_")):
+        return
+    full = f"{prefix}.{name}" if prefix else name
+    if full not in symbols:
+        symbols.append(full)
+
+
+def _emit_symbols_for_node(node: AstNode, prefix: str, symbols: list[str]) -> None:
+    """Record any public names introduced by a single AST node. Doesn't
+    descend into children — `_visit_for_public_symbols` handles recursion.
+    """
+    if isinstance(node, LabelAstNode):
+        _record_public_symbol(symbols, prefix, node.label)
+        return
+    if isinstance(node, SymbolAffectationAstNode | AssignAstNode):
+        _record_public_symbol(symbols, prefix, node.symbol)
+        return
+    if isinstance(node, IncludeBinaryAstNode):
+        base = node.file_path.replace("/", "_").replace(".", "_")
+        _record_public_symbol(symbols, prefix, base)
+        _record_public_symbol(symbols, prefix, f"{base}__size")
+
+
+def _visit_for_public_symbols(nodes: list[AstNode], prefix: str, symbols: list[str]) -> None:
+    """Walk `nodes`, emitting symbols and recursing into child containers.
+
+    `.scope name { ... }` opens a dotted prefix for its members; every
+    other node carries the current prefix down into `body` / `block` /
+    `else_block` / `included_nodes`.
+    """
+    from a816.parse.ast.nodes import BlockAstNode, CompoundAstNode, ScopeAstNode
+
+    for node in nodes:
+        if isinstance(node, ScopeAstNode):
+            inner = f"{prefix}.{node.name}" if prefix else node.name
+            body = node.body
+            if isinstance(body, BlockAstNode | CompoundAstNode):
+                _visit_for_public_symbols(body.body, inner, symbols)
+            continue
+
+        _emit_symbols_for_node(node, prefix, symbols)
+        _descend_into_children(node, prefix, symbols)
+
+
+def _descend_into_children(node: AstNode, prefix: str, symbols: list[str]) -> None:
+    """Recurse into the conventional container attributes carried by
+    block-like AST nodes, keeping the prefix intact.
+    """
+    from a816.parse.ast.nodes import BlockAstNode, CompoundAstNode
+
+    for attr in ("body", "block", "else_block"):
+        child = getattr(node, attr, None)
+        if isinstance(child, BlockAstNode | CompoundAstNode):
+            _visit_for_public_symbols(child.body, prefix, symbols)
+        elif isinstance(child, list):
+            _visit_for_public_symbols(child, prefix, symbols)
+    included = getattr(node, "included_nodes", None)
+    if isinstance(included, list):
+        _visit_for_public_symbols(included, prefix, symbols)
+
+
 def _collect_public_symbols(nodes: list[AstNode], symbols: list[str]) -> None:
     """Recursively collect public symbols from AST nodes.
 
@@ -499,57 +567,7 @@ def _collect_public_symbols(nodes: list[AstNode], symbols: list[str]) -> None:
     so `.import` consumers can resolve those bare names without an extra
     `.extern` declaration.
     """
-    from a816.parse.ast.nodes import (
-        BlockAstNode,
-        CompoundAstNode,
-        ScopeAstNode,
-    )
-
-    def _add(prefix: str, name: str) -> None:
-        if not name:
-            return
-        # Underscore privacy applies to the bare symbol; a label declared
-        # as `_foo` inside `scope` stays private even though the dotted
-        # form would be `scope._foo`.
-        if name.startswith("_") or (prefix and prefix.startswith("_")):
-            return
-        full = f"{prefix}.{name}" if prefix else name
-        if full not in symbols:
-            symbols.append(full)
-
-    def _visit(nodes_: list[AstNode], prefix: str) -> None:
-        for node in nodes_:
-            if isinstance(node, ScopeAstNode):
-                inner_prefix = f"{prefix}.{node.name}" if prefix else node.name
-                # Skip emitting the scope name itself — only the members
-                # of the block surface as `prefix.name.member`.
-                body = node.body
-                if isinstance(body, BlockAstNode | CompoundAstNode):
-                    _visit(body.body, inner_prefix)
-                continue
-
-            if isinstance(node, LabelAstNode):
-                _add(prefix, node.label)
-            elif isinstance(node, SymbolAffectationAstNode | AssignAstNode):
-                _add(prefix, node.symbol)
-            elif isinstance(node, IncludeBinaryAstNode):
-                base = node.file_path.replace("/", "_").replace(".", "_")
-                _add(prefix, base)
-                _add(prefix, f"{base}__size")
-
-            # Descend into the standard container attributes (body, block,
-            # else_block, included_nodes) carrying the same prefix.
-            for attr in ("body", "block", "else_block"):
-                child = getattr(node, attr, None)
-                if isinstance(child, BlockAstNode | CompoundAstNode):
-                    _visit(child.body, prefix)
-                elif isinstance(child, list):
-                    _visit(child, prefix)
-            included = getattr(node, "included_nodes", None)
-            if isinstance(included, list):
-                _visit(included, prefix)
-
-    _visit(nodes, "")
+    _visit_for_public_symbols(nodes, "", symbols)
 
 
 def generate_register_size(

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -488,18 +488,27 @@ def _collect_public_symbols(nodes: list[AstNode], symbols: list[str]) -> None:
 
     Public symbols don't start with underscore (_); underscored symbols are
     treated as module-private.
+
+    `.incbin "path"` registers the same auto-symbols `BinaryNode.pc_after`
+    creates at codegen time (`<sanitized_path>` and `<sanitized_path>__size`)
+    so `.import` consumers can resolve those bare names without an extra
+    `.extern` declaration.
     """
     from a816.parse.ast.visitor import walk
 
-    for node in walk(nodes):
-        name: str | None = None
-        if isinstance(node, LabelAstNode):
-            name = node.label
-        elif isinstance(node, SymbolAffectationAstNode | AssignAstNode):
-            name = node.symbol
-
-        if name is not None and not name.startswith("_") and name not in symbols:
+    def _add(name: str) -> None:
+        if name and not name.startswith("_") and name not in symbols:
             symbols.append(name)
+
+    for node in walk(nodes):
+        if isinstance(node, LabelAstNode):
+            _add(node.label)
+        elif isinstance(node, SymbolAffectationAstNode | AssignAstNode):
+            _add(node.symbol)
+        elif isinstance(node, IncludeBinaryAstNode):
+            base = node.file_path.replace("/", "_").replace(".", "_")
+            _add(base)
+            _add(f"{base}__size")
 
 
 def generate_register_size(

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -489,26 +489,67 @@ def _collect_public_symbols(nodes: list[AstNode], symbols: list[str]) -> None:
     Public symbols don't start with underscore (_); underscored symbols are
     treated as module-private.
 
+    Labels and equates declared inside a `.scope name { ... }` block are
+    surfaced with their dotted form (`name.label`) — the same way the
+    object emitter exports them — so `.import` consumers can resolve the
+    qualified names without re-declaring each as `.extern`.
+
     `.incbin "path"` registers the same auto-symbols `BinaryNode.pc_after`
     creates at codegen time (`<sanitized_path>` and `<sanitized_path>__size`)
     so `.import` consumers can resolve those bare names without an extra
     `.extern` declaration.
     """
-    from a816.parse.ast.visitor import walk
+    from a816.parse.ast.nodes import (
+        BlockAstNode,
+        CompoundAstNode,
+        ScopeAstNode,
+    )
 
-    def _add(name: str) -> None:
-        if name and not name.startswith("_") and name not in symbols:
-            symbols.append(name)
+    def _add(prefix: str, name: str) -> None:
+        if not name:
+            return
+        # Underscore privacy applies to the bare symbol; a label declared
+        # as `_foo` inside `scope` stays private even though the dotted
+        # form would be `scope._foo`.
+        if name.startswith("_") or (prefix and prefix.startswith("_")):
+            return
+        full = f"{prefix}.{name}" if prefix else name
+        if full not in symbols:
+            symbols.append(full)
 
-    for node in walk(nodes):
-        if isinstance(node, LabelAstNode):
-            _add(node.label)
-        elif isinstance(node, SymbolAffectationAstNode | AssignAstNode):
-            _add(node.symbol)
-        elif isinstance(node, IncludeBinaryAstNode):
-            base = node.file_path.replace("/", "_").replace(".", "_")
-            _add(base)
-            _add(f"{base}__size")
+    def _visit(nodes_: list[AstNode], prefix: str) -> None:
+        for node in nodes_:
+            if isinstance(node, ScopeAstNode):
+                inner_prefix = f"{prefix}.{node.name}" if prefix else node.name
+                # Skip emitting the scope name itself — only the members
+                # of the block surface as `prefix.name.member`.
+                body = node.body
+                if isinstance(body, BlockAstNode | CompoundAstNode):
+                    _visit(body.body, inner_prefix)
+                continue
+
+            if isinstance(node, LabelAstNode):
+                _add(prefix, node.label)
+            elif isinstance(node, SymbolAffectationAstNode | AssignAstNode):
+                _add(prefix, node.symbol)
+            elif isinstance(node, IncludeBinaryAstNode):
+                base = node.file_path.replace("/", "_").replace(".", "_")
+                _add(prefix, base)
+                _add(prefix, f"{base}__size")
+
+            # Descend into the standard container attributes (body, block,
+            # else_block, included_nodes) carrying the same prefix.
+            for attr in ("body", "block", "else_block"):
+                child = getattr(node, attr, None)
+                if isinstance(child, BlockAstNode | CompoundAstNode):
+                    _visit(child.body, prefix)
+                elif isinstance(child, list):
+                    _visit(child, prefix)
+            included = getattr(node, "included_nodes", None)
+            if isinstance(included, list):
+                _visit(included, prefix)
+
+    _visit(nodes, "")
 
 
 def generate_register_size(

--- a/tests/test_incbin_propagation.py
+++ b/tests/test_incbin_propagation.py
@@ -1,11 +1,13 @@
 """Tests for `.import` propagating .incbin auto-symbols."""
-import os
+
 from pathlib import Path
+
+import pytest
 
 from a816.parse.codegen import _extract_public_symbols_from_source
 
 
-def test_incbin_symbols_propagate_via_import(tmp_path, monkeypatch):
+def test_incbin_symbols_propagate_via_import(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Public .incbin auto-symbols (`<base>` and `<base>__size`) appear
     in the extracted public symbol list so an `.import`-er can resolve
     them as bare names without an extra `.extern`."""
@@ -18,7 +20,7 @@ def test_incbin_symbols_propagate_via_import(tmp_path, monkeypatch):
     assert "blob_dat__size" in syms, syms
 
 
-def test_incbin_underscore_path_stays_private(tmp_path, monkeypatch):
+def test_incbin_underscore_path_stays_private(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`.incbin "_priv.dat"` must NOT propagate — auto-symbol
     `_priv_dat` is underscore-prefixed → module-private."""
     monkeypatch.chdir(tmp_path)
@@ -30,7 +32,7 @@ def test_incbin_underscore_path_stays_private(tmp_path, monkeypatch):
     assert "_priv_dat__size" not in syms
 
 
-def test_incbin_alongside_label(tmp_path, monkeypatch):
+def test_incbin_alongside_label(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     Path("data.bin").write_bytes(b"x")
     src = tmp_path / "mod.s"
@@ -40,17 +42,12 @@ def test_incbin_alongside_label(tmp_path, monkeypatch):
     assert "data_bin" in syms
 
 
-def test_scope_members_emit_dotted_names(tmp_path, monkeypatch):
+def test_scope_members_emit_dotted_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`.scope foo { bar: ... }` exports `foo.bar` so importers don't
     need to re-declare each scoped label as `.extern`."""
     monkeypatch.chdir(tmp_path)
     src = tmp_path / "mod.s"
-    src.write_text(
-        ".scope render_allocator {\n"
-        "init: rts\n"
-        "increment: rts\n"
-        "}\n"
-    )
+    src.write_text(".scope render_allocator {\ninit: rts\nincrement: rts\n}\n")
     syms = _extract_public_symbols_from_source(src)
     assert "render_allocator.init" in syms
     assert "render_allocator.increment" in syms
@@ -59,17 +56,12 @@ def test_scope_members_emit_dotted_names(tmp_path, monkeypatch):
     assert "increment" not in syms
 
 
-def test_scope_with_underscore_label_stays_private(tmp_path, monkeypatch):
+def test_scope_with_underscore_label_stays_private(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Underscore-prefix on the label still hides it; `foo._helper` is
     still private even though the scope `foo` is public."""
     monkeypatch.chdir(tmp_path)
     src = tmp_path / "mod.s"
-    src.write_text(
-        ".scope foo {\n"
-        "public: rts\n"
-        "_helper: rts\n"
-        "}\n"
-    )
+    src.write_text(".scope foo {\npublic: rts\n_helper: rts\n}\n")
     syms = _extract_public_symbols_from_source(src)
     assert "foo.public" in syms
     assert "foo._helper" not in syms

--- a/tests/test_incbin_propagation.py
+++ b/tests/test_incbin_propagation.py
@@ -1,0 +1,40 @@
+"""Tests for `.import` propagating .incbin auto-symbols."""
+import os
+from pathlib import Path
+
+from a816.parse.codegen import _extract_public_symbols_from_source
+
+
+def test_incbin_symbols_propagate_via_import(tmp_path, monkeypatch):
+    """Public .incbin auto-symbols (`<base>` and `<base>__size`) appear
+    in the extracted public symbol list so an `.import`-er can resolve
+    them as bare names without an extra `.extern`."""
+    monkeypatch.chdir(tmp_path)
+    Path("blob.dat").write_bytes(b"\x00\x01\x02\x03")
+    src = tmp_path / "mod.s"
+    src.write_text('.incbin "blob.dat"\n')
+    syms = _extract_public_symbols_from_source(src)
+    assert "blob_dat" in syms, syms
+    assert "blob_dat__size" in syms, syms
+
+
+def test_incbin_underscore_path_stays_private(tmp_path, monkeypatch):
+    """`.incbin "_priv.dat"` must NOT propagate — auto-symbol
+    `_priv_dat` is underscore-prefixed → module-private."""
+    monkeypatch.chdir(tmp_path)
+    Path("_priv.dat").write_bytes(b"\x00")
+    src = tmp_path / "mod.s"
+    src.write_text('.incbin "_priv.dat"\n')
+    syms = _extract_public_symbols_from_source(src)
+    assert "_priv_dat" not in syms
+    assert "_priv_dat__size" not in syms
+
+
+def test_incbin_alongside_label(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    Path("data.bin").write_bytes(b"x")
+    src = tmp_path / "mod.s"
+    src.write_text('foo:\n    rts\n.incbin "data.bin"\n')
+    syms = _extract_public_symbols_from_source(src)
+    assert "foo" in syms
+    assert "data_bin" in syms

--- a/tests/test_incbin_propagation.py
+++ b/tests/test_incbin_propagation.py
@@ -38,3 +38,38 @@ def test_incbin_alongside_label(tmp_path, monkeypatch):
     syms = _extract_public_symbols_from_source(src)
     assert "foo" in syms
     assert "data_bin" in syms
+
+
+def test_scope_members_emit_dotted_names(tmp_path, monkeypatch):
+    """`.scope foo { bar: ... }` exports `foo.bar` so importers don't
+    need to re-declare each scoped label as `.extern`."""
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "mod.s"
+    src.write_text(
+        ".scope render_allocator {\n"
+        "init: rts\n"
+        "increment: rts\n"
+        "}\n"
+    )
+    syms = _extract_public_symbols_from_source(src)
+    assert "render_allocator.init" in syms
+    assert "render_allocator.increment" in syms
+    # Bare names should not leak — only the qualified form is public.
+    assert "init" not in syms
+    assert "increment" not in syms
+
+
+def test_scope_with_underscore_label_stays_private(tmp_path, monkeypatch):
+    """Underscore-prefix on the label still hides it; `foo._helper` is
+    still private even though the scope `foo` is public."""
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "mod.s"
+    src.write_text(
+        ".scope foo {\n"
+        "public: rts\n"
+        "_helper: rts\n"
+        "}\n"
+    )
+    syms = _extract_public_symbols_from_source(src)
+    assert "foo.public" in syms
+    assert "foo._helper" not in syms


### PR DESCRIPTION
## Summary

Two small, decoupled patches that make \`.import\" surface the symbols a downstream module would otherwise have to re-declare with \`.extern\".

### 1. \`.incbin\" auto-symbols
\`BinaryNode.pc_after\" registers \`<sanitized_path>\" and
\`<sanitized_path>__size\" at codegen time, so \`.incbin \"assets/items.dat\"\`
produces \`assets_items_dat\" / \`assets_items_dat__size\". Until now the
public-symbol extractor used by \`.import\" only walked label and equate AST
nodes, so importers of asset-style modules had to re-declare every blob as
\`.extern\".

Extend \`_collect_public_symbols\` to also visit \`IncludeBinaryAstNode\` and
emit the same two derived names. Underscore-prefix privacy still applies:
\`.incbin \"_priv.dat\"\` stays module-private.

### 2. Scope-qualified labels
Labels and equates inside \`.scope name { ... }\` already ship as
\`name.label\` GLOBAL symbols in the .o emit path, so \`_import_from_object\`
exposes them to consumers. The source-extraction path was flat-walking and
emitting bare names. Make the walker tree-shape-aware so a label inside a
\`ScopeAstNode\` surfaces as \`scope.label\`, matching the object emitter.
Underscore privacy applies per-segment: \`scope._helper\` is still private.

## Impact on downstream
In ff4-modules these two changes eliminate ~20 cross-module \`.extern\` lines
across vwf.s, dialog.s, intro.s, battle/sram.s, small_vwf/init.s with no
linker changes needed.

## Test plan
- [x] \`pytest tests/test_incbin_propagation.py\` — new tests cover both directions (public propagates, underscore stays private, dotted scope members surface, dotted-private labels stay private)
- [x] Full \`pytest -q\` — 624 pass, no regressions
- [x] ff4-modules end-to-end build with editable install: build clean, 98 pytest pass

## Out of scope
- Hard link error on duplicate bare-name exports (separate PR; logical follow-up but the kerning collision class needs broader linker changes).