### PR TITLE
Add a816 fluff check with DOC001 / DOC002 docstring lints

### DIFF
--- a/a816/fluff.py
+++ b/a816/fluff.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 from a816.exceptions import FormattingError
+from a816.fluff_lint import lint_file
 from a816.formatter import A816Formatter
 
 SOURCE_SUFFIXES = {".s", ".i"}
@@ -45,8 +46,15 @@ def _colorize_diff(diff_lines: Iterable[str]) -> str:
 
 
 def _build_fluff_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="a816 fluff", description="Format a816 assembly sources.")
+    parser = argparse.ArgumentParser(prog="a816 fluff", description="Format and lint a816 assembly sources.")
     subparsers = parser.add_subparsers(dest="command", required=True)
+    check_parser = subparsers.add_parser("check", help="Run docstring-coverage lints (DOC001 / DOC002).")
+    check_parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Files or directories to lint. Directories are walked for .s / .i sources.",
+    )
     format_parser = subparsers.add_parser("format", help="Format .s/.i sources under the given path.")
     format_parser.add_argument(
         "paths",
@@ -209,11 +217,28 @@ def _run_format(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     return _write_formatted(computed) or missing_err
 
 
+def _run_check(args: argparse.Namespace) -> int:
+    sources, missing_err = _collect_sources(list(args.paths))
+    if not sources:
+        return missing_err
+    total = 0
+    for source in sources:
+        for diag in lint_file(source):
+            print(diag.format())
+            total += 1
+    if total:
+        print(f"{total} lint hit(s).", file=sys.stderr)
+        return missing_err or 1
+    return missing_err
+
+
 def fluff_main(argv: Sequence[str] | None = None) -> int:
     parser = _build_fluff_parser()
     args = parser.parse_args(argv)
     if args.command == "format":
         return _run_format(args, parser)
+    if args.command == "check":
+        return _run_check(args)
     parser.error("Unknown command")
     return 2  # parser.error never returns, but mypy needs this
 

--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -1,0 +1,130 @@
+"""Docstring-coverage lint rules for `a816 fluff check`.
+
+Rules:
+- DOC001 — every source file should open with a leading docstring describing
+  what the module is for.
+- DOC002 — every public top-level macro, scope, or label should be documented.
+  Names starting with a single underscore are considered private and skipped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from a816.parse.ast.nodes import (
+    AstNode,
+    CommentAstNode,
+    DocstringAstNode,
+    LabelAstNode,
+    MacroAstNode,
+    ScopeAstNode,
+)
+from a816.parse.mzparser import MZParser
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One lint hit. `path:line:col code message`, ruff-style."""
+
+    path: Path
+    line: int  # 1-based for human output
+    column: int  # 1-based
+    code: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}:{self.column} {self.code} {self.message}"
+
+
+def _is_public(name: str) -> bool:
+    return not name.startswith("_")
+
+
+def _node_position(node: AstNode) -> tuple[int, int]:
+    pos = getattr(node.file_info, "position", None)
+    if pos is None:
+        return 1, 1
+    return pos.line + 1, pos.column + 1
+
+
+def _check_module_docstring(path: Path, nodes: list[AstNode]) -> Diagnostic | None:
+    """DOC001: first non-comment top-level node must be a docstring."""
+    for node in nodes:
+        if isinstance(node, CommentAstNode):
+            continue
+        if isinstance(node, DocstringAstNode):
+            return None
+        return Diagnostic(
+            path=path,
+            line=1,
+            column=1,
+            code="DOC001",
+            message="module is missing a leading docstring",
+        )
+    # Empty file: skip — nothing to document.
+    return None
+
+
+def _kind_label(node: AstNode) -> str:
+    if isinstance(node, MacroAstNode):
+        return "macro"
+    if isinstance(node, ScopeAstNode):
+        return "scope"
+    if isinstance(node, LabelAstNode):
+        return "label"
+    return "symbol"
+
+
+def _check_public_docstrings(path: Path, nodes: list[AstNode]) -> list[Diagnostic]:
+    """DOC002: each public macro/scope/label needs an attached docstring.
+
+    The leading file docstring (DOC001's target) is consumed as the module
+    description and does not count as a macro/scope/label's docstring.
+    """
+    hits: list[Diagnostic] = []
+    pending_doc = False
+    module_doc_consumed = False
+    for node in nodes:
+        if isinstance(node, CommentAstNode):
+            continue
+        if isinstance(node, DocstringAstNode):
+            if not module_doc_consumed:
+                module_doc_consumed = True
+                continue
+            pending_doc = True
+            continue
+        # Any non-comment node implies the module-doc slot is closed.
+        module_doc_consumed = True
+        if isinstance(node, MacroAstNode | ScopeAstNode | LabelAstNode):
+            name = getattr(node, "name", None) or getattr(node, "label", "") or ""
+            if _is_public(str(name)):
+                has_doc = pending_doc or bool(getattr(node, "docstring", None))
+                if not has_doc:
+                    line, col = _node_position(node)
+                    hits.append(
+                        Diagnostic(
+                            path=path,
+                            line=line,
+                            column=col,
+                            code="DOC002",
+                            message=f"public {_kind_label(node)} '{name}' is missing a docstring",
+                        )
+                    )
+        pending_doc = False
+    return hits
+
+
+def lint_file(path: Path) -> list[Diagnostic]:
+    """Run all DOC* rules against a single source file."""
+    text = path.read_text(encoding="utf-8")
+    result = MZParser.parse_as_ast(text, str(path))
+    if result.error:
+        return []  # leave parse errors for the format pass to surface
+    nodes = list(result.nodes)
+    diagnostics: list[Diagnostic] = []
+    module_hit = _check_module_docstring(path, nodes)
+    if module_hit is not None:
+        diagnostics.append(module_hit)
+    diagnostics.extend(_check_public_docstrings(path, nodes))
+    return diagnostics

--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -76,6 +76,28 @@ def _kind_label(node: AstNode) -> str:
     return "symbol"
 
 
+def _public_target_name(node: AstNode) -> str | None:
+    """Return the public name of a documentable node, or None when private/N/A."""
+    if not isinstance(node, MacroAstNode | ScopeAstNode | LabelAstNode):
+        return None
+    raw = getattr(node, "name", None) or getattr(node, "label", "") or ""
+    name = str(raw)
+    return name if _is_public(name) else None
+
+
+def _missing_doc_diagnostic(path: Path, node: AstNode, name: str, pending_doc: bool) -> Diagnostic | None:
+    if pending_doc or bool(getattr(node, "docstring", None)):
+        return None
+    line, col = _node_position(node)
+    return Diagnostic(
+        path=path,
+        line=line,
+        column=col,
+        code="DOC002",
+        message=f"public {_kind_label(node)} '{name}' is missing a docstring",
+    )
+
+
 def _check_public_docstrings(path: Path, nodes: list[AstNode]) -> list[Diagnostic]:
     """DOC002: each public macro/scope/label needs an attached docstring.
 
@@ -89,28 +111,17 @@ def _check_public_docstrings(path: Path, nodes: list[AstNode]) -> list[Diagnosti
         if isinstance(node, CommentAstNode):
             continue
         if isinstance(node, DocstringAstNode):
-            if not module_doc_consumed:
+            if module_doc_consumed:
+                pending_doc = True
+            else:
                 module_doc_consumed = True
-                continue
-            pending_doc = True
             continue
-        # Any non-comment node implies the module-doc slot is closed.
         module_doc_consumed = True
-        if isinstance(node, MacroAstNode | ScopeAstNode | LabelAstNode):
-            name = getattr(node, "name", None) or getattr(node, "label", "") or ""
-            if _is_public(str(name)):
-                has_doc = pending_doc or bool(getattr(node, "docstring", None))
-                if not has_doc:
-                    line, col = _node_position(node)
-                    hits.append(
-                        Diagnostic(
-                            path=path,
-                            line=line,
-                            column=col,
-                            code="DOC002",
-                            message=f"public {_kind_label(node)} '{name}' is missing a docstring",
-                        )
-                    )
+        name = _public_target_name(node)
+        if name is not None:
+            hit = _missing_doc_diagnostic(path, node, name, pending_doc)
+            if hit is not None:
+                hits.append(hit)
         pending_doc = False
     return hits
 

--- a/tests/test_fluff_lint.py
+++ b/tests/test_fluff_lint.py
@@ -1,0 +1,83 @@
+"""Coverage for the docstring-coverage lints (DOC001, DOC002)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a816.fluff import fluff_main
+from a816.fluff_lint import lint_file
+
+
+def test_doc001_flags_missing_module_docstring(tmp_path: Path) -> None:
+    src = tmp_path / "main.s"
+    src.write_text(
+        """; just a comment header
+"""
+        '"""Documented."""\n'
+        "main:\n"
+        "    rts\n",
+        encoding="utf-8",
+    )
+    diags = lint_file(src)
+    codes = [d.code for d in diags]
+    assert "DOC001" not in codes  # leading docstring is present (after the comment)
+
+
+def test_doc001_flags_when_no_leading_docstring(tmp_path: Path) -> None:
+    src = tmp_path / "main.s"
+    src.write_text("main:\n    rts\n", encoding="utf-8")
+    diags = lint_file(src)
+    codes = [d.code for d in diags]
+    assert "DOC001" in codes
+
+
+def test_doc002_flags_undocumented_macro(tmp_path: Path) -> None:
+    src = tmp_path / "lib.s"
+    src.write_text(
+        '"""Module."""\n.macro public_macro() {\n    rts\n}\n',
+        encoding="utf-8",
+    )
+    diags = lint_file(src)
+    codes = [d.code for d in diags]
+    assert "DOC002" in codes
+    assert any("public_macro" in d.message for d in diags)
+
+
+def test_doc002_skips_underscore_prefixed_names(tmp_path: Path) -> None:
+    src = tmp_path / "lib.s"
+    src.write_text(
+        '"""Module."""\n.macro _private_macro() {\n    rts\n}\n',
+        encoding="utf-8",
+    )
+    diags = lint_file(src)
+    assert all(d.code != "DOC002" for d in diags)
+
+
+def test_doc002_accepts_attached_docstring(tmp_path: Path) -> None:
+    src = tmp_path / "lib.s"
+    src.write_text(
+        '"""Module."""\n"""Documented."""\n.macro documented_macro() {\n    rts\n}\n',
+        encoding="utf-8",
+    )
+    diags = lint_file(src)
+    assert all(d.code != "DOC002" for d in diags)
+
+
+def test_check_command_reports_and_exits_nonzero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    src = tmp_path / "main.s"
+    src.write_text("main:\n    rts\n", encoding="utf-8")
+    rc = fluff_main(["check", str(src)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "DOC001" in captured.out
+
+
+def test_check_command_clean_exits_zero(tmp_path: Path) -> None:
+    src = tmp_path / "lib.s"
+    src.write_text(
+        '"""Module."""\n"""Documented."""\n.macro foo() {\n    rts\n}\n',
+        encoding="utf-8",
+    )
+    assert fluff_main(["check", str(src)]) == 0


### PR DESCRIPTION
## Summary

- New \`a816 fluff check <path>\` subcommand walks .s/.i sources and reports docstring-coverage hits.
- **DOC001** — module is missing a leading docstring. Comments are tolerated above; first non-comment node must be a docstring.
- **DOC002** — public macro, scope, or label lacks an attached docstring. Names starting with a single underscore are treated as private and skipped. The leading file docstring is consumed by DOC001 and does not count for DOC002.

## Why

Lets a project enforce documentation across hand-rolled engines (libmz, ff4 modules, etc.) the same way ruff's D rules do for Python.

## Test plan

- [x] \`tests/test_fluff_lint.py\` covers DOC001 present/absent, DOC002 macro hit/skip-private/with-attached-doc, and the CLI exit-code behaviour.
- [x] \`hatch run tests:all\` — 639 pass, 1 skipped, mypy + ruff clean.