### PR TITLE
Fix LSP crashes, scanner Position start, x816→a816 rename

### DIFF
--- a/a816/cli.py
+++ b/a816/cli.py
@@ -41,7 +41,7 @@ _ASM_SUFFIXES = (".s", ".asm")
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="x816", description="x816 usage", epilog="")
+    parser = argparse.ArgumentParser(prog="a816", description="a816 usage", epilog="")
     parser.add_argument("--verbose", action="store_true", help="Displays all log levels.")
     parser.add_argument("-o", "--output", type=Path, dest="output_file", default="a.out", help="Output file")
     parser.add_argument("input_files", nargs="+", type=Path, help="Input files (asm files or object files for linking)")

--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -708,19 +708,15 @@ class DocstringAlignment(Rule):
     def _open_column(text: str, node: DocstringAstNode) -> int | None:
         """Column of the opening `\"\"\"` in source.
 
-        The parser stores the *end* of the token in `position`, so we
-        walk back by the docstring's newline count and look up `\"\"\"`
-        on the resulting source line. Returns None defensively when the
-        position can't be located.
+        Returns None defensively when the position can't be located.
         """
         pos = getattr(node.file_info, "position", None)
         if pos is None:
             return None
-        open_line_no = pos.line - node.text.count("\n")
         source_lines = text.split("\n")
-        if open_line_no < 0 or open_line_no >= len(source_lines):
+        if pos.line < 0 or pos.line >= len(source_lines):
             return None
-        idx = source_lines[open_line_no].find('"""')
+        idx = source_lines[pos.line].find('"""')
         return idx if idx >= 0 else None
 
     @staticmethod

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -84,12 +84,17 @@ class A816Formatter:
             CodeLookupAstNode,
         )
 
-    def format_text(self, content: str, file_path: str | None = None) -> str:
+    def format_text(
+        self,
+        content: str,
+        file_path: str | None = None,
+        include_paths: list[Path] | None = None,
+    ) -> str:
         """Format assembly code from text content"""
         source = file_path or "<input>"
         try:
             # Parse the content into an AST
-            result = MZParser.parse_as_ast(content, source)
+            result = MZParser.parse_as_ast(content, source, include_paths=include_paths)
 
             if result.error:
                 raise FormattingError(f"Unable to format {source}:\n{result.error}")

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -1078,7 +1078,7 @@ class A816LanguageServer:
             workspace.replace_document(doc)
         self._publish_diagnostics(params.text_document.uri, doc.diagnostics)
         try:
-            self.server.send_notification("workspace/semanticTokens/refresh")
+            self.server.semantic_tokens_refresh()
         except (AttributeError, RuntimeError, TypeError) as e:
             logger.debug(f"Could not refresh semantic tokens: {e}")
 
@@ -1652,7 +1652,9 @@ class A816LanguageServer:
         original_formatter = self.formatter
         self.formatter = A816Formatter(formatting_options)
         try:
-            formatted_content = self.formatter.format_text(doc.content)
+            formatted_content = self.formatter.format_text(
+                doc.content, file_path=doc.uri, include_paths=doc.include_paths
+            )
             if formatted_content != doc.content:
                 return [TextEdit(range=self._full_document_range(doc), new_text=formatted_content)]
             return []

--- a/a816/parse/mzparser.py
+++ b/a816/parse/mzparser.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from time import gmtime, strftime
@@ -12,6 +13,8 @@ from a816.parse.scanner import Scanner
 from a816.parse.scanner_states import lex_initial
 from a816.protocols import NodeProtocol
 from a816.symbols import Resolver
+
+logger = logging.getLogger("a816.parser")
 
 
 @dataclass
@@ -35,7 +38,7 @@ class MZParser:
 
     def parse(self, program: str, filename: str = "") -> tuple[str | None, list[NodeProtocol]]:
         include_paths = self.resolver.context.include_paths
-        ast = self.parse_as_ast(program, filename, include_paths=include_paths)
+        ast = self.parse_as_ast(program, filename, include_paths=include_paths, verbose_errors=True)
         self.resolver.current_scope.add_symbol("BUILD_DATE", strftime("%Y-%m-%d %H:%M:%S", gmtime()))
         return ast.error, code_gen(ast.nodes, self.resolver)
 
@@ -44,6 +47,7 @@ class MZParser:
         program: str,
         filename: str = "memory.s",
         include_paths: list[Path] | None = None,
+        verbose_errors: bool = False,
     ) -> ParserResult:
         scanner = Scanner(lex_initial)
         ast: list[AstNode] = []
@@ -68,6 +72,9 @@ class MZParser:
                 length=1,
             )
         except ParserSyntaxError as e:
+            if verbose_errors:
+                logger.exception(e)
+                e.token.display()
             if e.token.position is not None:
                 pos = e.token.position
                 try:

--- a/a816/parse/parser.py
+++ b/a816/parse/parser.py
@@ -20,9 +20,8 @@ class Parser:
         try:
             return self.initial_state(self)
         except ParserSyntaxError as e:
-            logger.exception(e)
-            e.token.display()
-            raise e
+            logger.debug("Parser syntax error: %s", e)
+            raise
 
     def current(self) -> Token:
         try:

--- a/a816/parse/scanner.py
+++ b/a816/parse/scanner.py
@@ -21,6 +21,8 @@ class Scanner:
         self.tokens: list[Token] = []
         self.line_offset = 0
         self.current_line = 0
+        self.start_line = 0
+        self.start_column = 0
 
     def scan(self, filename: str, input_: str) -> list[Token]:
         self.file = File(filename)
@@ -91,7 +93,7 @@ class Scanner:
             pass
 
     def ignore(self) -> None:
-        self.start = self.pos
+        self._sync_start()
 
     def ignore_run(self, candidates: str) -> None:
         self.accept_run(candidates)
@@ -104,11 +106,16 @@ class Scanner:
         return Token(token_type, self.current_token_text(), self.get_position())
 
     def get_position(self) -> Position:
-        return Position(self.current_line, self.start - self.line_offset, self.file)
+        return Position(self.start_line, self.start_column, self.file)
 
     def emit(self, token_type: TokenType) -> None:
         self.tokens.append(self.get_token(token_type))
+        self._sync_start()
+
+    def _sync_start(self) -> None:
         self.start = self.pos
+        self.start_line = self.current_line
+        self.start_column = self.pos - self.line_offset
 
 
 ScannerStateFunc = Callable[[Scanner], None]

--- a/tests/test_debug_info.py
+++ b/tests/test_debug_info.py
@@ -84,6 +84,53 @@ def test_deserialize_rejects_bad_magic() -> None:
         raise AssertionError("expected ValueError on bad magic")
 
 
+def test_include_lines_attribute_to_included_file(tmp_path: Path) -> None:
+    """`.include`d code should report lines against the included file, not the parent."""
+    from a816.program import Program
+
+    inc = tmp_path / "inc.s"
+    inc.write_text("; comment line 1\n; comment line 2\nlda.b #0x10\nsta.b 0x20\n", encoding="utf-8")
+    main = tmp_path / "main.s"
+    main.write_text('*=0x008000\n.include "inc.s"\nlda.b #0x55\n', encoding="utf-8")
+
+    program = Program()
+    program.enable_debug_capture()
+    program.assemble_as_patch(str(main), tmp_path / "out.ips")
+    info = program.build_debug_info(str(main))
+
+    by_addr = {entry.address: entry for entry in info.lines}
+    files = info.files
+
+    inc_lda = by_addr[0x008000]
+    inc_sta = by_addr[0x008002]
+    main_lda = by_addr[0x008004]
+
+    assert Path(files[inc_lda.file_idx]).name == "inc.s"
+    assert inc_lda.line == 2  # 0-indexed: third source line
+    assert Path(files[inc_sta.file_idx]).name == "inc.s"
+    assert inc_sta.line == 3
+    assert Path(files[main_lda.file_idx]).name == "main.s"
+    assert main_lda.line == 2
+
+
+def test_multiline_docstring_does_not_skew_following_line_numbers(tmp_path: Path) -> None:
+    """A multi-line docstring at the top must not push the next instruction's reported line."""
+    from a816.program import Program
+
+    src = tmp_path / "main.s"
+    # `"""..."""` spans 3 source lines; opcode sits on line 4 (0-indexed: 3).
+    src.write_text('"""\nmodule docstring\n"""\n*=0x008000\nlda.b #0x42\n', encoding="utf-8")
+
+    program = Program()
+    program.enable_debug_capture()
+    program.assemble_as_patch(str(src), tmp_path / "out.ips")
+    info = program.build_debug_info(str(src))
+
+    lda = next(e for e in info.lines if e.address == 0x008000)
+    assert lda.line == 4  # editor line 5 → 0-indexed 4
+    assert lda.column == 0
+
+
 def test_string_table_dedupes() -> None:
     info = DebugInfo()
     info.modules = [

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -390,6 +390,37 @@ rts
             # Clean up
             Path(temp_path).unlink()
 
+    def test_format_text_resolves_include_relative_to_file_path(self) -> None:
+        """Regression: format_text with file_path must resolve .include relative to that file."""
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "libmz.i").write_text("; lib\n", encoding="utf-8")
+            main = tmp_path / "main.s"
+            main_content = '.include "libmz.i"\n'
+            main.write_text(main_content, encoding="utf-8")
+
+            formatted = self.formatter.format_text(main_content, file_path=main.as_uri())
+            self.assertIn(".include", formatted)
+
+    def test_format_text_resolves_include_via_include_paths(self) -> None:
+        """Regression: format_text honors include_paths when source dir lacks the file."""
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as inc_dir, TemporaryDirectory() as src_dir:
+            (Path(inc_dir) / "libmz.i").write_text("; lib\n", encoding="utf-8")
+            main = Path(src_dir) / "main.s"
+            main_content = '.include "libmz.i"\n'
+            main.write_text(main_content, encoding="utf-8")
+
+            formatted = self.formatter.format_text(
+                main_content,
+                file_path=main.as_uri(),
+                include_paths=[Path(inc_dir)],
+            )
+            self.assertIn(".include", formatted)
+
     def test_format_with_special_directives(self) -> None:
         """Test formatting assembly directives"""
         with NamedTemporaryFile(mode="w", suffix=".s", delete=False) as include_file:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -134,6 +134,34 @@ class ScannerTest(TestCase):
         tokens = self._scan('"""docstring"""')
         self.assertEqual(tokens[0][0], TokenType.DOCSTRING)
 
+    def test_multiline_docstring_position_points_at_start(self) -> None:
+        """Multi-line docstring's Position should report the line/column where it begins."""
+        scanner = Scanner(lex_initial)
+        tokens = scanner.scan("test.s", '"""\nfoo bar\n"""\nlda.b #1\n')
+        docstring = next(t for t in tokens if t.type == TokenType.DOCSTRING)
+        assert docstring.position is not None
+        self.assertEqual(docstring.position.line, 0, "docstring should start on line 0")
+        self.assertEqual(docstring.position.column, 0, "docstring should start at column 0")
+
+    def test_multiline_block_comment_position_points_at_start(self) -> None:
+        """Multi-line block comment's Position should report the line/column where it begins."""
+        scanner = Scanner(lex_initial)
+        tokens = scanner.scan("test.s", "/* line0\nline1\nline2 */\nlda.b #1\n")
+        comment = next(t for t in tokens if t.type == TokenType.COMMENT)
+        assert comment.position is not None
+        self.assertEqual(comment.position.line, 0)
+        self.assertEqual(comment.position.column, 0)
+
+    def test_token_after_multiline_docstring_has_correct_line(self) -> None:
+        """Tokens after a multi-line docstring should still get correct line numbers."""
+        scanner = Scanner(lex_initial)
+        # Docstring spans lines 0-2, opcode is on line 3.
+        tokens = scanner.scan("test.s", '"""\nfoo\n"""\nlda.b #1\n')
+        opcode = next(t for t in tokens if t.type == TokenType.OPCODE)
+        assert opcode.position is not None
+        self.assertEqual(opcode.position.line, 3)
+        self.assertEqual(opcode.position.column, 0)
+
     def test_scoped_identifier(self) -> None:
         """Test scoped identifier (scope.member) parsing."""
         tokens = self._scan("scope.member")


### PR DESCRIPTION
## Summary

Three fixes on top of master, mostly LSP / scanner correctness.

Rename CLI prog from `x816` to `a816` in argparse so `--help` shows the canonical name.

Fix scanner `Position` to point at token start instead of token end. Multi-line tokens (docstrings, block comments) were reporting the line and column where the token ended, producing line numbers off by N and negative columns in `.adbg` debug-info, parser error messages, and LSP diagnostics. Capture `start_line` / `start_column` when start is synced and use those in `get_position`; drop the now-obsolete walkback in DOC007's `_open_column`.

Fix nasty LSP crashes seen in nvim `lsp.log`:

- Format on save raised `FileNotFoundError: 'libmz.i'` because `formatter.format_text` did not know the source path, so `parse_include` resolved against CWD. Thread `file_path` and `include_paths` through `format_text` → `MZParser.parse_as_ast` and pass `doc.uri` / `doc.include_paths` from the LSP. Adds two regression tests.
- Workspace semantic-tokens refresh threw `WorkspaceSemanticTokensRefreshRequest.__init__() missing 1 required positional argument: 'id'` because we sent it via `send_notification`. Switch to pygls' `semantic_tokens_refresh()` helper which builds a proper request with id.
- Every keystroke logged a full `ParserSyntaxError` traceback (and a stdout `print` from `Token.display()` — fatal under stdio LSP transport). Move the verbose logging out of `Parser.parse` and into `MZParser.parse` (build path) behind a `verbose_errors` flag, so the build CLI keeps the readable error output while the LSP, formatter, and lint paths stay quiet.

## Test plan

- [x] \`hatch run tests:all\` green locally
- [x] Open a file with \`.include \"libmz.i\"\` in nvim → \`:LspFormat\` succeeds, no FileNotFoundError in \`lsp.log\`
- [x] Edit a file with a syntax error in nvim → no traceback spam in \`lsp.log\`, diagnostics still appear
- [x] Semantic tokens refresh after \`didChange\` no longer logs the \`missing 'id'\` error