### PR TITLE
Wire .alloc through allocator + Resolver.allocate_pools hook

### DIFF
--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -899,12 +899,12 @@ def generate_alloc(
     macro_definitions: MacroDefinitions,
     file_info: Token,
 ) -> GenNodes:
+    from a816.parse.nodes import AllocNode
+
     if node.pool_name not in resolver.pools:
         raise NodeError(f"alloc into unknown pool {node.pool_name!r}", file_info)
-    raise NodeError(
-        f"alloc into pool {node.pool_name!r}: code generation not yet wired up; tracking in a follow-up to PR #46",
-        file_info,
-    )
+    body_nodes = _code_gen(node.body.body, resolver, macro_definitions)
+    return [AllocNode(node.name, node.pool_name, body_nodes, resolver, file_info)]
 
 
 def generate_relocate(

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -686,6 +686,93 @@ class OpcodeNode(NodeProtocol):
         return f"OpcodeNode({self.opcode}, {self.addressing_mode}, {self.index}, {self.value_node})"
 
 
+class AllocNode(NodeProtocol):
+    """Emits `body` at an address picked by the named pool's allocator.
+
+    `pc_after` runs once per resolver pass; the pool allocator is invoked
+    by `Resolver.allocate_pools()` between passes. The body is walked
+    first to measure its size, the slot is requested, and once placed the
+    `name` label binds at the allocated address.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        pool_name: str,
+        body: list[NodeProtocol],
+        resolver: "Resolver",
+        file_info: Token,
+    ) -> None:
+        self.name = name
+        self.pool_name = pool_name
+        self.body = body
+        self.resolver = resolver
+        self.file_info = file_info
+        self._alloc: object | None = None
+        self._size: int = 0
+
+    def _sandbox_pc(self) -> Address:
+        pool = self.resolver.pools[self.pool_name]
+        anchor = pool.ranges[0].start if pool.ranges else 0
+        return self.resolver.get_bus().get_address(anchor)
+
+    def _measure_body(self) -> int:
+        start = self._sandbox_pc()
+        pc = start
+        for node in self.body:
+            pc = node.pc_after(pc)
+        return pc.logical_value - start.logical_value
+
+    def pc_after(self, current_pc: Address) -> Address:
+        pool = self.resolver.pools.get(self.pool_name)
+        if pool is None:
+            raise NodeError(f".alloc into unknown pool {self.pool_name!r}", self.file_info)
+
+        if self._alloc is None:
+            self._size = max(1, self._measure_body())
+            self._alloc = pool.request(self.name, self._size)
+            return current_pc
+
+        alloc = self._alloc
+        if getattr(alloc, "placed", False):
+            target = self.resolver.get_bus().get_address(alloc.addr)  # type: ignore[attr-defined]
+            self.resolver.current_scope.add_label(self.name, target)
+            pc = target
+            for node in self.body:
+                pc = node.pc_after(pc)
+        return current_pc
+
+    def emit(self, current_addr: Address) -> bytes:
+        del current_addr
+        return b""
+
+    def emit_blocks(self, current_addr: Address) -> list[tuple[int, bytes]]:
+        del current_addr
+        alloc = self._alloc
+        if alloc is None or not getattr(alloc, "placed", False):
+            return []
+        saved_pc = self.resolver.pc
+        saved_reloc = self.resolver.reloc_address
+        try:
+            self.resolver.set_position(alloc.addr)  # type: ignore[attr-defined]
+            out = b""
+            cur = self.resolver.reloc_address
+            for node in self.body:
+                emitted = node.emit(cur)
+                if emitted:
+                    out += emitted
+                    cur = cur + len(emitted)
+                    self.resolver.pc += len(emitted)
+                    self.resolver.reloc_address = cur
+            return [(alloc.addr, out)]  # type: ignore[attr-defined]
+        finally:
+            self.resolver.pc = saved_pc
+            self.resolver.reloc_address = saved_reloc
+
+    def __str__(self) -> str:
+        return f"AllocNode({self.name} in {self.pool_name})"
+
+
 class CodePositionNode(NodeProtocol):
     def __init__(self, value_node: ValueNodeProtocol, resolver: Resolver):
         self.value_node = value_node

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -14,6 +14,7 @@ from a816.object_file import Region
 from a816.parse.ast.expression import eval_expression, eval_expression_str
 from a816.parse.ast.nodes import BlockAstNode, ExpressionAstNode
 from a816.parse.tokens import Token
+from a816.pool import Allocation
 from a816.protocols import NodeProtocol, OpcodeProtocol, ValueNodeProtocol
 from a816.symbols import Resolver, Scope
 from script import Table
@@ -708,7 +709,7 @@ class AllocNode(NodeProtocol):
         self.body = body
         self.resolver = resolver
         self.file_info = file_info
-        self._alloc: object | None = None
+        self._alloc: Allocation | None = None
         self._size: int = 0
 
     def _sandbox_pc(self) -> Address:
@@ -723,23 +724,31 @@ class AllocNode(NodeProtocol):
             pc = node.pc_after(pc)
         return pc.logical_value - start.logical_value
 
-    def pc_after(self, current_pc: Address) -> Address:
+    def _request_slot(self) -> None:
+        pool = self.resolver.pools[self.pool_name]
+        self._size = max(1, self._measure_body())
+        self._alloc = pool.request(self.name, self._size)
+
+    def _bind_body_labels(self) -> None:
+        alloc = self._alloc
+        assert alloc is not None
+        target = self.resolver.get_bus().get_address(alloc.addr)
+        self.resolver.current_scope.add_label(self.name, target)
+        pc = target
+        for node in self.body:
+            pc = node.pc_after(pc)
+
+    def pc_after(self, current_pc: Address) -> Address:  # NOSONAR S3516
+        # Returning current_pc unchanged is by design: an .alloc block emits
+        # at the allocator-chosen address (via emit_blocks), not inline,
+        # so the surrounding PC must not advance past this node.
         pool = self.resolver.pools.get(self.pool_name)
         if pool is None:
             raise NodeError(f".alloc into unknown pool {self.pool_name!r}", self.file_info)
-
         if self._alloc is None:
-            self._size = max(1, self._measure_body())
-            self._alloc = pool.request(self.name, self._size)
-            return current_pc
-
-        alloc = self._alloc
-        if getattr(alloc, "placed", False):
-            target = self.resolver.get_bus().get_address(alloc.addr)  # type: ignore[attr-defined]
-            self.resolver.current_scope.add_label(self.name, target)
-            pc = target
-            for node in self.body:
-                pc = node.pc_after(pc)
+            self._request_slot()
+        elif self._alloc.placed:
+            self._bind_body_labels()
         return current_pc
 
     def emit(self, current_addr: Address) -> bytes:
@@ -749,12 +758,12 @@ class AllocNode(NodeProtocol):
     def emit_blocks(self, current_addr: Address) -> list[tuple[int, bytes]]:
         del current_addr
         alloc = self._alloc
-        if alloc is None or not getattr(alloc, "placed", False):
+        if alloc is None or not alloc.placed:
             return []
         saved_pc = self.resolver.pc
         saved_reloc = self.resolver.reloc_address
         try:
-            self.resolver.set_position(alloc.addr)  # type: ignore[attr-defined]
+            self.resolver.set_position(alloc.addr)
             out = b""
             cur = self.resolver.reloc_address
             for node in self.body:
@@ -764,7 +773,7 @@ class AllocNode(NodeProtocol):
                     cur = cur + len(emitted)
                     self.resolver.pc += len(emitted)
                     self.resolver.reloc_address = cur
-            return [(alloc.addr, out)]  # type: ignore[attr-defined]
+            return [(alloc.addr, out)]
         finally:
             self.resolver.pc = saved_pc
             self.resolver.reloc_address = saved_reloc

--- a/a816/program.py
+++ b/a816/program.py
@@ -9,6 +9,7 @@ from a816.cpu.cpu_65c816 import RomType
 from a816.object_file import ObjectFile, SymbolSection, SymbolType
 from a816.parse.mzparser import MZParser
 from a816.parse.nodes import (
+    AllocNode,
     BinaryNode,
     CodePositionNode,
     IncludeIpsNode,
@@ -166,6 +167,10 @@ class Program:
                 continue
             previous_pc = node.pc_after(previous_pc)
 
+        # Run the freespace allocator between passes so .alloc / .relocate
+        # blocks see their final addresses when binding labels in pass 2.
+        self.resolver.allocate_pools()
+
         self.resolver_reset()
 
         previous_pc = self.resolver.reloc_address
@@ -258,6 +263,9 @@ class Program:
         if isinstance(node, LinkedModuleNode):
             self._emit_linked_module(node, writer, state)
             return
+        if isinstance(node, AllocNode):
+            self._emit_alloc(node, writer, state)
+            return
         self._emit_default(node, writer, state)
         if isinstance(node, CodePositionNode):
             self._handle_code_position(writer, state)
@@ -285,6 +293,16 @@ class Program:
             advance = len(blocks[0][1])
             self.resolver.pc += advance
             self.resolver.reloc_address += advance
+        state.current_block_addr = self.resolver.pc
+        state.current_block_logical = self.resolver.reloc_address.logical_value
+
+    def _emit_alloc(self, node: AllocNode, writer: Writer, state: _EmitState) -> None:
+        """Write an `.alloc` block at its allocator-chosen address."""
+        self._flush_pending(writer, state)
+        blocks = node.emit_blocks(self.resolver.reloc_address)
+        for base, block in blocks:
+            if block:
+                writer.write_block(block, self._to_physical(base))
         state.current_block_addr = self.resolver.pc
         state.current_block_logical = self.resolver.reloc_address.logical_value
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -250,6 +250,17 @@ class Resolver:
         self.pools: dict[str, Pool] = {}
         self.set_position(pc)
 
+    def allocate_pools(self) -> None:
+        """Run the allocator on every declared pool.
+
+        Called between resolver passes by Program.resolve_labels so that
+        `.alloc` and `.relocate` blocks see their final addresses on the
+        pass that binds labels. Pool.allocate is idempotent — safe to call
+        multiple times.
+        """
+        for pool in self.pools.values():
+            pool.allocate()
+
     def get_bus(self) -> Bus:
         if self.bus.has_mappings():
             bus = self.bus

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -5,7 +5,9 @@ import pytest
 from a816.parse.codegen import code_gen
 from a816.parse.mzparser import MZParser
 from a816.pool import Strategy
+from a816.program import Program
 from a816.symbols import Resolver
+from tests import StubWriter
 
 
 def _gen(src: str) -> Resolver:
@@ -100,7 +102,7 @@ class TestReclaimCodegen:
         assert len(resolver.pools["p"].ranges) == 1
 
 
-class TestAllocPlaceholder:
+class TestAllocCodegen:
     def test_alloc_into_unknown_pool_errors(self) -> None:
         with pytest.raises(Exception, match="unknown pool"):
             _gen(
@@ -111,16 +113,59 @@ class TestAllocPlaceholder:
                 """,
             )
 
-    def test_alloc_not_yet_wired(self) -> None:
-        with pytest.raises(Exception, match="not yet wired up"):
-            _gen(
-                """
-                .pool p { range 0x028000 0x0280ff }
-                .alloc fn in p {
-                    rts
-                }
-                """,
-            )
+    def test_alloc_emits_alloc_node(self) -> None:
+        from a816.parse.nodes import AllocNode
+
+        resolver = Resolver()
+        result = MZParser.parse_as_ast(
+            """
+            .pool p { range 0x028000 0x0280ff }
+            .alloc fn in p {
+                rts
+            }
+            """,
+            filename="t.s",
+        )
+        assert result.parse_error is None
+        nodes = code_gen(result.nodes, resolver)
+        alloc_nodes = [n for n in nodes if isinstance(n, AllocNode)]
+        assert len(alloc_nodes) == 1
+        assert alloc_nodes[0].name == "fn"
+        assert alloc_nodes[0].pool_name == "p"
+
+
+class TestAllocEndToEnd:
+    def test_body_lands_at_allocated_addr(self) -> None:
+        writer = StubWriter()
+        program = Program()
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        # rts opcode = 0x60. Body should land at allocator-chosen 0x028000.
+        assert b"\x60" in writer.data
+        idx = writer.data.index(b"\x60")
+        # The address recorded is physical; first range starts at logical
+        # 0x028000 which maps to physical 0x010000 under low_rom.
+        assert writer.data_addresses[idx] in (0x028000, 0x010000)
+
+    def test_alloc_binds_symbol(self) -> None:
+        program = Program()
+        resolver = program.resolver
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            rts
+        }
+        """
+        writer = StubWriter()
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        # Symbol `fn` should resolve to the allocator-picked address.
+        labels = resolver.current_scope.labels
+        assert "fn" in labels
 
 
 class TestRelocatePlaceholder:


### PR DESCRIPTION
Next slice on top of #48. End-to-end \`.alloc\`: body lands at allocator-chosen addr, label binds there, callers can resolve the symbol.

## What works
\`\`\`ca65
.pool bank02_slack { range 0x028000 0x028fff fill 0xea }

.alloc helper in bank02_slack {
    rts
}
\`\`\`

Output: \`0x60\` (rts) written at 0x028000; \`helper\` symbol resolves to 0x028000.

## How

- **AllocNode** (\`a816/parse/nodes.py\`): wraps the body's codegen output. \`pc_after\` runs twice through the resolver passes — pass 1 measures the body in a sandbox starting at the pool's first range, calls \`pool.request\`; pass 2 binds the label at \`alloc.addr\` and re-walks the body so child labels resolve at the final addresses.
- **Resolver.allocate_pools** (\`a816/symbols.py\`): runs \`pool.allocate()\` on every registered pool. Idempotent — safe to call multiple times.
- **Program.resolve_labels** hook (\`a816/program.py\`): invokes \`resolver.allocate_pools()\` between the two passes so pass 2 sees final addresses.
- **Program._emit_alloc**: dispatches AllocNode emission like LinkedModuleNode — writes the body block at the allocator-chosen physical address, doesn't touch the surrounding emit state.
- **generate_alloc** (\`a816/parse/codegen.py\`): produces the real AllocNode now instead of raising "not yet wired up".

## What's not in this PR
- **\`.relocate\`** — still raises "not yet wired up". Needs an automatic \`pool.reclaim\` of the symbol's original \`(addr, size)\` before the request, plus address resolution for the symbol's pre-move location.
- **Fill emission** — pool's \`fill\` byte is parsed and stored, but no IPS records are written for unused chunk tails or reclaimed ranges.
- **Pool stats as scope symbols** — \`bank02_slack.free\` etc. not exposed for \`.if\` guards yet.
- **Multi-alloc fragmentation testing** — works in principle (pool.allocate runs once across all requests), but no end-to-end test yet of two .alloc into the same pool.
- **Object / linker mode** — pool decls + alloc records aren't serialized to \`.o\` yet; cross-TU pool merge is the slice after.

## Test plan
- [x] \`hatch run tests:tests\` — 839 passed, 1 skipped (2 new end-to-end alloc tests + existing 837)
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean
- [x] CI on this PR (workflow filter fix from #48 in effect)

## Follow-ups
1. \`.relocate\` codegen: extend AllocNode for relocate semantics or add a sibling RelocateNode that does request + reclaim + bind.
2. Fill emission: pool emits its \`fill\` byte for the gaps (unused tail + reclaimed-but-not-reused ranges) as separate IPS records.
3. Pool stats as scope symbols.
4. Multi-TU object / linker integration.