### PR TITLE
Add cld / cli / clv to the assembler opcode table

### DIFF
--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -321,6 +321,9 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
     "cop": {AddressingMode.immediate: Opcode([0x02])},
     "wdm": {AddressingMode.immediate: Opcode([0x42])},
     "clc": {AddressingMode.none: OpcodeWithoutOperand(0x18)},
+    "cld": {AddressingMode.none: OpcodeWithoutOperand(0xD8)},
+    "cli": {AddressingMode.none: OpcodeWithoutOperand(0x58)},
+    "clv": {AddressingMode.none: OpcodeWithoutOperand(0xB8)},
     "cmp": {
         AddressingMode.immediate: Opcode([0xC9, 0xC9], is_a=True),
         AddressingMode.direct: Opcode([0xC5, 0xCD, 0xCF], is_a=True),

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -266,3 +266,12 @@ class EmitTest(unittest.TestCase):
         program.emit(nodes, writer)
 
         self.assertEqual(writer.data[0], b"Final Fantasy VI    ")
+
+    def test_clear_flag_implied_opcodes(self) -> None:
+        """`cld`, `cli`, `clv` are 1-byte implied instructions matching the
+        symmetric set-flag ops (`sed`, `sei`)."""
+        program = Program()
+        writer = StubWriter()
+        program.assemble_string_with_emitter("clc\ncld\ncli\nclv\n", "test_clear_flags", writer)
+        # clc=0x18, cld=0xD8, cli=0x58, clv=0xB8
+        self.assertEqual(writer.data[0], b"\x18\xd8\x58\xb8")


### PR DESCRIPTION
The disassembler already decoded these one-byte implied instructions (disassembler.py:272-274), but the assembler side was missing the symmetric entries — so source containing \`cld\` / \`cli\` / \`clv\` errored out as unknown opcodes even though the set-flag pair (\`sed\` / \`sei\`) compiled fine.

| Mnemonic | Opcode | Effect |
|----------|--------|--------|
| \`cld\` | 0xD8 | clear decimal flag |
| \`cli\` | 0x58 | clear interrupt-disable flag |
| \`clv\` | 0xB8 | clear overflow flag |

## Test plan
- [x] \`hatch run tests:all\` (625 passed, 1 skipped, 85% coverage)
- [x] New \`test_clear_flag_implied_opcodes\` asserts \`clc cld cli clv\` emits \`\\x18\\xd8\\x58\\xb8\`