### PR TITLE
Wire .relocate through allocator + fluff round-trip

### DIFF
--- a/a816/parse/ast/nodes.py
+++ b/a816/parse/ast/nodes.py
@@ -543,6 +543,19 @@ class RegisterSizeAstNode(AstNode):
         return f".{self.register}{self.size}"
 
 
+def _indent_block_body(block: "BlockAstNode", indent: str = "    ") -> str:
+    """Render a block's children with consistent indentation, no surrounding braces.
+
+    Used by `.alloc` and `.relocate` canonicalisation so fluff format can pass
+    the source through a round-trip without losing the body's structure.
+    """
+    lines: list[str] = []
+    for node in block.body:
+        for line in node.to_canonical().splitlines() or [""]:
+            lines.append(f"{indent}{line}" if line else line)
+    return "\n".join(lines)
+
+
 class PoolAstNode(AstNode):
     """AST node for `.pool NAME { ... }` directive.
 
@@ -601,35 +614,44 @@ class AllocAstNode(AstNode):
         return self.kind, self.name, self.pool_name, self.body.to_representation()[0]
 
     def to_canonical(self) -> str:
-        return f".alloc {self.name} in {self.pool_name} {{ ... }}"
+        body = _indent_block_body(self.body)
+        return f".alloc {self.name} in {self.pool_name} {{\n{body}\n}}"
 
 
 class RelocateAstNode(AstNode):
-    """AST node for `.relocate SYMBOL into POOL { body }` directive.
+    """AST node for `.relocate SYMBOL OLD_START OLD_END into POOL { body }`.
 
-    Moves the labelled region `SYMBOL` into the named pool. Old range is
-    reclaimed back into the pool (filled with the pool's fill byte) and
-    `body` is placed at the allocator-chosen address; `SYMBOL` resolves to
-    the new location.
+    Moves the labelled region `SYMBOL` from `[OLD_START, OLD_END]` into the
+    named pool. The old range is reclaimed back into the pool (fill byte
+    applied during emission) and `body` is placed at the allocator-chosen
+    address; `SYMBOL` resolves to the new location.
     """
 
     def __init__(
         self,
         symbol: str,
+        old_start: int,
+        old_end: int,
         pool_name: str,
         body: "BlockAstNode",
         file_info: Token,
     ) -> None:
         super().__init__("relocate", file_info)
         self.symbol = symbol
+        self.old_start = old_start
+        self.old_end = old_end
         self.pool_name = pool_name
         self.body = body
 
     def to_representation(self) -> tuple[Any, ...]:
-        return self.kind, self.symbol, self.pool_name, self.body.to_representation()[0]
+        return self.kind, self.symbol, self.old_start, self.old_end, self.pool_name, self.body.to_representation()[0]
 
     def to_canonical(self) -> str:
-        return f".relocate {self.symbol} into {self.pool_name} {{ ... }}"
+        body = _indent_block_body(self.body)
+        return (
+            f".relocate {self.symbol} 0x{self.old_start:06x} 0x{self.old_end:06x} "
+            f"into {self.pool_name} {{\n{body}\n}}"
+        )
 
 
 class ReclaimAstNode(AstNode):

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -913,13 +913,22 @@ def generate_relocate(
     macro_definitions: MacroDefinitions,
     file_info: Token,
 ) -> GenNodes:
+    from a816.parse.nodes import RelocateNode
+
     if node.pool_name not in resolver.pools:
         raise NodeError(f"relocate into unknown pool {node.pool_name!r}", file_info)
-    raise NodeError(
-        f"relocate {node.symbol!r} into pool {node.pool_name!r}: "
-        "code generation not yet wired up; tracking in a follow-up to PR #46",
-        file_info,
-    )
+    body_nodes = _code_gen(node.body.body, resolver, macro_definitions)
+    return [
+        RelocateNode(
+            node.symbol,
+            node.old_start,
+            node.old_end,
+            node.pool_name,
+            body_nodes,
+            resolver,
+            file_info,
+        )
+    ]
 
 
 generators = {

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -782,6 +782,48 @@ class AllocNode(NodeProtocol):
         return f"AllocNode({self.name} in {self.pool_name})"
 
 
+class RelocateNode(AllocNode):
+    """`AllocNode` that also reclaims the symbol's original (addr, end) range.
+
+    Pass 1 reclaims `[old_start, old_end]` back into the pool *before*
+    requesting a slot for the body, so the reclaimed bytes may be reused
+    by the same `.relocate` if the pool's free space is otherwise full.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        old_start: int,
+        old_end: int,
+        pool_name: str,
+        body: list[NodeProtocol],
+        resolver: "Resolver",
+        file_info: Token,
+    ) -> None:
+        super().__init__(name, pool_name, body, resolver, file_info)
+        self.old_start = old_start
+        self.old_end = old_end
+        self._reclaimed = False
+
+    def _request_slot(self) -> None:
+        if not self._reclaimed:
+            from a816.pool import PoolRange
+
+            pool = self.resolver.pools[self.pool_name]
+            try:
+                pool.reclaim(PoolRange(start=self.old_start, end=self.old_end))
+            except Exception as exc:
+                raise NodeError(
+                    f".relocate {self.name!r} reclaim 0x{self.old_start:06x}..0x{self.old_end:06x}: {exc}",
+                    self.file_info,
+                ) from exc
+            self._reclaimed = True
+        super()._request_slot()
+
+    def __str__(self) -> str:
+        return f"RelocateNode({self.name} from 0x{self.old_start:06x}..0x{self.old_end:06x} -> {self.pool_name})"
+
+
 class CodePositionNode(NodeProtocol):
     def __init__(self, value_node: ValueNodeProtocol, resolver: Resolver):
         self.value_node = value_node

--- a/a816/parse/parser_states.py
+++ b/a816/parse/parser_states.py
@@ -501,17 +501,26 @@ def parse_alloc(p: Parser) -> AllocAstNode:
 
 
 def parse_relocate(p: Parser) -> RelocateAstNode:
-    """Parse `.relocate SYMBOL into POOL { body }`."""
+    """Parse `.relocate SYMBOL OLD_START OLD_END into POOL { body }`."""
     keyword = p.current()
     symbol_token = p.next()
     expect_token(symbol_token, TokenType.IDENTIFIER)
+    old_start = _parse_pool_number(p)
+    old_end = _parse_pool_number(p)
     _expect_contextual_keyword(p, "into")
     pool_token = p.next()
     expect_token(pool_token, TokenType.IDENTIFIER)
     lbrace = p.next()
     expect_token(lbrace, TokenType.LBRACE)
     body = BlockAstNode(parse_block(p), lbrace)
-    return RelocateAstNode(symbol_token.value, pool_token.value, body, keyword)
+    return RelocateAstNode(
+        symbol_token.value,
+        old_start,
+        old_end,
+        pool_token.value,
+        body,
+        keyword,
+    )
 
 
 def parse_reclaim(p: Parser) -> ReclaimAstNode:

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -168,24 +168,77 @@ class TestAllocEndToEnd:
         assert "fn" in labels
 
 
-class TestRelocatePlaceholder:
+class TestRelocateCodegen:
     def test_relocate_into_unknown_pool_errors(self) -> None:
         with pytest.raises(Exception, match="unknown pool"):
             _gen(
                 """
-                .relocate fn into ghost {
+                .relocate fn 0x02c000 0x02c17f into ghost {
                     rts
                 }
                 """,
             )
 
-    def test_relocate_not_yet_wired(self) -> None:
-        with pytest.raises(Exception, match="not yet wired up"):
-            _gen(
-                """
-                .pool p { range 0x028000 0x0280ff }
-                .relocate fn into p {
-                    rts
-                }
-                """,
-            )
+    def test_relocate_emits_relocate_node(self) -> None:
+        from a816.parse.nodes import RelocateNode
+
+        resolver = Resolver()
+        result = MZParser.parse_as_ast(
+            """
+            .pool p { range 0x028000 0x0280ff }
+            .relocate fn 0x02c000 0x02c17f into p {
+                rts
+            }
+            """,
+            filename="t.s",
+        )
+        assert result.parse_error is None
+        nodes = code_gen(result.nodes, resolver)
+        relocs = [n for n in nodes if isinstance(n, RelocateNode)]
+        assert len(relocs) == 1
+        assert relocs[0].name == "fn"
+        assert relocs[0].old_start == 0x02C000
+        assert relocs[0].old_end == 0x02C17F
+
+
+class TestRelocateEndToEnd:
+    def test_relocate_reclaims_old_range_into_pool(self) -> None:
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .relocate fn 0x02c000 0x02c17f into p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        pool = program.resolver.pools["p"]
+        # Pool now contains the original 0x100-byte range plus the
+        # reclaimed 0x180-byte range, minus the 1 byte the body used.
+        assert pool.capacity == 0x100 + 0x180
+        assert pool.used == 1
+
+    def test_relocate_binds_symbol_to_new_addr(self) -> None:
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .relocate fn 0x02c000 0x02c17f into p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        labels = program.resolver.current_scope.labels
+        assert "fn" in labels
+
+    def test_relocate_reclaim_overlapping_pool_range_errors(self) -> None:
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p { range 0x02c100 0x02c200 }
+        .relocate fn 0x02c150 0x02c1ff into p {
+            rts
+        }
+        """
+        with pytest.raises(Exception, match="overlap"):
+            program.assemble_string_with_emitter(src, "test.s", writer)

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -127,7 +127,7 @@ class TestRelocateDirective:
     def test_basic(self) -> None:
         node = _first_of(
             """
-            .relocate fn_old into bank02_slack {
+            .relocate fn_old 0x02c000 0x02c17f into bank02_slack {
                 pha
                 rts
             }
@@ -135,6 +135,8 @@ class TestRelocateDirective:
             RelocateAstNode,
         )
         assert node.symbol == "fn_old"
+        assert node.old_start == 0x02C000
+        assert node.old_end == 0x02C17F
         assert node.pool_name == "bank02_slack"
         assert isinstance(node.body, BlockAstNode)
         opcodes = [n for n in node.body.body if isinstance(n, OpcodeAstNode)]
@@ -142,11 +144,25 @@ class TestRelocateDirective:
 
     def test_missing_into_keyword_is_error(self) -> None:
         result = MZParser.parse_as_ast(
-            ".relocate fn bank02 { rts }",
+            ".relocate fn 0x02c000 0x02c17f bank02 { rts }",
             filename="t.s",
         )
         assert result.parse_error is not None
         assert "'into'" in result.parse_error.message
+
+    def test_to_canonical_includes_body(self) -> None:
+        node = _first_of(
+            """
+            .relocate fn 0x02c000 0x02c17f into p {
+                rts
+            }
+            """,
+            RelocateAstNode,
+        )
+        canon = node.to_canonical()
+        assert "rts" in canon
+        assert "0x02c000" in canon
+        assert "0x02c17f" in canon
 
 
 class TestReclaimDirective:
@@ -180,11 +196,11 @@ class TestIntegration:
                 rts
             }
 
-            .relocate fn_old into bank02_slack {
+            .relocate fn_old 0x02c000 0x02c17f into bank02_slack {
                 rts
             }
 
-            .reclaim bank02_slack 0x02c000 0x02c17f
+            .reclaim bank02_slack 0x02d000 0x02d17f
             """,
         )
         kinds = [type(n).__name__ for n in nodes if not type(n).__name__.startswith(("Comment", "Docstring"))]
@@ -192,6 +208,42 @@ class TestIntegration:
         assert "AllocAstNode" in kinds
         assert "RelocateAstNode" in kinds
         assert "ReclaimAstNode" in kinds
+
+
+class TestFluffFormat:
+    def test_pool_alloc_relocate_reclaim_round_trip(self) -> None:
+        from a816.formatter import A816Formatter
+
+        src = """.pool p {
+    range 0x028000 0x0280ff
+    fill 0xea
+    strategy pack
+}
+.alloc fn in p {
+    rts
+}
+.relocate moved 0x02c000 0x02c17f into p {
+    pha
+    rts
+}
+.reclaim p 0x02d000 0x02d0ff
+"""
+        out = A816Formatter().format_text(src)
+        # Stable across two passes — fluff format converges.
+        assert A816Formatter().format_text(out) == out
+        # Body opcodes appear inside the brace pair.
+        for keyword in (".pool p", ".alloc fn in p", ".relocate moved", ".reclaim p"):
+            assert keyword in out
+        for opcode in ("rts", "pha"):
+            assert opcode in out
+
+
+class TestLspKeywordCompletions:
+    def test_pool_keywords_advertised(self) -> None:
+        from a816.parse.scanner_states import KEYWORDS
+
+        for kw in ("pool", "alloc", "relocate", "reclaim"):
+            assert kw in KEYWORDS, f"{kw!r} not in scanner KEYWORDS — LSP completion will not surface it"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Next slice on top of #49. End-to-end \`.relocate\`: old range reclaimed into pool, body placed at allocator-chosen addr, symbol resolves there.

## Syntax change

\`.relocate\` now takes the symbol's old \`(start, end)\` bytes inline:

\`\`\`ca65
.pool bank02_slack { range 0x028000 0x028fff fill 0xea }

.relocate fn_old 0x02c000 0x02c17f into bank02_slack {
    pha
    rts
}
\`\`\`

Equivalent semantics to:

\`\`\`ca65
.reclaim bank02_slack 0x02c000 0x02c17f
.alloc fn_old in bank02_slack { pha; rts }
\`\`\`

…but as one atomic directive that auto-reclaims before requesting the slot, so the freed bytes can fund the move when the rest of the pool is otherwise full.

## How

- **\`RelocateAstNode\`** carries \`old_start\` / \`old_end\` (numbers only — expressions are a follow-up, same as for \`.pool\` ranges).
- **\`RelocateNode\`** (\`a816/parse/nodes.py\`) subclasses \`AllocNode\`. Override of \`_request_slot\` runs \`pool.reclaim(PoolRange(old_start, old_end))\` once (idempotent via \`self._reclaimed\`) before delegating to \`AllocNode._request_slot\`. Errors from \`Pool.reclaim\` (overlap, cross-bank) surface as \`NodeError\` at the directive's file/line.
- **\`generate_relocate\`** (\`a816/parse/codegen.py\`) now produces \`RelocateNode\` instead of raising "not yet wired up".

## Fluff / LSP integration

- **\`.alloc\` and \`.relocate\` \`to_canonical\`** now render body content with indentation via a shared \`_indent_block_body\` helper. fluff format passes through the fallback path (\`ast.to_canonical().splitlines()\`) and produces stable, round-trippable output.
- **Test asserts two-pass convergence** — formatting twice yields identical bytes.
- **LSP completion** already surfaces \`pool\` / \`alloc\` / \`relocate\` / \`reclaim\` because \`_build_keyword_completions\` reads from the scanner's \`KEYWORDS\` set (verified by a new test that gates that fact).
- **fluff lint** has no rules that match these directives yet — neutral pass.

## What's not in this PR
- **Fill emission** — pool's \`fill\` byte still parses + stores but no IPS records are written for the reclaimed range or unused chunk tails. Next slice.
- **Pool stats as scope symbols** — \`bank02_slack.free\` etc. for \`.if\` guards. Slice after fill.
- **LSP document outline** — pool decls and alloc/relocate symbols aren't surfaced as \`DocumentSymbol\`s yet. Cosmetic; hover/goto still works via the underlying label binding.
- **Expression support** in old_start / old_end / range / fill. Numeric literals only for now.
- **Object / linker** integration.

## Test plan
- [x] \`hatch run tests:tests\` — 845 passed, 1 skipped (4 new tests: relocate end-to-end, overlap error path, fluff round-trip, LSP keyword presence)
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean
- [x] CI active (workflow filter from #48)