### PR TITLE
Promote macro / scope labels to NamedScope parents

### DIFF
--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -120,7 +120,10 @@ def generate_scope(
 
     code += _code_gen(node.body.body, resolver, macro_definitions)
     code.append(PopScopeNode(resolver))
-    resolver.restore_scope(exports=False)
+    # Promote `name.label` and `name.symbol` to the parent so callers can
+    # `jsr.l ns.init` after `.scope ns { init: ... }`. Underscore-prefixed
+    # names stay private (see Resolver.restore_scope filter).
+    resolver.restore_scope(exports=True)
     return code
 
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -20,6 +20,33 @@ def _is_exportable(name: str) -> bool:
     return not name.startswith("_") or name.startswith("__")
 
 
+def _bubble_anon_into_named(scope: "Scope", parent: "NamedScope") -> None:
+    """Surface labels/symbols from an anonymous scope into its NamedScope parent.
+
+    A macro's arg-binding scope (or a plain `{ }` block) is anonymous, so
+    its labels would be discarded on restore. When such a scope sits inside
+    a NamedScope, we copy the exportable names up so the next
+    NamedScope.restore_scope(exports=True) publishes them as `Name.label`.
+    """
+    for label_name, label_value in scope.labels.items():
+        if _is_exportable(label_name) and label_name not in parent.labels:
+            parent.labels[label_name] = label_value
+    for sym_name, sym_value in scope.symbols.items():
+        if _is_exportable(sym_name) and sym_name not in parent.symbols:
+            parent.symbols[sym_name] = sym_value
+
+
+def _publish_named_dotted(scope: "NamedScope", parent: "Scope") -> None:
+    """Promote `Name.label` and `Name.symbol` into the parent scope.
+
+    Both labels and symbols carry the dotted prefix so the object writer
+    can distinguish CODE labels (need link-time rebasing) from DATA
+    constants without re-walking scopes.
+    """
+    parent.symbols |= {f"{scope.name}.{k}": v for k, v in scope.symbols.items() if _is_exportable(k)}
+    parent.labels |= {f"{scope.name}.{k}": v for k, v in scope.labels.items() if _is_exportable(k)}
+
+
 logger = logging.getLogger("a816")
 
 
@@ -251,25 +278,10 @@ class Resolver:
         if parent is None:
             raise RuntimeError("Current scope has no parent...")
 
-        # An anonymous scope (e.g. a macro's arg-binding scope or a `{ }`
-        # block) inside a NamedScope must surface its labels and symbols to
-        # the NamedScope so the next NamedScope.restore_scope(exports=True)
-        # can publish them as `Name.label`. Underscore-prefixed names stay
-        # private (mirrors the object-mode export rule).
         if not isinstance(scope, NamedScope) and isinstance(parent, NamedScope):
-            for label_name, label_value in scope.labels.items():
-                if _is_exportable(label_name) and label_name not in parent.labels:
-                    parent.labels[label_name] = label_value
-            for sym_name, sym_value in scope.symbols.items():
-                if _is_exportable(sym_name) and sym_name not in parent.symbols:
-                    parent.symbols[sym_name] = sym_value
-
+            _bubble_anon_into_named(scope, parent)
         if exports and isinstance(scope, NamedScope):
-            parent.symbols |= {f"{scope.name}.{k}": v for k, v in scope.symbols.items() if _is_exportable(k)}
-            # Propagate label-ness too so the object writer can tell that
-            # `scope.name` refers to a CODE address (and therefore needs
-            # rebasing at link time) instead of a DATA constant.
-            parent.labels |= {f"{scope.name}.{k}": v for k, v in scope.labels.items() if _is_exportable(k)}
+            _publish_named_dotted(scope, parent)
 
         self.current_scope = parent
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -9,6 +9,17 @@ from a816.exceptions import ExternalSymbolReference, SymbolNotDefined
 from a816.parse.ast.nodes import BlockAstNode
 from script import Table
 
+
+def _is_exportable(name: str) -> bool:
+    """Names with a single leading underscore are private to their scope.
+
+    Mirrors the object-mode export rule: `_helper` stays local, `helper`
+    promotes, and dunder names like `__size` (struct size symbol) keep
+    promoting because they're system-injected, not user-private.
+    """
+    return not name.startswith("_") or name.startswith("__")
+
+
 logger = logging.getLogger("a816")
 
 
@@ -235,18 +246,32 @@ class Resolver:
         self.current_scope = self.scopes[self.last_used_scope]
 
     def restore_scope(self, exports: bool = False) -> None:
-        if exports and isinstance(self.current_scope, NamedScope):
-            scope = self.current_scope
-            if scope.parent is not None:
-                scope.parent.symbols |= {f"{scope.name}.{k}": v for k, v in scope.symbols.items()}
-                # Propagate label-ness too so the object writer can tell that
-                # `scope.name` refers to a CODE address (and therefore needs
-                # rebasing at link time) instead of a DATA constant.
-                scope.parent.labels |= {f"{scope.name}.{k}": v for k, v in scope.labels.items()}
-        if self.current_scope.parent is not None:
-            self.current_scope = self.current_scope.parent
-        else:
+        scope = self.current_scope
+        parent = scope.parent
+        if parent is None:
             raise RuntimeError("Current scope has no parent...")
+
+        # An anonymous scope (e.g. a macro's arg-binding scope or a `{ }`
+        # block) inside a NamedScope must surface its labels and symbols to
+        # the NamedScope so the next NamedScope.restore_scope(exports=True)
+        # can publish them as `Name.label`. Underscore-prefixed names stay
+        # private (mirrors the object-mode export rule).
+        if not isinstance(scope, NamedScope) and isinstance(parent, NamedScope):
+            for label_name, label_value in scope.labels.items():
+                if _is_exportable(label_name) and label_name not in parent.labels:
+                    parent.labels[label_name] = label_value
+            for sym_name, sym_value in scope.symbols.items():
+                if _is_exportable(sym_name) and sym_name not in parent.symbols:
+                    parent.symbols[sym_name] = sym_value
+
+        if exports and isinstance(scope, NamedScope):
+            parent.symbols |= {f"{scope.name}.{k}": v for k, v in scope.symbols.items() if _is_exportable(k)}
+            # Propagate label-ness too so the object writer can tell that
+            # `scope.name` refers to a CODE address (and therefore needs
+            # rebasing at link time) instead of a DATA constant.
+            parent.labels |= {f"{scope.name}.{k}": v for k, v in scope.labels.items() if _is_exportable(k)}
+
+        self.current_scope = parent
 
     def _dump_symbols(self, symbols: dict[str, Any]) -> None:
         keys = sorted(symbols.keys())

--- a/tests/test_scope_export.py
+++ b/tests/test_scope_export.py
@@ -1,0 +1,112 @@
+"""Promote macro and scope labels to a NamedScope parent."""
+
+from __future__ import annotations
+
+from a816.program import Program
+
+
+def _resolved(source: str) -> Program:
+    program = Program()
+    error, nodes = program.parser.parse(source)
+    assert error is None, error
+    program.resolve_labels(nodes)
+    return program
+
+
+def _public_symbols(program: Program) -> dict[str, int | str]:
+    """What the root scope sees — what callers can resolve."""
+    root = program.resolver.scopes[0]
+    flat: dict[str, int | str] = {}
+    flat.update(root.symbols)
+    flat.update(root.labels)
+    return flat
+
+
+def test_scope_promotes_labels_to_dotted_names() -> None:
+    program = _resolved(
+        """
+        *=0x008000
+        .scope inventory {
+        init:
+            rts
+        render:
+            rts
+        }
+        """
+    )
+    public = _public_symbols(program)
+    assert "inventory.init" in public
+    assert "inventory.render" in public
+
+
+def test_scope_skips_underscore_prefixed_names() -> None:
+    program = _resolved(
+        """
+        *=0x008000
+        .scope inventory {
+        public_entry:
+            rts
+        _helper:
+            rts
+        }
+        """
+    )
+    public = _public_symbols(program)
+    assert "inventory.public_entry" in public
+    assert "inventory._helper" not in public
+    assert "inventory.__size" not in public  # struct-only convention
+
+
+def test_scope_keeps_dunder_names() -> None:
+    """Struct-style `__size` exports must still pass the underscore filter."""
+    program = _resolved(
+        """
+        .struct OAM {
+            byte a
+            byte b
+        }
+        """
+    )
+    public = _public_symbols(program)
+    assert public["OAM.__size"] == 2
+
+
+def test_macro_inside_scope_publishes_labels() -> None:
+    program = _resolved(
+        """
+        .macro engine() {
+        init:
+            rts
+        render:
+            rts
+        _local:
+            rts
+        }
+        *=0x008000
+        .scope inventory {
+            engine()
+        }
+        """
+    )
+    public = _public_symbols(program)
+    assert "inventory.init" in public
+    assert "inventory.render" in public
+    assert "inventory._local" not in public
+
+
+def test_macro_outside_scope_does_not_leak() -> None:
+    """Bare `engine()` calls keep labels private (no NamedScope to bubble to)."""
+    program = _resolved(
+        """
+        .macro engine() {
+        init:
+            rts
+        }
+        *=0x008000
+        engine()
+        """
+    )
+    public = _public_symbols(program)
+    # Labels stay buried in the anon arg-binding scope when there's no
+    # NamedScope wrapping the call site.
+    assert "init" not in public


### PR DESCRIPTION
## Summary

- \`.scope NAME { ... }\` now promotes its labels and symbols to the parent as \`NAME.label\` / \`NAME.symbol\` (was previously a no-op for anything but assignments inside the body).
- Macro calls inside a \`.scope NAME { ... }\` bubble their labels up through the macro's anonymous arg-binding scope into the surrounding NamedScope, so \`engine()\`-emitted labels become \`NAME.engine_label\`.
- Names starting with a single underscore stay private; dunder names like \`.struct\`'s \`__size\` keep exporting.

## Why

Lets the maintainer collapse near-identical engine files (inventory_rolling.s, treasure_rolling.s, …) into one \`.macro engine(args) { … }\` and instantiate per profile:

\`\`\`ca65
.scope inventory {
    engine(state_base, hdma_ch, item_count, bg)
}

jsr.l inventory.init
\`\`\`

Today macro-local labels are unreachable from callers; this PR closes that gap with the smallest semantic change (option A from the discussion: extend the existing NamedScope export path).

## Test plan

- [x] \`hatch run tests:tests tests/test_scope_export.py -v\` — 5 new tests pass (scope dotted promotion, underscore filter, dunder pass-through, macro-inside-scope publish, bare macro stays private).
- [x] \`hatch run tests:all\` — 630 pass, 1 skipped, mypy + ruff clean.

## Future work (separate PR)

- \`.export label\` directive for fine-grained per-label promote when a project needs it.
- Repeated macro invocations inside the same \`.scope\` currently win on first definition; later invocations of the same macro emit their own labels but only the first reaches the parent. Needs a different strategy (mangling or per-call sub-scope) for that case.