### PR TITLE
Mangle underscore labels per nested scope so repeated macro calls keep distinct addresses

### DIFF
--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -56,8 +56,8 @@ class ExpressionNode(ValueNodeProtocol):
             if owner is None:
                 continue
             touches_label = True
-            if owner is self.resolver.scopes[0] or tok.value.startswith("_"):
-                continue
+            if owner is self.resolver.scopes[0]:
+                continue  # root labels keep their plain name; only nested-scope refs need mangling
             scope_idx = self.resolver.scopes.index(owner)
             rename[tok.value] = f"__sc{scope_idx}__{tok.value}"
         return rename, touches_label

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -16,7 +16,12 @@ def _is_exportable(name: str) -> bool:
     Mirrors the object-mode export rule: `_helper` stays local, `helper`
     promotes, and dunder names like `__size` (struct size symbol) keep
     promoting because they're system-injected, not user-private.
+    The `__sc<idx>__` prefix is the codegen's internal scope-isolation
+    mangling — purely scaffolding and must stay private even though it
+    starts with double underscore.
     """
+    if name.startswith("__sc"):
+        return False
     return not name.startswith("_") or name.startswith("__")
 
 
@@ -319,14 +324,17 @@ class Resolver:
                 continue
             mangle = mangle_nested and idx > 0 and not isinstance(scope, NamedScope)
             for name, value in scope.get_labels():
-                exported = f"__sc{idx}__{name}" if mangle and not name.startswith("_") else name
+                exported = f"__sc{idx}__{name}" if mangle else name
                 labels.append((exported, value))
         return labels
 
     @staticmethod
     def _mangle(name: str, idx: int, mangle: bool) -> str:
-        # Names starting with `_` are explicitly local; keep their short form.
-        return f"__sc{idx}__{name}" if mangle and not name.startswith("_") else name
+        # Every nested anonymous scope's labels get a unique prefix so
+        # repeated macro invocations don't collide on the same name —
+        # underscore-prefixed names included (they are private to the
+        # *invocation*, which still needs distinct addresses across calls).
+        return f"__sc{idx}__{name}" if mangle else name
 
     def _scope_int_symbols(self, scope: "Scope") -> list[tuple[str, int]]:
         return [(name, value) for name, value in scope.symbols.items() if isinstance(value, int)]

--- a/tests/test_macro_underscore_label_isolation.py
+++ b/tests/test_macro_underscore_label_isolation.py
@@ -1,0 +1,89 @@
+"""Regression test: underscore-prefixed labels inside repeated macro invocations
+must each resolve to a distinct address. Earlier `_label` skipped per-scope
+mangling, so PEA-style operands (`pea.w _return_addr - 1`) collapsed every
+invocation onto the first one's address."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from a816.object_file import ObjectFile
+from a816.program import Program
+
+
+def _pea_operands(data: bytes) -> list[int]:
+    operands: list[int] = []
+    idx = 0
+    while True:
+        i = data.find(b"\xf4", idx)
+        if i < 0 or i + 3 > len(data):
+            return operands
+        operands.append(data[i + 1] | (data[i + 2] << 8))
+        idx = i + 1
+
+
+def test_underscore_label_distinct_per_macro_invocation_in_ips() -> None:
+    src = """
+.macro callee_with_return(arg) {
+    pea.w _return_addr - 1
+    pea.w arg
+    jmp.w some_target
+_return_addr:
+    rts
+}
+
+*=0x008000
+some_target:
+    rts
+
+start:
+    callee_with_return(0x1111)
+    callee_with_return(0x2222)
+    callee_with_return(0x3333)
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "main.s"
+        asm.write_text(src)
+        ips = Path(tmp) / "out.ips"
+        rc = Program().assemble_as_patch(str(asm), ips)
+        assert rc == 0
+        operands = _pea_operands(ips.read_bytes())
+        # Three return-address PEAs and three arg PEAs; return addresses differ.
+        return_pea_values = [v for i, v in enumerate(operands) if i % 2 == 0]
+        assert len(set(return_pea_values)) == 3, return_pea_values
+
+
+def test_underscore_label_distinct_per_macro_invocation_in_object_file() -> None:
+    """Object-file path must record distinct symbols and per-call relocations."""
+    src = """
+.macro callee_with_return(arg) {
+    pea.w _return_addr - 1
+    pea.w arg
+    jmp.w some_target
+_return_addr:
+    rts
+}
+
+*=0x008000
+some_target:
+    rts
+
+start:
+    callee_with_return(0x1111)
+    callee_with_return(0x2222)
+    callee_with_return(0x3333)
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "main.s"
+        asm.write_text(src)
+        obj = Path(tmp) / "main.o"
+        rc = Program().assemble_as_object(str(asm), obj)
+        assert rc == 0
+        loaded = ObjectFile.from_file(str(obj))
+        return_addrs = [(name, addr) for name, addr, _t, _s in loaded.symbols if name.endswith("_return_addr")]
+        assert len(return_addrs) == 3, return_addrs
+        # Each invocation should produce its own mangled relocation expression.
+        return_relocs = [expr for _offset, expr, _size in loaded.expression_relocations if "_return_addr" in expr]
+        assert len(return_relocs) == 3
+        assert len(set(return_relocs)) == 3, return_relocs

--- a/tests/test_object_file.py
+++ b/tests/test_object_file.py
@@ -158,10 +158,14 @@ second_label:
     obj = ObjectFile.from_file(str(obj_file))
     by_name = {name: address for name, address, _, _ in obj.symbols}
     assert "first_label" in by_name
-    assert "_inner_label" in by_name
+    # Anonymous-block labels are mangled with __sc<idx>__ so repeated
+    # blocks (or repeated macro invocations) keep distinct addresses.
+    inner_keys = [k for k in by_name if k.endswith("_inner_label")]
+    assert len(inner_keys) == 1, f"expected one mangled _inner_label, got {inner_keys}"
+    inner = inner_keys[0]
     assert "second_label" in by_name
     # Labels are 3 bytes apart (lda #imm = 2 + rts = 1).
-    assert by_name["_inner_label"] - by_name["first_label"] == 3
+    assert by_name[inner] - by_name["first_label"] == 3
     assert by_name["second_label"] - by_name["first_label"] == 6
 
 
@@ -195,8 +199,16 @@ final:
     obj = ObjectFile.from_file(str(obj_file))
     by_name = {name: address for name, address, _, _ in obj.symbols}
     base = by_name["outer"]
-    # nop = 1 byte; consecutive labels are one byte apart.
-    assert by_name["_level1"] - base == 1
-    assert by_name["_level2"] - base == 2
-    assert by_name["_after_nested"] - base == 3
+
+    def find_one(suffix: str) -> int:
+        keys = [k for k in by_name if k.endswith(suffix)]
+        assert len(keys) == 1, f"expected one mangled {suffix}, got {keys}"
+        return by_name[keys[0]]
+
+    # nop = 1 byte; consecutive labels are one byte apart. Underscore-prefixed
+    # nested-scope labels are mangled with __sc<idx>__ to keep repeated
+    # invocations / blocks distinct.
+    assert find_one("_level1") - base == 1
+    assert find_one("_level2") - base == 2
+    assert find_one("_after_nested") - base == 3
     assert by_name["final"] - base == 4


### PR DESCRIPTION
## Summary

- Underscore-prefixed labels in nested anonymous scopes (\`_return_addr\` inside a macro body) now get the same \`__sc<idx>__\` mangling as other nested labels.
- Object file output records one entry per invocation; expression relocations (\`pea.w _return_addr - 1\`) resolve per-call instead of collapsing onto the first call.
- \`_is_exportable\` rejects \`__sc\`-prefixed names so internal scope-isolation scaffolding stays private.

## Why

Reported by ff4-modules (libmz \`dma_transfer_to_vram_call\` / \`dma_transfer_to_palette_call\`): three sequential invocations all returned to the same address, derailing intro splash. Root cause: the nested-scope mangling carved out \`_\`-prefixed names — so multiple anon scopes registered the same bare \`_return_addr\` and the link-time relocation resolved to the last one.

Branch refs (\`bne\`/\`bra\`) worked because they're resolved per-pass before the symbol table is exported. Expression operands (\`pea.w _return_addr - 1\`) emit deferred relocations that re-evaluate at link time against the (single, shared) symbol table.

## Fix

- \`Resolver.get_all_labels\` and \`Resolver._mangle\`: drop the \`not name.startswith("_")\` carve-out; mangle every nested-scope label.
- \`ExpressionNode._compute_local_label_renames\`: same — emit \`__sc<idx>__\` rename for every nested label, not only non-underscore ones.
- \`_is_exportable\`: still rejects \`_\`-prefixed names; additionally rejects the \`__sc\` mangled prefix so the scaffolding stays out of \`.scope\` exports.

## Test plan

- [x] \`tests/test_macro_underscore_label_isolation.py\` — IPS + object-mode regression: three \`callee_with_return\` invocations produce three distinct return-addr operands and three relocations.
- [x] \`tests/test_object_file.py\` — updated existing tests that asserted bare \`_inner_label\` symbols; they now look up the mangled form.
- [x] \`hatch run tests:all\` — 632 pass, 1 skipped, mypy + ruff clean.