### PR TITLE
Pool dogfood fix + expressions + stats symbols + multi-alloc

### DIFF
--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -717,10 +717,23 @@ class AllocNode(NodeProtocol):
         anchor = pool.ranges[0].start if pool.ranges else 0
         return self.resolver.get_bus().get_address(anchor)
 
+    @staticmethod
+    def _skip_in_pass1(node: NodeProtocol) -> bool:
+        """Mirror `Program.resolve_labels` pass-1 skip set.
+
+        Nodes whose `pc_after` eagerly evaluates expressions (e.g.
+        `SymbolNode`) must wait for pass-2 or forward references raise.
+        AllocNode walks its body across the same passes, so applies the
+        same skip rule when measuring + when binding labels.
+        """
+        return isinstance(node, SymbolNode)
+
     def _measure_body(self) -> int:
         start = self._sandbox_pc()
         pc = start
         for node in self.body:
+            if self._skip_in_pass1(node):
+                continue
             pc = node.pc_after(pc)
         return pc.logical_value - start.logical_value
 

--- a/tests/test_pool_allocator.py
+++ b/tests/test_pool_allocator.py
@@ -234,6 +234,28 @@ class TestIdempotence:
             pool.request("b", 0x100)
 
 
+class TestFreeRangesEdgeCases:
+    def test_free_ranges_before_allocate_returns_full_ranges(self) -> None:
+        pool = _pool(_range(0x028000, 0x0280FF))
+        free = pool._free_ranges()  # noqa: SLF001
+        assert free == [_range(0x028000, 0x0280FF)]
+
+    def test_subtract_one_placement_outside_range(self) -> None:
+        # Two ranges, alloc lands in first, second untouched but checked.
+        pool = _pool(
+            _range(0x028000, 0x0280FF),
+            _range(0x02A000, 0x02A0FF),
+            strategy=Strategy.ORDER,
+        )
+        pool.request("a", 0x80)
+        pool.allocate()
+        # The unused tail of chunk 1 plus all of chunk 2 should be reported.
+        assert pool.fragments == 2
+        chunks = pool._free_ranges()  # noqa: SLF001
+        assert chunks[0].start == 0x028080
+        assert chunks[1] == _range(0x02A000, 0x02A0FF)
+
+
 class TestAllocationDataclass:
     def test_unplaced_by_default(self) -> None:
         assert not Allocation(name="x", size=0x100).placed

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -201,6 +201,38 @@ class TestRelocateCodegen:
         assert relocs[0].old_end == 0x02C17F
 
 
+class TestAllocPass1ForwardRefs:
+    """Regression: ff4-modules dogfood surfaced AllocNode crashing on
+    forward refs because `SymbolNode.pc_after` evaluates RHS eagerly.
+    `Program.resolve_labels` skips SymbolNode in pass-1 for the same
+    reason; AllocNode now mirrors that.
+    """
+
+    def test_alloc_body_with_forward_label_ref(self) -> None:
+        """Mirrors ff4-modules pattern: body references a label declared
+        later in another scope. Pre-fix this raised SymbolNotDefined
+        during AllocNode's pass-1 size measurement."""
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            jsr.l later.target
+            rts
+        }
+
+        .scope later {
+        target:
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        flat = b"".join(writer.data)
+        # jsr.l (0x22) + 3-byte operand + rts (0x60).
+        assert 0x22 in flat
+        assert 0x60 in flat
+
+
 class TestRelocateEndToEnd:
     def test_relocate_reclaims_old_range_into_pool(self) -> None:
         program = Program()

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -245,6 +245,103 @@ class TestAllocPass1ForwardRefs:
         )
 
 
+class TestAllocNodeInternals:
+    """Cover NodeProtocol surface bits (emit, __str__, empty paths)."""
+
+    @staticmethod
+    def _make_alloc(src: str):  # type: ignore[no-untyped-def]
+        from a816.parse.nodes import AllocNode
+
+        resolver = Resolver()
+        result = MZParser.parse_as_ast(src, filename="t.s")
+        assert result.parse_error is None
+        nodes = code_gen(result.nodes, resolver)
+        allocs = [n for n in nodes if isinstance(n, AllocNode)]
+        assert allocs
+        return allocs[0]
+
+    _SRC = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            rts
+        }
+        """
+
+    def test_alloc_str_repr(self) -> None:
+        node = self._make_alloc(self._SRC)
+        assert "fn" in str(node)
+        assert "p" in str(node)
+
+    def test_alloc_emit_returns_empty_bytes(self) -> None:
+        node = self._make_alloc(self._SRC)
+        dummy = Resolver().get_bus().get_address(0)
+        # emit() is documented to be a no-op; bytes flow through emit_blocks.
+        assert node.emit(dummy) == b""
+
+    def test_emit_blocks_empty_before_allocation(self) -> None:
+        node = self._make_alloc(self._SRC)
+        dummy = Resolver().get_bus().get_address(0)
+        # Before pc_after runs and allocator places the slot, emit_blocks
+        # returns [].
+        assert node.emit_blocks(dummy) == []
+
+    def test_pc_after_unknown_pool_raises(self) -> None:
+        """Defense in depth: codegen validates the pool exists before
+        constructing AllocNode, but the runtime guard also raises if a
+        node is built directly without going through generate_alloc."""
+        from a816.parse.nodes import AllocNode, NodeError
+        from a816.parse.tokens import Token, TokenType
+
+        resolver = Resolver()
+        fake_tok = Token(TokenType.IDENTIFIER, "ghost")
+        node = AllocNode("fn", "ghost", [], resolver, fake_tok)
+        dummy = resolver.get_bus().get_address(0)
+        with pytest.raises(NodeError, match="unknown pool"):
+            node.pc_after(dummy)
+
+    def test_alloc_skips_symbol_node_in_pass1(self) -> None:
+        """`continue` branch in _measure_body when body has a SymbolNode."""
+        program = Program()
+        writer = StubWriter()
+        # `local_const = 0x42` produces a SymbolNode that pass-1 must skip
+        # to keep measurement deterministic (regardless of RHS resolvability).
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            local_const = 0x42
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        labels = program.resolver.current_scope.labels
+        assert "fn" in labels
+
+
+class TestRelocateNodeInternals:
+    def test_relocate_str_repr(self) -> None:
+        from a816.parse.nodes import RelocateNode
+
+        resolver = Resolver()
+        result = MZParser.parse_as_ast(
+            """
+            .pool p { range 0x028000 0x0280ff }
+            .relocate fn 0x02c000 0x02c17f into p {
+                rts
+            }
+            """,
+            filename="t.s",
+        )
+        assert result.parse_error is None
+        nodes = code_gen(result.nodes, resolver)
+        relocs = [n for n in nodes if isinstance(n, RelocateNode)]
+        assert relocs
+        s = str(relocs[0])
+        assert "fn" in s
+        assert "0x02c000" in s
+        assert "0x02c17f" in s
+        assert "p" in s
+
+
 class TestRelocateEndToEnd:
     def test_relocate_reclaims_old_range_into_pool(self) -> None:
         program = Program()

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -221,16 +221,28 @@ class TestAllocPass1ForwardRefs:
             rts
         }
 
+        *=0x008000
         .scope later {
         target:
             rts
         }
         """
         program.assemble_string_with_emitter(src, "test.s", writer)
-        flat = b"".join(writer.data)
-        # jsr.l (0x22) + 3-byte operand + rts (0x60).
-        assert 0x22 in flat
-        assert 0x60 in flat
+
+        labels = program.resolver.current_scope.labels
+        assert "fn" in labels, "alloc label must bind"
+        # fn binds at logical 0x028000 (only chunk start). Translate to
+        # physical via the bus so we can find the matching writer record.
+        fn_logical = labels["fn"]
+        fn_phys = program.resolver.get_bus().get_address(fn_logical).physical
+        # Body bytes: 22 00 80 00 (jsr.l later.target) + 60 (rts) = 5 bytes.
+        alloc_block = next(
+            (b for a, b in zip(writer.data_addresses, writer.data, strict=False) if a == fn_phys),
+            None,
+        )
+        assert alloc_block == b"\x22\x00\x80\x00\x60", (
+            f"alloc body bytes wrong at phys=0x{fn_phys:06x}: {alloc_block!r}"
+        )
 
 
 class TestRelocateEndToEnd:

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -210,6 +210,64 @@ class TestIntegration:
         assert "ReclaimAstNode" in kinds
 
 
+class TestAstToRepresentation:
+    """Exercise to_representation on each pool AST node — used by AST
+    inspection tools and round-trip tests."""
+
+    def test_pool_representation(self) -> None:
+        node = _first_of(
+            ".pool p { range 0x028000 0x0280ff fill 0xea strategy order }",
+            PoolAstNode,
+        )
+        kind, name, ranges, fill, strategy = node.to_representation()
+        assert kind == "pool"
+        assert name == "p"
+        assert ranges == ((0x028000, 0x0280FF),)
+        assert fill == 0xEA
+        assert strategy == "order"
+
+    def test_alloc_representation(self) -> None:
+        node = _first_of(
+            """
+            .alloc fn in p {
+                rts
+            }
+            """,
+            AllocAstNode,
+        )
+        kind, name, pool_name, body = node.to_representation()
+        assert kind == "alloc"
+        assert name == "fn"
+        assert pool_name == "p"
+        # body is the first slot of BlockAstNode.to_representation() —
+        # the string kind "block" (the list is index 1).
+        assert body == "block"
+
+    def test_relocate_representation(self) -> None:
+        node = _first_of(
+            """
+            .relocate fn 0x02c000 0x02c17f into p {
+                rts
+            }
+            """,
+            RelocateAstNode,
+        )
+        kind, symbol, lo, hi, pool_name, body = node.to_representation()
+        assert kind == "relocate"
+        assert symbol == "fn"
+        assert lo == 0x02C000
+        assert hi == 0x02C17F
+        assert pool_name == "p"
+        assert body == "block"
+
+    def test_reclaim_representation(self) -> None:
+        node = _first_of(
+            ".reclaim p 0x02c000 0x02c17f",
+            ReclaimAstNode,
+        )
+        assert node.to_representation() == ("reclaim", "p", 0x02C000, 0x02C17F)
+
+
 class TestFluffFormat:
     def test_pool_alloc_relocate_reclaim_round_trip(self) -> None:
         from a816.formatter import A816Formatter


### PR DESCRIPTION
Stack on master after #50. **Option A scope** — combines remaining slices (sans fill emission per request) into one PR.

## What ships

### 1. Dogfood fix (the original PR)
Converted ff4-modules' `src/ingame/free_space.s` to `.pool`/`.alloc`. Surfaced `AllocNode._measure_body` crashing on forward refs because `SymbolNode.pc_after` evaluates RHS eagerly. `Program.resolve_labels` already skips SymbolNode in pass 1; AllocNode now mirrors that rule.

### 2. Multi-alloc validated
Two `.alloc`s into one pool with `strategy order` lay out contiguously, byte-identical to the legacy single-region layout. Validated by splitting free_space.s into pre-inventory + inventory blocks: IPS records concatenate to byte-match the baseline modulo BUILD_DATE timestamp drift.

### 3. Expression support in pool literals
`.pool` / `.reclaim` / `.relocate` accept `ExpressionAstNode` instead of bare ints for range bounds, fill byte, reclaim/relocate addrs. Arithmetic on literals works (forward refs to user-declared constants raise with a clear message — they live in `SymbolNode.pc_after`).

### 4. Pool stats as scope symbols
`.pool` decl publishes `<name>.capacity`, `<name>.fragments`, `<name>.largest_chunk` for compile-time `.if` guards.

### 5. Object mode + linker
**`.alloc` works in `.compile-only` mode.** `Program._object_emit_alloc` opens a pinned region at the allocator-chosen address, walks the body through the standard object-emit path so relocations record properly. The module becomes non-relocatable (allocator picked final addrs — link-time relocation makes no sense). The alloc's label exports through the normal symbol path.

Cross-TU verified end-to-end:
```ca65
; provider.s
.pool p { range 0x028000 0x0280ff }
.alloc fn in p { rts }

; consumer.s
.extern fn
*=0x008000
main:
    jsr.l fn
    rts
```
After `assemble_as_object` + `Linker.link()`, the consumer's `jsr.l fn` operand resolves to `0x028000` (provider's allocator-chosen address).

**Scope**: each `.o` owns its own pool registry. Cross-TU pool *merging* (two `.o`s declaring same-named pool, linker unioning their ranges) is a separate follow-up — current scope matches ff4-modules' actual layout (each module declares its own bank's slack).

### 6. Coverage hardening
100% line coverage on `AllocNode`, `RelocateNode`, all four pool AST nodes, `pool.py`, `Resolver.allocate_pools`. Tests now assert exact emitted bytes at allocator-chosen addresses, not loose membership.

### 7. Parser cleanup
Replaces `dict[str, str | int] + cast` pattern in `parse_pool` with a `_PoolAttrs` dataclass.

## What's **not** in this PR

| follow-up | why deferred |
|-----------|--------------|
| Fill-byte emission | Per request — can wait |
| Cross-TU pool merging | Separate slice — serialize pool decls + alloc requests to .o, linker collects + runs allocator at link time |
| LSP DocumentSymbol outline | Cosmetic; LSP keyword completion already covers `pool` / `alloc` / `relocate` / `reclaim` |
| Forward-ref constants in pool literals | Requires eager eval of `SymbolAffectationAstNode` at codegen — broader change |

## Test plan
- [x] `hatch run tests:tests` — 869 passed, 1 skipped (31 new tests in this PR)
- [x] `hatch run tests:check` — ruff clean
- [x] `hatch run tests:type` — mypy clean
- [x] ff4-modules dogfood (single `.alloc` and two-`.alloc` split) — IPS byte-identical modulo timestamp
- [x] Object-mode + linker round-trip for cross-module `.alloc` references
- [x] CI active (workflow filter from #48)