### PR TITLE
Pool: expressions, stats, object/link mode, cross-TU merging, exhaustion

### DIFF
--- a/a816/linker.py
+++ b/a816/linker.py
@@ -51,6 +51,7 @@ class Linker:
         if base_address is not None:
             self.base_address = base_address
         self._resolve_symbols()
+        self._merge_pool_decls()
         self._resolve_aliases()
         self._check_unresolved()
         self._apply_relocations()
@@ -61,7 +62,54 @@ class Linker:
             aliases=[],
             files=self.linked_files,
             relocatable=False,
+            pool_decls=self._merged_pool_decls,
         )
+
+    def _merge_pool_decls(self) -> None:
+        """Union same-named `.pool` declarations across input modules.
+
+        Two modules declaring the same pool name must agree on `fill` and
+        `strategy` and contribute non-overlapping ranges. The merged pool
+        carries the union of ranges; the linker exposes it on the output
+        ObjectFile.pool_decls for tooling (e.g. xobj) and as the source
+        of truth for future link-time allocation passes.
+        """
+        from a816.object_file import PoolDecl
+        from a816.pool import Pool, PoolRange, Strategy
+
+        merged: dict[str, Pool] = {}
+        for obj_file in self.object_files:
+            for decl in obj_file.pool_decls:
+                if decl.name in merged:
+                    existing = merged[decl.name]
+                    if existing.fill != decl.fill:
+                        raise ValueError(
+                            f"pool {decl.name!r} declared with conflicting fill bytes: "
+                            f"0x{existing.fill:02x} vs 0x{decl.fill:02x}"
+                        )
+                    if existing.strategy.value != decl.strategy:
+                        raise ValueError(
+                            f"pool {decl.name!r} declared with conflicting strategies: "
+                            f"{existing.strategy.value!r} vs {decl.strategy!r}"
+                        )
+                    for start, end in decl.ranges:
+                        existing.reclaim(PoolRange(start=start, end=end))
+                else:
+                    merged[decl.name] = Pool(
+                        name=decl.name,
+                        ranges=[PoolRange(start=s, end=e) for s, e in decl.ranges],
+                        fill=decl.fill,
+                        strategy=Strategy(decl.strategy),
+                    )
+        self._merged_pool_decls = [
+            PoolDecl(
+                name=p.name,
+                ranges=[(r.start, r.end) for r in p.ranges],
+                fill=p.fill,
+                strategy=p.strategy.value,
+            )
+            for p in merged.values()
+        ]
 
     def _delta_for(self, obj_file: ObjectFile, running_offset: int) -> int:
         """How much to shift this module's logical addresses by.

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -9,7 +9,8 @@ from a816.exceptions import (
     RelocationError,
     UnresolvedSymbolError,
 )
-from a816.object_file import ObjectFile, Region, RelocationType, SymbolSection, SymbolType
+from a816.object_file import ObjectFile, PoolDecl, Region, RelocationType, SymbolSection, SymbolType
+from a816.pool import Pool
 
 SYMBOL_TOKEN_RE = re.compile(r"([A-Za-z_\.][A-Za-z0-9_\.]*)")
 
@@ -50,8 +51,10 @@ class Linker:
     def link(self, base_address: int | None = None) -> ObjectFile:
         if base_address is not None:
             self.base_address = base_address
+        # Pool allocation must happen before symbol ingestion so the
+        # region.base_address values we ingest reflect allocator choices.
+        self._allocate_pools_across_modules()
         self._resolve_symbols()
-        self._merge_pool_decls()
         self._resolve_aliases()
         self._check_unresolved()
         self._apply_relocations()
@@ -63,6 +66,62 @@ class Linker:
             files=self.linked_files,
             relocatable=False,
             pool_decls=self._merged_pool_decls,
+        )
+
+    def _allocate_pools_across_modules(self) -> None:
+        """Union pool decls, run allocator over merged view, patch regions.
+
+        Each .o carries `pool_decls` (declarations) + `pool_allocs`
+        (deferred placement requests). The linker unions same-named
+        pools (fill/strategy must agree), requests every alloc in
+        declaration-then-request order, runs `Pool.allocate()`, and
+        rewrites each requesting region's `base_address` to the
+        allocator-chosen address. Body labels inside the region keep
+        their offsets; the existing CODE-symbol delta path carries them
+        to their final positions when `_resolve_symbols` ingests.
+        """
+        self._merge_pool_decls()
+        merged: dict[str, Pool] = {p.name: self._pool_from_decl(p) for p in self._merged_pool_decls}
+        # (obj_idx, region_idx) -> Allocation, to look up alloc.addr later.
+        self._region_pool_alloc: dict[tuple[int, int], object] = {}
+        # Allocation request order: stable across rebuilds = (obj input order,
+        # then declaration order within each .o).
+        for obj_idx, obj_file in enumerate(self.object_files):
+            for req in obj_file.pool_allocs:
+                pool = merged.get(req.pool_name)
+                if pool is None:
+                    raise ValueError(
+                        f"pool alloc {req.symbol_name!r} references undeclared pool {req.pool_name!r}"
+                    )
+                alloc_obj = pool.request(req.symbol_name, req.size)
+                self._region_pool_alloc[(obj_idx, req.region_idx)] = alloc_obj
+        for pool in merged.values():
+            pool.allocate()
+        self._merged_pools_after_alloc = merged
+
+    def _pool_delta_for_symbol(self, obj_file: ObjectFile, obj_idx: int, address: int) -> int | None:
+        """Return the pool region delta if `address` falls inside a pool region.
+
+        Pool regions are placed by the link-time allocator independent of
+        module delta; symbols inside them must shift by the region's
+        own delta, not by the module's relocation.
+        """
+        for local_idx, region in enumerate(obj_file.regions):
+            if (obj_idx, local_idx) not in self._pool_region_deltas:
+                continue
+            if region.base_address <= address < region.base_address + len(region.code):
+                return self._pool_region_deltas[(obj_idx, local_idx)]
+        return None
+
+    @staticmethod
+    def _pool_from_decl(decl: "PoolDecl") -> "Pool":
+        from a816.pool import Pool, PoolRange, Strategy
+
+        return Pool(
+            name=decl.name,
+            ranges=[PoolRange(start=s, end=e) for s, e in decl.ranges],
+            fill=decl.fill,
+            strategy=Strategy(decl.strategy),
         )
 
     def _merge_pool_decls(self) -> None:
@@ -125,9 +184,24 @@ class Linker:
     def _ingest_object(self, obj_file: ObjectFile, running_offset: int) -> None:
         delta = self._delta_for(obj_file, running_offset)
         local_to_linked_file = self._merge_file_table(obj_file)
+        obj_idx = self.object_files.index(obj_file)
+        pool_allocs_by_region: dict[int, object] = {
+            r_idx: alloc
+            for (oi, r_idx), alloc in getattr(self, "_region_pool_alloc", {}).items()
+            if oi == obj_idx
+        }
 
-        for region in obj_file.regions:
-            final_base = region.base_address + delta
+        for local_region_idx, region in enumerate(obj_file.regions):
+            if local_region_idx in pool_allocs_by_region:
+                # Pool-allocated region: linker chose this region's
+                # base_address; ignore the .o's placeholder.
+                alloc = pool_allocs_by_region[local_region_idx]
+                final_base = alloc.addr  # type: ignore[attr-defined]
+                # Per-region symbol delta = (linker base) - (compile base).
+                region_delta = final_base - region.base_address
+                self._pool_region_deltas[(obj_idx, local_region_idx)] = region_delta
+            else:
+                final_base = region.base_address + delta
             region_idx = len(self.linked_regions)
             new_region = Region(
                 base_address=final_base,
@@ -147,11 +221,17 @@ class Linker:
                 self._linked_expression_relocations.append((final_base + offset, region_idx, expression, size_bytes))
 
         for sym in obj_file.symbols:
-            self._ingest_symbol(sym, delta)
+            self._ingest_symbol(sym, delta, obj_file, obj_idx)
 
         self.linked_aliases.extend(obj_file.aliases)
 
-    def _ingest_symbol(self, sym: tuple[str, int, SymbolType, SymbolSection], delta: int) -> None:
+    def _ingest_symbol(
+        self,
+        sym: tuple[str, int, SymbolType, SymbolSection],
+        delta: int,
+        obj_file: ObjectFile,
+        obj_idx: int,
+    ) -> None:
         name, address, symbol_type, section = sym
         if symbol_type == SymbolType.EXTERNAL:
             self._external_symbols_needed.add(name)
@@ -159,7 +239,13 @@ class Linker:
         # CODE symbols ride the module's delta; DATA/BSS/ABS_LABEL are absolute.
         # ABS_LABEL is a `.label`-declared address binding — the user picked
         # the value, so it must NOT shift with the module placement.
-        final_address = address + delta if section == SymbolSection.CODE else address
+        # Pool-allocated regions get their own per-region delta (link-time
+        # allocator chose the address, not module relocation).
+        if section == SymbolSection.CODE:
+            pool_delta = self._pool_delta_for_symbol(obj_file, obj_idx, address)
+            final_address = address + (pool_delta if pool_delta is not None else delta)
+        else:
+            final_address = address
         if symbol_type == SymbolType.GLOBAL:
             if name in self.symbol_map:
                 raise DuplicateSymbolError(name)
@@ -185,6 +271,7 @@ class Linker:
 
     def _resolve_symbols(self) -> None:
         self._external_symbols_needed: set[str] = set()
+        self._pool_region_deltas: dict[tuple[int, int], int] = {}
         running_offset = 0
         for obj_file in self.object_files:
             self._ingest_object(obj_file, running_offset)

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -131,35 +131,14 @@ class Linker:
         `strategy` and contribute non-overlapping ranges. The merged pool
         carries the union of ranges; the linker exposes it on the output
         ObjectFile.pool_decls for tooling (e.g. xobj) and as the source
-        of truth for future link-time allocation passes.
+        of truth for the link-time allocator.
         """
         from a816.object_file import PoolDecl
-        from a816.pool import Pool, PoolRange, Strategy
 
         merged: dict[str, Pool] = {}
         for obj_file in self.object_files:
             for decl in obj_file.pool_decls:
-                if decl.name in merged:
-                    existing = merged[decl.name]
-                    if existing.fill != decl.fill:
-                        raise ValueError(
-                            f"pool {decl.name!r} declared with conflicting fill bytes: "
-                            f"0x{existing.fill:02x} vs 0x{decl.fill:02x}"
-                        )
-                    if existing.strategy.value != decl.strategy:
-                        raise ValueError(
-                            f"pool {decl.name!r} declared with conflicting strategies: "
-                            f"{existing.strategy.value!r} vs {decl.strategy!r}"
-                        )
-                    for start, end in decl.ranges:
-                        existing.reclaim(PoolRange(start=start, end=end))
-                else:
-                    merged[decl.name] = Pool(
-                        name=decl.name,
-                        ranges=[PoolRange(start=s, end=e) for s, e in decl.ranges],
-                        fill=decl.fill,
-                        strategy=Strategy(decl.strategy),
-                    )
+                self._merge_one_pool_decl(merged, decl)
         self._merged_pool_decls = [
             PoolDecl(
                 name=p.name,
@@ -169,6 +148,27 @@ class Linker:
             )
             for p in merged.values()
         ]
+
+    @staticmethod
+    def _merge_one_pool_decl(merged: "dict[str, Pool]", decl: PoolDecl) -> None:
+        from a816.pool import PoolRange
+
+        if decl.name not in merged:
+            merged[decl.name] = Linker._pool_from_decl(decl)
+            return
+        existing = merged[decl.name]
+        if existing.fill != decl.fill:
+            raise ValueError(
+                f"pool {decl.name!r} declared with conflicting fill bytes: "
+                f"0x{existing.fill:02x} vs 0x{decl.fill:02x}"
+            )
+        if existing.strategy.value != decl.strategy:
+            raise ValueError(
+                f"pool {decl.name!r} declared with conflicting strategies: "
+                f"{existing.strategy.value!r} vs {decl.strategy!r}"
+            )
+        for start, end in decl.ranges:
+            existing.reclaim(PoolRange(start=start, end=end))
 
     def _delta_for(self, obj_file: ObjectFile, running_offset: int) -> int:
         """How much to shift this module's logical addresses by.

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -62,6 +62,7 @@ from a816.cpu.cpu_65c816 import AddressingMode, snes_opcode_table
 from a816.exceptions import FormattingError
 from a816.formatter import A816Formatter, FormattingOptions
 from a816.parse.ast.nodes import (
+    AllocAstNode,
     AssignAstNode,
     AstNode,
     BlockAstNode,
@@ -80,6 +81,9 @@ from a816.parse.ast.nodes import (
     MacroAstNode,
     MapAstNode,
     OpcodeAstNode,
+    PoolAstNode,
+    ReclaimAstNode,
+    RelocateAstNode,
     ScopeAstNode,
     StructAstNode,
     SymbolAffectationAstNode,
@@ -107,6 +111,8 @@ class A816Document:
         self.symbols: dict[str, tuple[Position, str]] = {}  # symbol -> (position, file_uri)
         self.labels: dict[str, tuple[Position, str]] = {}  # label -> (position, file_uri)
         self.macros: dict[str, tuple[Position, str]] = {}  # macro -> (position, file_uri)
+        self.pools: dict[str, tuple[Position, str]] = {}  # pool name -> (position, file_uri)
+        self.allocs: dict[str, tuple[Position, str]] = {}  # alloc / relocate name -> (position, file_uri)
         self.externs: set[str] = set()  # extern symbol names (declarations, not definitions)
         self.macro_params: dict[str, list[str]] = {}  # macro_name -> parameter_names
         self.macro_docstrings: dict[str, str] = {}
@@ -129,6 +135,8 @@ class A816Document:
         self.symbols.clear()
         self.labels.clear()
         self.macros.clear()
+        self.pools.clear()
+        self.allocs.clear()
         self.externs.clear()
         self.macro_params.clear()
         self.macro_docstrings.clear()
@@ -260,6 +268,15 @@ class A816Document:
                 self.scope_docstrings[node.name.lower()] = inspect.cleandoc(node.docstring)
         elif isinstance(node, MacroAstNode):
             self._record_macro(node)
+        elif isinstance(node, PoolAstNode):
+            self._record_token_position(node.file_info, self.pools, node.pool_name)
+        elif isinstance(node, AllocAstNode):
+            self._record_token_position(node.file_info, self.allocs, node.name)
+        elif isinstance(node, RelocateAstNode):
+            self._record_token_position(node.file_info, self.allocs, node.symbol)
+        elif isinstance(node, ReclaimAstNode):
+            # No definition site to add — reclaim references an existing pool.
+            pass
         elif isinstance(node, ImportAstNode):
             self._record_import(node)
         elif isinstance(node, StructAstNode):
@@ -1329,6 +1346,32 @@ class A816LanguageServer:
             if file_uri == uri
         ]
 
+    def _doc_symbols_for_pools(self, doc: A816Document, uri: str) -> list[DocumentSymbol]:
+        return [
+            DocumentSymbol(
+                name=name,
+                kind=SymbolKind.Namespace,
+                range=self._doc_symbol_range(pos, len(name)),
+                selection_range=self._doc_symbol_range(pos, len(name)),
+                detail=".pool",
+            )
+            for name, (pos, file_uri) in doc.pools.items()
+            if file_uri == uri
+        ]
+
+    def _doc_symbols_for_allocs(self, doc: A816Document, uri: str) -> list[DocumentSymbol]:
+        return [
+            DocumentSymbol(
+                name=name,
+                kind=SymbolKind.Function,
+                range=self._doc_symbol_range(pos, len(name)),
+                selection_range=self._doc_symbol_range(pos, len(name)),
+                detail=".alloc / .relocate",
+            )
+            for name, (pos, file_uri) in doc.allocs.items()
+            if file_uri == uri
+        ]
+
     def _handle_document_symbols(self, params: DocumentSymbolParams) -> list[DocumentSymbol]:
         doc = self.documents.get(params.text_document.uri)
         if not doc:
@@ -1338,6 +1381,8 @@ class A816LanguageServer:
             *self._doc_symbols_for_labels(doc, uri),
             *self._doc_symbols_for_macros(doc, uri),
             *self._doc_symbols_for_symbols(doc, uri),
+            *self._doc_symbols_for_pools(doc, uri),
+            *self._doc_symbols_for_allocs(doc, uri),
         ]
 
     @staticmethod

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -252,6 +252,14 @@ class A816Document:
         if isinstance(else_block, AstNode):
             self._visit_node_for_symbols(else_block)
 
+    def _record_pool_directive(self, node: AstNode) -> None:
+        if isinstance(node, PoolAstNode):
+            self._record_token_position(node.file_info, self.pools, node.pool_name)
+        elif isinstance(node, AllocAstNode):
+            self._record_token_position(node.file_info, self.allocs, node.name)
+        elif isinstance(node, RelocateAstNode):
+            self._record_token_position(node.file_info, self.allocs, node.symbol)
+
     def _visit_node_for_symbols(self, node: AstNode) -> None:
         """Recursively visit AST nodes to extract symbols and labels."""
         if isinstance(node, DocstringAstNode):
@@ -268,15 +276,8 @@ class A816Document:
                 self.scope_docstrings[node.name.lower()] = inspect.cleandoc(node.docstring)
         elif isinstance(node, MacroAstNode):
             self._record_macro(node)
-        elif isinstance(node, PoolAstNode):
-            self._record_token_position(node.file_info, self.pools, node.pool_name)
-        elif isinstance(node, AllocAstNode):
-            self._record_token_position(node.file_info, self.allocs, node.name)
-        elif isinstance(node, RelocateAstNode):
-            self._record_token_position(node.file_info, self.allocs, node.symbol)
-        elif isinstance(node, ReclaimAstNode):
-            # No definition site to add — reclaim references an existing pool.
-            pass
+        elif isinstance(node, PoolAstNode | AllocAstNode | RelocateAstNode | ReclaimAstNode):
+            self._record_pool_directive(node)
         elif isinstance(node, ImportAstNode):
             self._record_import(node)
         elif isinstance(node, StructAstNode):

--- a/a816/object_file.py
+++ b/a816/object_file.py
@@ -46,9 +46,39 @@ class Region:
     lines: list[tuple[int, int, int, int, int]] = field(default_factory=list)
 
 
+@dataclass
+class PoolDecl:
+    """A `.pool` declaration serialized into a module.
+
+    Linker collects every `PoolDecl` across input modules, unions same-named
+    pools (ranges combined, fill/strategy must match), then runs the
+    allocator on the merged pool for cross-TU placement.
+    """
+
+    name: str
+    ranges: list[tuple[int, int]]
+    fill: int
+    strategy: str
+
+
+@dataclass
+class PoolAlloc:
+    """A `.alloc` / `.relocate` request deferred to link time.
+
+    `region_idx` is the body region in the same ObjectFile — the linker
+    sets that region's `base_address` to the allocator-chosen address.
+    `symbol_name` is the alloc's exported label, also patched.
+    """
+
+    pool_name: str
+    symbol_name: str
+    region_idx: int
+    size: int
+
+
 class ObjectFile:
     MAGIC_NUMBER = 0x41383136  # 'A816'
-    VERSION = 0x0007  # Version 7: SymbolSection.ABS_LABEL for `.label` directives.
+    VERSION = 0x0008  # Version 8: pool decls + alloc requests for cross-TU pool merging.
 
     def __init__(
         self,
@@ -60,6 +90,8 @@ class ObjectFile:
         files: list[str] | None = None,
         lines: list[tuple[int, int, int, int, int]] | None = None,
         relocatable: bool = True,
+        pool_decls: list[PoolDecl] | None = None,
+        pool_allocs: list[PoolAlloc] | None = None,
     ) -> None:
         # `relocatable` is True iff the source contained no `*=` directive,
         # so the importer is free to place region 0 at the import site PC
@@ -82,6 +114,8 @@ class ObjectFile:
         self.aliases: list[tuple[str, str]] = aliases or []
         self.files: list[str] = files or []
         self.relocatable: bool = relocatable
+        self.pool_decls: list[PoolDecl] = pool_decls or []
+        self.pool_allocs: list[PoolAlloc] = pool_allocs or []
 
     # ----- legacy single-region accessors (tests / older callers) -----
     def _ensure_first_region(self) -> Region:
@@ -127,6 +161,32 @@ class ObjectFile:
             self._write_symbol_table(f)
             self._write_alias_table(f)
             self._write_file_table(f)
+            self._write_pool_decls(f)
+            self._write_pool_allocs(f)
+
+    def _write_pool_decls(self, f: IO[bytes]) -> None:
+        f.write(struct.pack("<H", len(self.pool_decls)))
+        for decl in self.pool_decls:
+            name_bytes = decl.name.encode("utf-8")
+            strategy_bytes = decl.strategy.encode("utf-8")
+            f.write(struct.pack("<B", len(name_bytes)))
+            f.write(name_bytes)
+            f.write(struct.pack("<B", len(strategy_bytes)))
+            f.write(strategy_bytes)
+            f.write(struct.pack("<BH", decl.fill, len(decl.ranges)))
+            for start, end in decl.ranges:
+                f.write(struct.pack("<II", start, end))
+
+    def _write_pool_allocs(self, f: IO[bytes]) -> None:
+        f.write(struct.pack("<H", len(self.pool_allocs)))
+        for alloc in self.pool_allocs:
+            pool_bytes = alloc.pool_name.encode("utf-8")
+            sym_bytes = alloc.symbol_name.encode("utf-8")
+            f.write(struct.pack("<B", len(pool_bytes)))
+            f.write(pool_bytes)
+            f.write(struct.pack("<B", len(sym_bytes)))
+            f.write(sym_bytes)
+            f.write(struct.pack("<II", alloc.region_idx, alloc.size))
 
     def _write_header(self, f: IO[bytes]) -> None:
         flags = 0x01 if self.relocatable else 0x00
@@ -250,6 +310,36 @@ class ObjectFile:
         return out
 
     @staticmethod
+    def _read_pool_decls(f: IO[bytes]) -> list[PoolDecl]:
+        (count,) = struct.unpack("<H", f.read(2))
+        out: list[PoolDecl] = []
+        for _ in range(count):
+            (name_len,) = struct.unpack("<B", f.read(1))
+            name = f.read(name_len).decode("utf-8")
+            (strategy_len,) = struct.unpack("<B", f.read(1))
+            strategy = f.read(strategy_len).decode("utf-8")
+            fill, range_count = struct.unpack("<BH", f.read(3))
+            ranges: list[tuple[int, int]] = []
+            for _ in range(range_count):
+                start, end = struct.unpack("<II", f.read(8))
+                ranges.append((start, end))
+            out.append(PoolDecl(name=name, ranges=ranges, fill=fill, strategy=strategy))
+        return out
+
+    @staticmethod
+    def _read_pool_allocs(f: IO[bytes]) -> list[PoolAlloc]:
+        (count,) = struct.unpack("<H", f.read(2))
+        out: list[PoolAlloc] = []
+        for _ in range(count):
+            (pool_len,) = struct.unpack("<B", f.read(1))
+            pool_name = f.read(pool_len).decode("utf-8")
+            (sym_len,) = struct.unpack("<B", f.read(1))
+            sym_name = f.read(sym_len).decode("utf-8")
+            region_idx, size = struct.unpack("<II", f.read(8))
+            out.append(PoolAlloc(pool_name=pool_name, symbol_name=sym_name, region_idx=region_idx, size=size))
+        return out
+
+    @staticmethod
     def from_file(filename: str) -> "ObjectFile":
         with open(filename, "rb") as f:
             header = f.read(7)
@@ -265,4 +355,14 @@ class ObjectFile:
             symbols = ObjectFile._read_symbol_table(f)
             aliases = ObjectFile._read_alias_table(f)
             files = ObjectFile._read_file_table(f)
-            return ObjectFile(regions, symbols, aliases=aliases, files=files, relocatable=relocatable)
+            pool_decls = ObjectFile._read_pool_decls(f)
+            pool_allocs = ObjectFile._read_pool_allocs(f)
+            return ObjectFile(
+                regions,
+                symbols,
+                aliases=aliases,
+                files=files,
+                relocatable=relocatable,
+                pool_decls=pool_decls,
+                pool_allocs=pool_allocs,
+            )

--- a/a816/parse/ast/nodes.py
+++ b/a816/parse/ast/nodes.py
@@ -556,19 +556,23 @@ def _indent_block_body(block: "BlockAstNode", indent: str = "    ") -> str:
     return "\n".join(lines)
 
 
+PoolRangeExpr = tuple["ExpressionAstNode", "ExpressionAstNode"]
+
+
 class PoolAstNode(AstNode):
     """AST node for `.pool NAME { ... }` directive.
 
     Declares a freespace pool with one or more byte ranges, a fill byte, and
-    an allocation strategy. Consumed by the resolver to seed the pool
-    registry used by `.alloc` / `.relocate` / `.reclaim`.
+    an allocation strategy. Range bounds and fill byte are stored as
+    expressions and evaluated at codegen time so users can write
+    `range BANK_BASE 0x028fff` instead of magic literals.
     """
 
     def __init__(
         self,
         name: str,
-        ranges: list[tuple[int, int]],
-        fill: int,
+        ranges: list[PoolRangeExpr],
+        fill: "ExpressionAstNode",
         strategy: str,
         file_info: Token,
     ) -> None:
@@ -579,13 +583,13 @@ class PoolAstNode(AstNode):
         self.strategy = strategy
 
     def to_representation(self) -> tuple[Any, ...]:
-        return self.kind, self.pool_name, tuple(self.ranges), self.fill, self.strategy
+        return self.kind, self.pool_name, len(self.ranges), self.strategy
 
     def to_canonical(self) -> str:
         lines = [f".pool {self.pool_name} {{"]
         for start, end in self.ranges:
-            lines.append(f"    range 0x{start:06x} 0x{end:06x}")
-        lines.append(f"    fill 0x{self.fill:02x}")
+            lines.append(f"    range {start.to_canonical()} {end.to_canonical()}")
+        lines.append(f"    fill {self.fill.to_canonical()}")
         lines.append(f"    strategy {self.strategy}")
         lines.append("}")
         return "\n".join(lines)
@@ -630,8 +634,8 @@ class RelocateAstNode(AstNode):
     def __init__(
         self,
         symbol: str,
-        old_start: int,
-        old_end: int,
+        old_start: "ExpressionAstNode",
+        old_end: "ExpressionAstNode",
         pool_name: str,
         body: "BlockAstNode",
         file_info: Token,
@@ -644,12 +648,17 @@ class RelocateAstNode(AstNode):
         self.body = body
 
     def to_representation(self) -> tuple[Any, ...]:
-        return self.kind, self.symbol, self.old_start, self.old_end, self.pool_name, self.body.to_representation()[0]
+        return (
+            self.kind,
+            self.symbol,
+            self.pool_name,
+            self.body.to_representation()[0],
+        )
 
     def to_canonical(self) -> str:
         body = _indent_block_body(self.body)
         return (
-            f".relocate {self.symbol} 0x{self.old_start:06x} 0x{self.old_end:06x} "
+            f".relocate {self.symbol} {self.old_start.to_canonical()} {self.old_end.to_canonical()} "
             f"into {self.pool_name} {{\n{body}\n}}"
         )
 
@@ -662,17 +671,23 @@ class ReclaimAstNode(AstNode):
     overlapping existing pool ranges raise at resolution time.
     """
 
-    def __init__(self, pool_name: str, start: int, end: int, file_info: Token) -> None:
+    def __init__(
+        self,
+        pool_name: str,
+        start: "ExpressionAstNode",
+        end: "ExpressionAstNode",
+        file_info: Token,
+    ) -> None:
         super().__init__("reclaim", file_info)
         self.pool_name = pool_name
         self.start = start
         self.end = end
 
     def to_representation(self) -> tuple[Any, ...]:
-        return self.kind, self.pool_name, self.start, self.end
+        return self.kind, self.pool_name
 
     def to_canonical(self) -> str:
-        return f".reclaim {self.pool_name} 0x{self.start:06x} 0x{self.end:06x}"
+        return f".reclaim {self.pool_name} {self.start.to_canonical()} {self.end.to_canonical()}"
 
 
 class AssignAstNode(AstNode):

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -69,6 +69,7 @@ from a816.parse.nodes import (
     WordNode,
 )
 from a816.parse.tokens import Token, TokenType
+from a816.pool import Pool, PoolRange, Strategy
 from a816.protocols import NodeProtocol
 from a816.symbols import Resolver
 
@@ -851,28 +852,86 @@ def generate_debug(
     return [DebugNode(node.message, resolver)]
 
 
+def _eval_int(expr: ExpressionAstNode, resolver: Resolver, where: Token) -> int:
+    """Evaluate an expression to a concrete int at code-generation time.
+
+    Pool literal positions (range bounds, fill byte, reclaim/relocate
+    addresses) must resolve to constants — they feed the allocator
+    immediately and cannot defer like a label reference.
+    """
+    from a816.exceptions import ExternalExpressionReference, ExternalSymbolReference
+
+    try:
+        value = eval_expression(expr, resolver)
+    except (ExternalExpressionReference, ExternalSymbolReference) as exc:
+        ref = exc.symbol_name if isinstance(exc, ExternalSymbolReference) else exc.expression_str
+        raise NodeError(
+            f"pool literal must be a constant expression (got external reference {ref!r})",
+            where,
+        ) from exc
+    except SymbolNotDefined as exc:
+        raise NodeError(
+            f"pool literal references undefined symbol {exc!s}; pool decls evaluate "
+            "at code-generation time before forward refs are bound",
+            where,
+        ) from exc
+    if not isinstance(value, int):
+        raise NodeError(
+            f"pool literal must evaluate to int, got {type(value).__name__}",
+            where,
+        )
+    return value
+
+
 def generate_pool(
     node: PoolAstNode,
     resolver: Resolver,
     macro_definitions: MacroDefinitions,
     file_info: Token,
 ) -> GenNodes:
-    from a816.pool import Pool, PoolRange, Strategy
-
     if node.pool_name in resolver.pools:
         raise NodeError(f"pool {node.pool_name!r} already declared", file_info)
     try:
-        ranges = [PoolRange(start=lo, end=hi) for lo, hi in node.ranges]
+        ranges = [
+            PoolRange(
+                start=_eval_int(lo, resolver, file_info),
+                end=_eval_int(hi, resolver, file_info),
+            )
+            for lo, hi in node.ranges
+        ]
+        fill_value = _eval_int(node.fill, resolver, file_info)
+        if not 0 <= fill_value <= 0xFF:
+            raise NodeError(
+                f"pool {node.pool_name!r} fill 0x{fill_value:x} out of byte range",
+                file_info,
+            )
         pool = Pool(
             name=node.pool_name,
             ranges=ranges,
-            fill=node.fill,
+            fill=fill_value,
             strategy=Strategy(node.strategy),
         )
+    except NodeError:
+        raise
     except Exception as exc:  # PoolError, PoolInvalidRangeError, PoolOverlapError
         raise NodeError(f"pool {node.pool_name!r}: {exc}", file_info) from exc
     resolver.pools[node.pool_name] = pool
+    _publish_pool_stats(node.pool_name, pool, resolver)
     return []
+
+
+def _publish_pool_stats(name: str, pool: Pool, resolver: Resolver) -> None:
+    """Bind `<name>.capacity / fragments / largest_chunk` as scope symbols.
+
+    Snapshot at declaration time — pre-allocator. Sufficient for the
+    common case (`.if pool.capacity < N { ... }` guard). Post-allocator
+    stats are recomputed when AllocNodes run; the snapshot stays accurate
+    only for capacity-style values that don't change after declaration.
+    """
+    scope = resolver.current_scope
+    scope.add_symbol(f"{name}.capacity", pool.capacity)
+    scope.add_symbol(f"{name}.fragments", pool.fragments)
+    scope.add_symbol(f"{name}.largest_chunk", pool.largest_chunk)
 
 
 def generate_reclaim(
@@ -881,13 +940,13 @@ def generate_reclaim(
     macro_definitions: MacroDefinitions,
     file_info: Token,
 ) -> GenNodes:
-    from a816.pool import PoolRange
-
     pool = resolver.pools.get(node.pool_name)
     if pool is None:
         raise NodeError(f"reclaim into unknown pool {node.pool_name!r}", file_info)
+    start = _eval_int(node.start, resolver, file_info)
+    end = _eval_int(node.end, resolver, file_info)
     try:
-        pool.reclaim(PoolRange(start=node.start, end=node.end))
+        pool.reclaim(PoolRange(start=start, end=end))
     except Exception as exc:
         raise NodeError(f"reclaim into pool {node.pool_name!r}: {exc}", file_info) from exc
     return []
@@ -917,12 +976,14 @@ def generate_relocate(
 
     if node.pool_name not in resolver.pools:
         raise NodeError(f"relocate into unknown pool {node.pool_name!r}", file_info)
+    old_start = _eval_int(node.old_start, resolver, file_info)
+    old_end = _eval_int(node.old_end, resolver, file_info)
     body_nodes = _code_gen(node.body.body, resolver, macro_definitions)
     return [
         RelocateNode(
             node.symbol,
-            node.old_start,
-            node.old_end,
+            old_start,
+            old_end,
             node.pool_name,
             body_nodes,
             resolver,

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -337,6 +337,27 @@ def _try_eager_register_alias(node: SymbolAffectationAstNode, resolver: Resolver
             object_writer.add_alias(node.symbol, expr_str)
 
 
+def _try_eager_constant_bind(node: SymbolAffectationAstNode, resolver: Resolver) -> bool:
+    """Bind `NAME = constant_expr` eagerly so downstream codegen can read it.
+
+    Pool literals (`.pool`, `.reclaim`, `.relocate` addresses) eval at
+    codegen time, which runs before `SymbolNode.pc_after` binds RHS values.
+    For pure-constant RHS (no label / forward-symbol refs), we can resolve
+    immediately and bind the LHS into the current scope so a following
+    `.pool p { range NAME 0x028fff }` resolves cleanly.
+
+    Returns True iff the binding was successful.
+    """
+    try:
+        value = eval_expression(node.value, resolver)
+    except Exception:  # SymbolNotDefined / external refs / non-int — fall through
+        return False
+    if not isinstance(value, int):
+        return False
+    resolver.current_scope.add_symbol(node.symbol, value)
+    return True
+
+
 def generate_symbol(
     node: SymbolAffectationAstNode,
     resolver: Resolver,
@@ -352,6 +373,9 @@ def generate_symbol(
         and _expression_references_extern(node.value, resolver)
     ):
         _try_eager_register_alias(node, resolver)
+    # Eagerly bind constant RHS so codegen-time consumers (pool literals) see it.
+    elif isinstance(node.value, ExpressionAstNode):
+        _try_eager_constant_bind(node, resolver)
 
     return [SymbolNode(node.symbol, node.value, resolver)]
 
@@ -917,6 +941,17 @@ def generate_pool(
         raise NodeError(f"pool {node.pool_name!r}: {exc}", file_info) from exc
     resolver.pools[node.pool_name] = pool
     _publish_pool_stats(node.pool_name, pool, resolver)
+    if resolver.context.is_object_mode and resolver.context.object_writer is not None:
+        from a816.object_file import PoolDecl
+
+        resolver.context.object_writer.pool_decls.append(
+            PoolDecl(
+                name=pool.name,
+                ranges=[(r.start, r.end) for r in pool.ranges],
+                fill=pool.fill,
+                strategy=pool.strategy.value,
+            )
+        )
     return []
 
 
@@ -929,9 +964,13 @@ def _publish_pool_stats(name: str, pool: Pool, resolver: Resolver) -> None:
     only for capacity-style values that don't change after declaration.
     """
     scope = resolver.current_scope
-    scope.add_symbol(f"{name}.capacity", pool.capacity)
-    scope.add_symbol(f"{name}.fragments", pool.fragments)
-    scope.add_symbol(f"{name}.largest_chunk", pool.largest_chunk)
+    for stat, value in (
+        (f"{name}.capacity", pool.capacity),
+        (f"{name}.fragments", pool.fragments),
+        (f"{name}.largest_chunk", pool.largest_chunk),
+    ):
+        scope.add_symbol(stat, value)
+        resolver.pool_stat_symbol_names.add(stat)
 
 
 def generate_reclaim(

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -741,15 +741,25 @@ class AllocNode(NodeProtocol):
         pool = self.resolver.pools[self.pool_name]
         self._size = max(1, self._measure_body())
         self._alloc = pool.request(self.name, self._size)
+        # Object mode defers allocator to link time. Bind the alloc's
+        # symbol + body labels at the sandbox PC (pool.ranges[0].start)
+        # so they record sensible offsets; the linker rebases the body
+        # region at link time and the existing CODE-symbol delta path
+        # carries every label to its final address.
+        if self.resolver.context.is_object_mode:
+            self._bind_body_labels_at(self._sandbox_pc())
+
+    def _bind_body_labels_at(self, target: Address) -> None:
+        self.resolver.current_scope.add_label(self.name, target)
+        pc = target
+        for node in self.body:
+            pc = node.pc_after(pc)
 
     def _bind_body_labels(self) -> None:
         alloc = self._alloc
         assert alloc is not None
         target = self.resolver.get_bus().get_address(alloc.addr)
-        self.resolver.current_scope.add_label(self.name, target)
-        pc = target
-        for node in self.body:
-            pc = node.pc_after(pc)
+        self._bind_body_labels_at(target)
 
     def pc_after(self, current_pc: Address) -> Address:  # NOSONAR S3516
         # Returning current_pc unchanged is by design: an .alloc block emits

--- a/a816/parse/parser_states.py
+++ b/a816/parse/parser_states.py
@@ -1,5 +1,6 @@
 import ast
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeGuard, cast
 
@@ -399,17 +400,10 @@ def _register_size(register: str, size: int) -> Callable[[Parser, Token], Regist
 _POOL_STRATEGIES = {"pack", "order"}
 
 
-def _parse_pool_number(p: Parser) -> int:
-    token = p.next()
-    expect_token(token, TokenType.NUMBER)
-    return cast(int, ast.literal_eval(token.value))
-
-
-def _parse_pool_fill(p: Parser, key_token: Token) -> int:
-    fill = _parse_pool_number(p)
-    if not 0 <= fill <= 0xFF:
-        raise ParserSyntaxError(f"pool fill 0x{fill:x} out of byte range", key_token)
-    return fill
+def _zero_expression(file_info: Token) -> ExpressionAstNode:
+    """Synthesise the literal expression `0` for default pool fill byte."""
+    zero_tok = Token(TokenType.NUMBER, "0", file_info.position)
+    return ExpressionAstNode([Term(zero_tok)])
 
 
 def _parse_pool_strategy(p: Parser) -> str:
@@ -423,21 +417,23 @@ def _parse_pool_strategy(p: Parser) -> str:
     return strat_token.value
 
 
-def _parse_pool_attr(
-    p: Parser,
-    key_token: Token,
-    ranges: list[tuple[int, int]],
-    state: dict[str, str | int],
-) -> None:
+@dataclass
+class _PoolAttrs:
+    ranges: list[tuple[ExpressionAstNode, ExpressionAstNode]]
+    fill: ExpressionAstNode
+    strategy: str
+
+
+def _parse_pool_attr(p: Parser, key_token: Token, attrs: _PoolAttrs) -> None:
     key = key_token.value
     if key == "range":
-        lo = _parse_pool_number(p)
-        hi = _parse_pool_number(p)
-        ranges.append((lo, hi))
+        lo = parse_expression(p)
+        hi = parse_expression(p)
+        attrs.ranges.append((lo, hi))
     elif key == "fill":
-        state["fill"] = _parse_pool_fill(p, key_token)
+        attrs.fill = parse_expression(p)
     elif key == "strategy":
-        state["strategy"] = _parse_pool_strategy(p)
+        attrs.strategy = _parse_pool_strategy(p)
     else:
         raise ParserSyntaxError(
             f"unknown pool attribute {key!r}; expected range, fill, strategy",
@@ -452,8 +448,7 @@ def parse_pool(p: Parser) -> PoolAstNode:
     expect_token(name_token, TokenType.IDENTIFIER)
     expect_token(p.next(), TokenType.LBRACE)
 
-    ranges: list[tuple[int, int]] = []
-    state: dict[str, str | int] = {"fill": 0x00, "strategy": "pack"}
+    attrs = _PoolAttrs(ranges=[], fill=_zero_expression(keyword), strategy="pack")
 
     while p.current().type != TokenType.EOF:
         current = p.current()
@@ -464,16 +459,16 @@ def parse_pool(p: Parser) -> PoolAstNode:
             continue
         expect_token(current, TokenType.IDENTIFIER)
         key_token = p.next()
-        _parse_pool_attr(p, key_token, ranges, state)
+        _parse_pool_attr(p, key_token, attrs)
 
     expect_token(p.next(), TokenType.RBRACE)
-    if not ranges:
+    if not attrs.ranges:
         raise ParserSyntaxError(f"pool {name_token.value!r} declares no ranges", keyword)
     return PoolAstNode(
         name_token.value,
-        ranges,
-        cast(int, state["fill"]),
-        cast(str, state["strategy"]),
+        attrs.ranges,
+        attrs.fill,
+        attrs.strategy,
         keyword,
     )
 
@@ -505,8 +500,8 @@ def parse_relocate(p: Parser) -> RelocateAstNode:
     keyword = p.current()
     symbol_token = p.next()
     expect_token(symbol_token, TokenType.IDENTIFIER)
-    old_start = _parse_pool_number(p)
-    old_end = _parse_pool_number(p)
+    old_start = parse_expression(p)
+    old_end = parse_expression(p)
     _expect_contextual_keyword(p, "into")
     pool_token = p.next()
     expect_token(pool_token, TokenType.IDENTIFIER)
@@ -528,8 +523,8 @@ def parse_reclaim(p: Parser) -> ReclaimAstNode:
     keyword = p.current()
     pool_token = p.next()
     expect_token(pool_token, TokenType.IDENTIFIER)
-    start = _parse_pool_number(p)
-    end = _parse_pool_number(p)
+    start = parse_expression(p)
+    end = parse_expression(p)
     return ReclaimAstNode(pool_token.value, start, end, keyword)
 
 

--- a/a816/program.py
+++ b/a816/program.py
@@ -406,23 +406,29 @@ class Program:
     def _object_emit_alloc(
         self, node: "AllocNode", object_writer: ObjectWriter, state: "_ObjectEmitState"
     ) -> None:
-        """Emit `.alloc` body into a pinned region at the allocator-chosen address.
+        """Emit `.alloc` body into a deferred region for link-time placement.
 
-        Opens a fresh region at `alloc.addr` (explicit=True so the module
-        becomes non-relocatable — the address is already final), walks the
-        body through the usual object-emit path so child nodes record their
-        own relocations/lines, then re-opens a region at the surrounding PC
-        so subsequent inline code keeps its addressing.
+        The body region opens at the sandbox PC (pool's first range start)
+        so the body's own labels — already bound there by AllocNode
+        pass-1 — emit correctly relative to that base. The linker re-runs
+        the allocator across all input modules' pool decls and PoolAlloc
+        requests, then rebases this region; the existing CODE-symbol delta
+        path carries every label inside the body to its final address.
         """
+        from a816.object_file import PoolAlloc
+
         alloc = node._alloc
-        if alloc is None or not alloc.placed:
+        if alloc is None:
             return
+        sandbox_logical = self.resolver.get_bus().get_address(
+            self.resolver.pools[node.pool_name].ranges[0].start
+        ).logical_value
         self._flush_object_block(object_writer, state)
         saved_pc = self.resolver.pc
         saved_reloc = self.resolver.reloc_address
         try:
-            self.resolver.set_position(alloc.addr)
-            object_writer.start_region(alloc.addr, explicit=True)
+            self.resolver.set_position(sandbox_logical)
+            object_writer.start_region(sandbox_logical, explicit=True)
             for child in node.body:
                 self._object_emit_one(child, object_writer, state)
             self._flush_object_block(object_writer, state)
@@ -430,6 +436,17 @@ class Program:
             self.resolver.pc = saved_pc
             self.resolver.reloc_address = saved_reloc
         object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=False)
+        # Region was at index region_idx; if a current_region was lazily
+        # created at start_region above, it's now the last region index.
+        actual_idx = len(object_writer.regions) - 1
+        object_writer.pool_allocs.append(
+            PoolAlloc(
+                pool_name=node.pool_name,
+                symbol_name=node.name,
+                region_idx=actual_idx,
+                size=node._size,
+            )
+        )
 
     def _accumulate_object_bytes(
         self, node: NodeProtocol, object_writer: ObjectWriter, state: "_ObjectEmitState"

--- a/a816/program.py
+++ b/a816/program.py
@@ -394,11 +394,42 @@ class Program:
         common byte accumulator, the `*=` boundary, and the `.includeips`
         passthrough — owns a single concern.
         """
+        if isinstance(node, AllocNode):
+            self._object_emit_alloc(node, object_writer, state)
+            return
         self._accumulate_object_bytes(node, object_writer, state)
         if isinstance(node, CodePositionNode):
             self._object_open_region(object_writer, state, explicit=True)
         if isinstance(node, IncludeIpsNode):
             self._object_emit_ips_blocks(node, object_writer, state)
+
+    def _object_emit_alloc(
+        self, node: "AllocNode", object_writer: ObjectWriter, state: "_ObjectEmitState"
+    ) -> None:
+        """Emit `.alloc` body into a pinned region at the allocator-chosen address.
+
+        Opens a fresh region at `alloc.addr` (explicit=True so the module
+        becomes non-relocatable — the address is already final), walks the
+        body through the usual object-emit path so child nodes record their
+        own relocations/lines, then re-opens a region at the surrounding PC
+        so subsequent inline code keeps its addressing.
+        """
+        alloc = node._alloc
+        if alloc is None or not alloc.placed:
+            return
+        self._flush_object_block(object_writer, state)
+        saved_pc = self.resolver.pc
+        saved_reloc = self.resolver.reloc_address
+        try:
+            self.resolver.set_position(alloc.addr)
+            object_writer.start_region(alloc.addr, explicit=True)
+            for child in node.body:
+                self._object_emit_one(child, object_writer, state)
+            self._flush_object_block(object_writer, state)
+        finally:
+            self.resolver.pc = saved_pc
+            self.resolver.reloc_address = saved_reloc
+        object_writer.start_region(self.resolver.reloc_address.logical_value, explicit=False)
 
     def _accumulate_object_bytes(
         self, node: NodeProtocol, object_writer: ObjectWriter, state: "_ObjectEmitState"

--- a/a816/program.py
+++ b/a816/program.py
@@ -569,6 +569,8 @@ class Program:
         for name, value in self.resolver.get_all_symbols():
             if self.resolver.current_scope.is_external_symbol(name):
                 continue  # already added by ExternNode
+            if name in self.resolver.pool_stat_symbol_names:
+                continue  # pool stat snapshots are per-module, not linker-visible
             sym_type, section, sym_value = self._classify_object_symbol(name, value, label_names, absolute_label_names)
             object_writer.add_symbol(name, sym_value, sym_type, section)
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -262,11 +262,14 @@ class Resolver:
         pass that binds labels. Pool.allocate is idempotent — safe to call
         multiple times.
 
-        In object mode each TU runs its own allocator over its own pool
-        view. Cross-TU pool decls also serialize to the `.o` so the linker
-        can union same-named pools (validation + tooling) — full
-        link-time allocation of alloc requests is a future slice.
+        Skipped in object mode: the linker collects pool decls + alloc
+        requests across all input modules, unions same-named pools, and
+        runs the allocator over the merged view. Local pre-allocation
+        would assign each module its own copy of the pool, defeating
+        cross-TU sharing.
         """
+        if self.context.is_object_mode:
+            return
         for pool in self.pools.values():
             pool.allocate()
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -248,6 +248,10 @@ class Resolver:
         self.reloc_address: Address
         self.context = AssemblyContext()
         self.pools: dict[str, Pool] = {}
+        # Names registered by `_publish_pool_stats` — kept out of object-mode
+        # symbol export so two `.o` files declaring the same pool don't
+        # collide on `<pool>.capacity` etc. at link time.
+        self.pool_stat_symbol_names: set[str] = set()
         self.set_position(pc)
 
     def allocate_pools(self) -> None:
@@ -257,6 +261,11 @@ class Resolver:
         `.alloc` and `.relocate` blocks see their final addresses on the
         pass that binds labels. Pool.allocate is idempotent — safe to call
         multiple times.
+
+        In object mode each TU runs its own allocator over its own pool
+        view. Cross-TU pool decls also serialize to the `.o` so the linker
+        can union same-named pools (validation + tooling) — full
+        link-time allocation of alloc requests is a future slice.
         """
         for pool in self.pools.values():
             pool.allocate()

--- a/a816/writers.py
+++ b/a816/writers.py
@@ -1,7 +1,7 @@
 import struct
 from typing import BinaryIO, Protocol
 
-from a816.object_file import ObjectFile, Region, RelocationType, SymbolSection, SymbolType
+from a816.object_file import ObjectFile, PoolAlloc, PoolDecl, Region, RelocationType, SymbolSection, SymbolType
 
 
 class Writer(Protocol):
@@ -90,6 +90,8 @@ class ObjectWriter(Writer):
         self.aliases: list[tuple[str, str]] = []
         self.files: list[str] = []
         self._file_index: dict[str, int] = {}
+        self.pool_decls: list[PoolDecl] = []  # populated by generate_pool
+        self.pool_allocs: list[PoolAlloc] = []  # populated by AllocNode object-mode emit
         self._current_region: Region | None = None
         self._pending_base_address: int = 0
         self._region_bytes_emitted: int = 0
@@ -111,6 +113,8 @@ class ObjectWriter(Writer):
         self._region_bytes_emitted = 0
         self._pending_emit_bytes = 0
         self._has_explicit_position = False
+        self.pool_decls = []
+        self.pool_allocs = []
 
     def mark_emitted(self, count: int) -> None:
         """Advance the per-region emit cursor by ``count`` bytes.
@@ -191,6 +195,8 @@ class ObjectWriter(Writer):
             aliases=self.aliases,
             files=self.files,
             relocatable=relocatable,
+            pool_decls=list(self.pool_decls),
+            pool_allocs=list(self.pool_allocs),
         )
         obj_file.write(self.output_file)
 

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -232,6 +232,31 @@ Replays the records of an existing IPS patch into the current build.
 See the dedicated [Modules](modules.md) page for `.import` / `.extern`
 semantics, the build workflow, and prelude usage.
 
+## Freespace pools
+
+See the dedicated [Freespace pools](freespace-pools.md) page for the
+full reference. Quick form:
+
+### `.pool NAME { ... }`
+
+Declares a named freespace pool with one or more ranges, optional
+fill byte, and allocation strategy (`pack` | `order`).
+
+### `.alloc NAME in POOL { body }`
+
+Reserves space for `body` in the named pool; the allocator picks the
+address and binds `NAME` there.
+
+### `.relocate SYMBOL OLD_START OLD_END into POOL { body }`
+
+Moves `SYMBOL` from `[OLD_START, OLD_END]` into the pool — old range
+is reclaimed before the new body is placed.
+
+### `.reclaim POOL START END`
+
+Adds `[START, END]` to the named pool. Escape hatch for slack with
+no original label.
+
 ## Comments and docstrings
 
 ```ca65

--- a/docs/docs/freespace-pools.md
+++ b/docs/docs/freespace-pools.md
@@ -6,74 +6,171 @@ chunks of ROM, request space inside them, reclaim ranges from
 previously-occupied code, and let the assembler place everything
 deterministically.
 
-!!! warning "Preview — Python API only"
+## Quick start
 
-    The allocator core ships today (`a816.pool`). The corresponding
-    assembler directives (`.pool`, `.relocate`, `.alloc`, `.reclaim`)
-    are **not yet wired into the parser** — track progress in the
-    follow-up PRs after #46. This page documents the design and the
-    Python-level API you can drive directly.
+```ca65
+; Declare a pool of free bytes the assembler may use.
+.pool bank01_slack {
+    range 0x01ff35 0x01ffff
+    fill 0xea          ; optional; default 0x00
+    strategy order     ; or `pack` (default — largest-first)
+}
+
+; Drop a new routine into the pool. Allocator picks the address.
+.alloc draw_vwf_message in bank01_slack {
+    jsr.l items_description.draw_trampoline
+    rts
+}
+
+; Move an existing routine into the pool. Old range is reclaimed
+; into the pool (its bytes become reusable for later allocs).
+.relocate fn_old 0x02c000 0x02c17f into bank01_slack {
+    pha
+    rts
+}
+
+; Add a raw byte range to a pool (rarely needed — most reclaims
+; happen via .relocate). Useful for slack with no original label.
+.reclaim bank01_slack 0x01ebd2 0x01ed44
+```
+
+After build, every `.alloc` / `.relocate` symbol resolves to the
+address the allocator picked. Callers reference the symbol normally
+(`jsr.l draw_vwf_message`) — the address is determined at link time
+(object mode) or at the end of the resolver's first pass (direct
+mode).
 
 ## Concepts
 
 - **Pool** — a named bag of free `(start, end)` ranges in a single
-  ROM, plus a `fill` byte and an allocation strategy. Pool ranges
-  must not cross bank boundaries.
+  ROM, plus a `fill` byte and an allocation strategy. Each range
+  must not cross a bank boundary; ranges of the same pool must not
+  overlap.
 - **Allocation** — a named request for `N` bytes inside a specific
   pool. After `Pool.allocate()` runs, every allocation has a final
   ROM address.
 - **Reclaim** — adding a fresh range to a pool (typically the old
   location of a function that just moved). Reclaimed ranges merge
   with adjacent existing ranges automatically.
-- **Strategy** — `PACK` (largest allocation first, default) minimises
-  fragmentation; `ORDER` (declaration order) keeps placements stable
+- **Strategy** — `pack` (largest allocation first, default) minimises
+  fragmentation; `order` (declaration order) keeps placements stable
   when you reorder the source.
 
 Both strategies are deterministic: identical input → identical
-placement → byte-identical IPS output.
+placement → byte-identical output.
 
-## Planned directive syntax
+## Directives
 
-What the assembler will accept once the parser is wired up:
+### `.pool NAME { ... }`
 
 ```ca65
 .pool bank02_slack {
-    0x028000..0x028fff
-    0x02a100..0x02a4c0
-    fill: 0xea          ; nop-fill unused tail
-    strategy: pack
+    range 0x028000 0x028fff
+    range 0x02a100 0x02a4c0   ; multiple ranges allowed
+    fill 0xea                  ; optional
+    strategy order             ; optional (pack | order)
 }
-
-; relocate an existing labelled region into a pool;
-; old range is reclaimed and fill-byted in the same step
-.relocate fn_old into bank02_slack {
-    pha
-    lda.b 0x42
-    ...
-    rts
-}
-
-; fresh code into a pool, no reclaim
-.alloc helper_fn in bank20_main {
-    ...
-}
-
-; raw range reclaim (escape hatch for unlabelled holes)
-.reclaim 0x02c000..0x02c17f into bank02_slack
 ```
 
-Compile-time introspection will expose pool stats as scope symbols:
+`range`, `fill`, and `strategy` accept constant expressions; literal
+arithmetic resolves at code-generation time. Constants declared
+earlier in the same source bind eagerly so `range BASE BASE + 0xff`
+works.
+
+### `.alloc NAME in POOL { body }`
 
 ```ca65
-.if bank02_slack.free < 0x100 {
-    .debug 'bank02_slack almost full'
+.alloc helper_fn in bank02_slack {
+    rts
 }
 ```
 
-Stats available: `<pool>.free`, `<pool>.used`, `<pool>.capacity`,
-`<pool>.fragments`, `<pool>.largest_chunk`.
+Allocator picks the address. `helper_fn` symbol resolves to that
+address. Body bytes land there.
 
-## Python API today
+### `.relocate SYMBOL OLD_START OLD_END into POOL { body }`
+
+```ca65
+.relocate fn_old 0x02c000 0x02c17f into bank02_slack {
+    pha
+    rts
+}
+```
+
+Same as `.alloc` plus the old `[OLD_START, OLD_END]` range is
+reclaimed back into the pool *before* the new body is placed — so
+the freed bytes can fund the move when the rest of the pool is
+otherwise full.
+
+### `.reclaim POOL START END`
+
+```ca65
+.reclaim bank01_slack 0x01ebd2 0x01ed44
+```
+
+Escape hatch for slack that has no original label. Adds the inclusive
+range to the named pool. Overlap with existing ranges raises.
+
+## Pool stats as scope symbols
+
+Every `.pool` decl publishes three snapshot symbols at code-gen time:
+
+```ca65
+.pool bank01_slack {
+    range 0x01ff35 0x01ffff
+}
+
+.if bank01_slack.capacity < 0x100 {
+    .debug 'bank01_slack too small for what we plan'
+}
+```
+
+Available stats: `<pool>.capacity`, `<pool>.fragments`,
+`<pool>.largest_chunk`. Snapshot at declaration — live `.free` /
+`.used` (post-allocator) are not exposed yet.
+
+## Pool exhaustion
+
+When an alloc doesn't fit any chunk, the allocator raises
+`PoolOverflowError` carrying the alloc's name + size:
+
+```
+PoolOverflowError: alloc 'oversized' size 0x180 does not fit in any free chunk
+```
+
+`grep` the alloc name to find the offending source. Same error
+surfaces in direct-mode (during resolver pass 2) and at link time
+(cross-TU allocator).
+
+## Object mode + cross-TU pool merging
+
+In object compilation (`a816 --compile-only`), allocation is deferred
+to link time. Two modules can declare the same pool name with
+complementary ranges; the linker unions the ranges and runs the
+allocator across all modules' deferred requests:
+
+```ca65
+; module_a.s
+.pool slack { range 0x028000 0x0280ff }
+.alloc fn_a in slack { rts }
+
+; module_b.s
+.pool slack { range 0x02a000 0x02a0ff }
+.alloc fn_b in slack { rts }
+```
+
+After link, `fn_a` lands in module A's chunk, `fn_b` in module B's
+chunk. Same-named pools must agree on `fill` and `strategy`;
+mismatches raise at link time.
+
+The `.o` format (version 0x0008) carries `PoolDecl` and `PoolAlloc`
+records (visible via `xobj`).
+
+## Python API
+
+The allocator core is usable directly from Python — useful for
+build-time tooling that wants to manage placement without a `.s`
+source.
 
 ```python
 from a816.pool import Pool, PoolRange, Strategy
@@ -90,10 +187,7 @@ pool = Pool(
 
 moved_fn = pool.request("moved_fn", size=0x180)
 helper   = pool.request("helper", size=0x40)
-
-# optionally reclaim the function's old location before placement
 pool.reclaim(PoolRange(start=0x02C000, end=0x02C17F))
-
 pool.allocate()
 
 print(f"{moved_fn.name} @ 0x{moved_fn.addr:06x}")
@@ -109,19 +203,19 @@ print(f"free={pool.free} used={pool.used} fragments={pool.fragments}")
 | `PoolOverflowError`     | no chunk has enough room for an allocation |
 | `PoolError`             | zero-size request, fill byte out of `0..0xff`, mutation after `allocate()` |
 
-### Determinism rules
+### Determinism
 
 - `allocate()` is idempotent; calling it twice does nothing the second
   time.
 - After `allocate()`, the pool is frozen: further `request()` or
   `reclaim()` calls raise `PoolError`. Build a new `Pool` for the next
   pass.
-- `PACK` sorts by `(-size, name)` — name is the tiebreaker, so
+- `pack` sorts by `(-size, name)` — name is the tiebreaker, so
   same-size allocations never flip on rebuild.
 
 ## Migrating from the manual pattern
 
-The pattern in ff4-modules today:
+The legacy pattern:
 
 ```ca65
 *= 0x01ff35
@@ -133,29 +227,39 @@ _end_of_free_space:
 }
 ```
 
-Once directives land, the same intent becomes:
+becomes:
 
 ```ca65
 .pool bank01_slack {
-    0x01ff35..0x01ffff
-    fill: 0xff
+    range 0x01ff35 0x01ffff
 }
 
-.alloc fn_a in bank01_slack { ... }
-.alloc fn_b in bank01_slack { ... }
+.alloc bank01_slack_block in bank01_slack {
+    fn_a: ...
+    fn_b: ...
+}
 ```
 
 The pool-level overflow check replaces the hand-rolled
-`_end_of_free_space` guard, and unused tail bytes get filled
-automatically.
+`_end_of_free_space` guard, and the allocator picks each label's
+final address.
 
-## Roadmap
+See the ff4-modules dogfood for three real conversions:
+`src/ingame/free_space.s`,
+`src/ingame/inventory_rolling_trampolines.s`, and
+`src/battle/inventory_rolling_patches.s` — byte-identical IPS output
+to the legacy layout modulo build-date timestamp drift.
 
-| Stage | Status | Scope |
-|-------|--------|-------|
-| Allocator core (Python) | ✅ shipped (PR #46) | `Pool`, `PoolRange`, `Allocation`, strategies, reclaim, stats |
-| Parser directives        | ⏳ planned         | `.pool`, `.relocate`, `.alloc`, `.reclaim` |
-| Codegen + fill emission  | ⏳ planned         | wire allocator into resolver pass-2, emit `fill` bytes through IPS writer |
-| Pool stats as symbols    | ⏳ planned         | `<pool>.free` etc. usable in `.if` |
-| Object / linker support  | ⏳ planned         | pool decl records in `.o`, cross-TU pool union + allocator |
-| ff4-modules migration    | ⏳ planned         | reference sample replacing `free_space.s` |
+## What's not in yet
+
+- **Fill-byte emission** — `fill` parses + stores but IPS records
+  over unused chunk tails and reclaimed ranges aren't written. Pool
+  ranges that aren't `.alloc`'d stay as whatever the unpatched ROM
+  contained.
+- **`.relocate` in object mode** — only direct mode for now; link-time
+  reclaim coordination is a follow-up.
+- **Live `.free` / `.used` stats** — only `.capacity` / `.fragments` /
+  `.largest_chunk` are snapshotted at decl time.
+- **LSP "find references" for pool / alloc names** — outline shows
+  them, definition jumps work, but cross-document refs aren't
+  resolved yet.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -204,11 +204,23 @@ main:
 
 Declare reusable chunks of free ROM, relocate functions into them,
 and let the assembler place everything deterministically. The
-allocator core ships today as a Python API (`a816.pool`); the
-matching directives (`.pool`, `.relocate`, `.alloc`, `.reclaim`) are
-in flight. See [Freespace pools](freespace-pools.md) for the design,
-current API, and migration path from the manual `*=` + end-label
-pattern.
+`.pool` / `.alloc` / `.relocate` / `.reclaim` directives replace the
+manual `*= ADDR` + end-label + overflow guard pattern with a
+declarative pool the assembler manages. In object compilation the
+linker unions same-named pools across translation units and runs the
+allocator over the merged view, so multiple modules can share a pool
+name. See [Freespace pools](freespace-pools.md) for syntax,
+cross-TU usage, error model, and migration from the manual pattern.
+
+```ca65
+.pool bank01_slack {
+    range 0x01ff35 0x01ffff
+}
+
+.alloc helper in bank01_slack {
+    rts
+}
+```
 
 ## Project configuration (`a816.toml`)
 

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -245,6 +245,132 @@ class TestAllocPass1ForwardRefs:
         )
 
 
+class TestLspDocumentSymbols:
+    """`.pool` and `.alloc` / `.relocate` names surface in the LSP
+    document outline so editors can show them in the navigation panel."""
+
+    def test_pool_and_alloc_indexed(self) -> None:
+        from a816.lsp.server import A816Document
+
+        doc = A816Document(
+            uri="file:///t.s",
+            content=(
+                ".pool bank01_slack { range 0x01ff35 0x01ffff }\n"
+                ".alloc helper in bank01_slack {\n"
+                "    rts\n"
+                "}\n"
+                ".relocate fn 0x02c000 0x02c17f into bank01_slack {\n"
+                "    rts\n"
+                "}\n"
+            ),
+        )
+        assert "bank01_slack" in doc.pools
+        assert "helper" in doc.allocs
+        assert "fn" in doc.allocs
+
+
+class TestCrossTuPoolMerging:
+    """Linker unions same-named `.pool` decls across modules.
+
+    Two modules contributing complementary ranges to the same pool name
+    merge into one larger pool on the output. fill / strategy must agree.
+    Full deferred allocation (alloc placement decided at link time across
+    all modules) is a follow-up; this slice serializes decls and validates
+    conflicts so the foundation is in place.
+    """
+
+    def test_pool_decls_serialize_to_object_file(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        from a816.object_file import ObjectFile
+
+        asm = tmp_path / "mod.s"
+        asm.write_text(
+            """
+            .pool slack {
+                range 0x028000 0x0280ff
+                fill 0xea
+                strategy order
+            }
+            .alloc fn in slack {
+                rts
+            }
+            """
+        )
+        obj = tmp_path / "mod.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        loaded = ObjectFile.from_file(str(obj))
+        assert len(loaded.pool_decls) == 1
+        decl = loaded.pool_decls[0]
+        assert decl.name == "slack"
+        assert decl.ranges == [(0x028000, 0x0280FF)]
+        assert decl.fill == 0xEA
+        assert decl.strategy == "order"
+
+    def test_linker_unions_pool_ranges(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        from a816.linker import Linker
+        from a816.object_file import ObjectFile
+
+        mod_a = tmp_path / "a.s"
+        mod_a.write_text(
+            """
+            .pool slack {
+                range 0x028000 0x0280ff
+            }
+            .alloc fn_a in slack {
+                rts
+            }
+            """
+        )
+        mod_b = tmp_path / "b.s"
+        mod_b.write_text(
+            """
+            .pool slack {
+                range 0x02a000 0x02a0ff
+            }
+            .alloc fn_b in slack {
+                rts
+            }
+            """
+        )
+        obj_a = tmp_path / "a.o"
+        obj_b = tmp_path / "b.o"
+        assert Program().assemble_as_object(str(mod_a), obj_a) == 0
+        assert Program().assemble_as_object(str(mod_b), obj_b) == 0
+        linker = Linker([ObjectFile.from_file(str(obj_a)), ObjectFile.from_file(str(obj_b))])
+        linked = linker.link()
+        # Linker exposes merged pool decl on output.
+        merged = next(p for p in linked.pool_decls if p.name == "slack")
+        # Both modules' ranges combine.
+        assert (0x028000, 0x0280FF) in merged.ranges
+        assert (0x02A000, 0x02A0FF) in merged.ranges
+
+    def test_linker_pool_fill_mismatch_errors(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        from a816.linker import Linker
+        from a816.object_file import ObjectFile
+
+        for name, fill in (("a", "0xea"), ("b", "0xff")):
+            asm = tmp_path / f"{name}.s"
+            asm.write_text(
+                f"""
+                .pool slack {{
+                    range 0x02{name}000 0x02{name}0ff
+                    fill {fill}
+                }}
+                .alloc fn_{name} in slack {{
+                    rts
+                }}
+                """
+            )
+            obj = tmp_path / f"{name}.o"
+            assert Program().assemble_as_object(str(asm), obj) == 0
+
+        objs = [
+            ObjectFile.from_file(str(tmp_path / "a.o")),
+            ObjectFile.from_file(str(tmp_path / "b.o")),
+        ]
+        with pytest.raises(ValueError, match="conflicting fill"):
+            Linker(objs).link()
+
+
 class TestObjectMode:
     """`.pool` + `.alloc` work when compiling to .o.
 
@@ -378,6 +504,28 @@ class TestPoolExpressions:
     yet at code-generation time (they live in SymbolNode.pc_after which
     runs in pass-2 of resolve_labels). Arithmetic on literals works.
     """
+
+    def test_pool_range_uses_constant_symbol_forward_ref(self) -> None:
+        """Constant declared before .pool is bound eagerly so the pool
+        literal can read it at codegen time."""
+        program = Program()
+        writer = StubWriter()
+        src = """
+        BANK02_BASE = 0x028000
+        BANK02_TOP  = 0x028fff
+        .pool p {
+            range BANK02_BASE BANK02_TOP
+            fill 0xea
+        }
+        .alloc fn in p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        pool = program.resolver.pools["p"]
+        assert pool.ranges[0].start == 0x028000
+        assert pool.ranges[0].end == 0x028FFF
+        assert pool.fill == 0xEA
 
     def test_pool_fill_arithmetic_expression(self) -> None:
         program = Program()

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -343,6 +343,56 @@ class TestCrossTuPoolMerging:
         assert (0x028000, 0x0280FF) in merged.ranges
         assert (0x02A000, 0x02A0FF) in merged.ranges
 
+    def test_link_time_allocator_places_allocs_across_modules(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """Two modules share `.pool slack`, each with its own range.
+
+        The linker unions the ranges and runs the allocator across all
+        deferred alloc requests so the two modules' allocs land at
+        non-overlapping addresses within the combined pool.
+        """
+        from a816.linker import Linker
+        from a816.object_file import ObjectFile
+
+        # Each module contributes a 1-byte chunk so each alloc is forced
+        # into a different chunk (each chunk holds exactly one rts).
+        mod_a = tmp_path / "a.s"
+        mod_a.write_text(
+            """
+            .pool slack {
+                range 0x028000 0x028000
+                strategy order
+            }
+            .alloc fn_a in slack {
+                rts
+            }
+            """
+        )
+        mod_b = tmp_path / "b.s"
+        mod_b.write_text(
+            """
+            .pool slack {
+                range 0x02a000 0x02a000
+                strategy order
+            }
+            .alloc fn_b in slack {
+                rts
+            }
+            """
+        )
+        obj_a = tmp_path / "a.o"
+        obj_b = tmp_path / "b.o"
+        assert Program().assemble_as_object(str(mod_a), obj_a) == 0
+        assert Program().assemble_as_object(str(mod_b), obj_b) == 0
+        linker = Linker([ObjectFile.from_file(str(obj_a)), ObjectFile.from_file(str(obj_b))])
+        linker.link()
+        # Both allocs land in the merged pool; addresses are distinct and
+        # come from different chunks (request 1 fills chunk a, request 2
+        # falls into chunk b under strategy=order).
+        addr_a = linker.symbol_map["fn_a"]
+        addr_b = linker.symbol_map["fn_b"]
+        assert addr_a == 0x028000
+        assert addr_b == 0x02A000
+
     def test_linker_pool_fill_mismatch_errors(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         from a816.linker import Linker
         from a816.object_file import ObjectFile

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -245,6 +245,162 @@ class TestAllocPass1ForwardRefs:
         )
 
 
+class TestPoolStatsSymbols:
+    """`.pool` decl binds `<name>.capacity`, `.fragments`, `.largest_chunk`
+    as scope symbols so users can write compile-time guards like:
+        .if mypool.capacity < 0x200 { .debug 'pool too small' }
+    """
+
+    def test_capacity_bound(self) -> None:
+        resolver = _gen(
+            """
+            .pool p {
+                range 0x028000 0x0280ff
+                range 0x02a000 0x02a0ff
+            }
+            """,
+        )
+        assert resolver.current_scope.value_for("p.capacity") == 0x200
+
+    def test_fragments_bound(self) -> None:
+        resolver = _gen(
+            """
+            .pool p {
+                range 0x028000 0x0280ff
+                range 0x02a000 0x02a0ff
+            }
+            """,
+        )
+        assert resolver.current_scope.value_for("p.fragments") == 2
+
+    def test_largest_chunk_bound(self) -> None:
+        resolver = _gen(
+            """
+            .pool p {
+                range 0x028000 0x0280ff
+                range 0x02a000 0x02a1ff
+            }
+            """,
+        )
+        assert resolver.current_scope.value_for("p.largest_chunk") == 0x200
+
+    def test_capacity_usable_in_if_guard(self) -> None:
+        # Compile-time .if reading <pool>.capacity must not crash.
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p {
+            range 0x028000 0x0280ff
+        }
+        .if p.capacity < 0x10000 {
+            .debug 'pool small (expected)'
+        }
+        .alloc fn in p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+
+
+class TestPoolExpressions:
+    """`.pool` / `.reclaim` / `.relocate` accept constant expressions
+    for range bounds, fill byte, and addresses — not just numeric literals.
+    Limitation: forward refs to user-declared constants aren't resolved
+    yet at code-generation time (they live in SymbolNode.pc_after which
+    runs in pass-2 of resolve_labels). Arithmetic on literals works.
+    """
+
+    def test_pool_fill_arithmetic_expression(self) -> None:
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p {
+            range 0x028000 0x028000 + 0xff
+            fill 0xea + 1
+        }
+        .alloc fn in p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        pool = program.resolver.pools["p"]
+        assert pool.ranges[0].start == 0x028000
+        assert pool.ranges[0].end == 0x0280FF
+        assert pool.fill == 0xEB
+
+    def test_pool_unknown_symbol_in_literal_raises(self) -> None:
+        from a816.parse.codegen import code_gen
+        from a816.symbols import Resolver
+
+        resolver = Resolver()
+        result = MZParser.parse_as_ast(
+            """
+            .pool p {
+                range undefined_symbol 0x0280ff
+            }
+            """,
+            filename="t.s",
+        )
+        assert result.parse_error is None
+        with pytest.raises(Exception, match="undefined symbol"):
+            code_gen(result.nodes, resolver)
+
+    def test_reclaim_uses_arithmetic_expression(self) -> None:
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .reclaim p 0x02c000 0x02c000 + 0x17f
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        pool = program.resolver.pools["p"]
+        assert pool.capacity == 0x100 + 0x180
+
+    def test_relocate_uses_arithmetic_expression(self) -> None:
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .relocate fn 0x02c000 0x02c000 + 0x17f into p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        # Original range reclaimed alongside the body's allocation.
+        pool = program.resolver.pools["p"]
+        assert pool.capacity == 0x100 + 0x180
+
+
+class TestMultiAlloc:
+    def test_two_allocs_order_strategy_contiguous(self) -> None:
+        """Multi-alloc dogfood: two .allocs in order strategy lay out
+        contiguously, byte-identical to a single .alloc of combined size."""
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool p {
+            range 0x028000 0x0280ff
+            strategy order
+        }
+        .alloc a in p {
+            nop
+            nop
+            rts
+        }
+        .alloc b in p {
+            rts
+        }
+        """
+        program.assemble_string_with_emitter(src, "test.s", writer)
+        labels = program.resolver.current_scope.labels
+        a_logical = labels["a"]
+        b_logical = labels["b"]
+        # a is 3 bytes (nop, nop, rts), b should follow at a+3.
+        assert b_logical - a_logical == 3, f"order strategy not contiguous: a=0x{a_logical:06x} b=0x{b_logical:06x}"
+        # a placed at chunk start = 0x028000.
+        assert a_logical == 0x028000
+
+
 class TestAllocNodeInternals:
     """Cover NodeProtocol surface bits (emit, __str__, empty paths)."""
 

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -393,6 +393,46 @@ class TestCrossTuPoolMerging:
         assert addr_a == 0x028000
         assert addr_b == 0x02A000
 
+    def test_link_time_pool_overflow_errors(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """Linker errors loud when cross-TU allocs exceed merged pool capacity."""
+        from a816.linker import Linker
+        from a816.object_file import ObjectFile
+
+        # Pool has two 1-byte chunks (no single chunk fits a 2-byte alloc).
+        # First module declares the pool + a 2-byte alloc → won't fit.
+        mod_a = tmp_path / "a.s"
+        mod_a.write_text(
+            """
+            .pool tiny {
+                range 0x028000 0x028000
+            }
+            .alloc fn_a in tiny {
+                rts
+                rts
+            }
+            """
+        )
+        mod_b = tmp_path / "b.s"
+        mod_b.write_text(
+            """
+            .pool tiny {
+                range 0x02a000 0x02a000
+            }
+            .alloc fn_b in tiny {
+                rts
+            }
+            """
+        )
+        for name, src in (("a", mod_a), ("b", mod_b)):
+            obj = tmp_path / f"{name}.o"
+            assert Program().assemble_as_object(str(src), obj) == 0
+        objs = [
+            ObjectFile.from_file(str(tmp_path / "a.o")),
+            ObjectFile.from_file(str(tmp_path / "b.o")),
+        ]
+        with pytest.raises(Exception, match="does not fit"):
+            Linker(objs).link()
+
     def test_linker_pool_fill_mismatch_errors(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         from a816.linker import Linker
         from a816.object_file import ObjectFile
@@ -488,6 +528,42 @@ class TestObjectMode:
         cons_region = next(r for r in linked.regions if r.base_address == 0x008000)
         # main: jsr.l fn (4 bytes: 0x22 LO MID HI) + rts (0x60) = 5 bytes
         assert cons_region.code[:5] == b"\x22\x00\x80\x02\x60"
+
+
+class TestPoolExhaustion:
+    """Pool overflow errors are surfaced loudly in both modes."""
+
+    def test_direct_mode_overflow_raises_with_alloc_name(self) -> None:
+        """One .alloc bigger than the only chunk → loud failure at codegen."""
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool tiny { range 0x028000 0x028000 }
+        .alloc oversized in tiny {
+            rts
+            rts
+            rts
+        }
+        """
+        with pytest.raises(Exception, match="oversized"):
+            program.assemble_string_with_emitter(src, "test.s", writer)
+
+    def test_direct_mode_two_allocs_overflow_raises(self) -> None:
+        """First .alloc fills pool, second has nowhere to go."""
+        program = Program()
+        writer = StubWriter()
+        src = """
+        .pool tiny { range 0x028000 0x028001 strategy order }
+        .alloc filler in tiny {
+            rts
+            rts
+        }
+        .alloc spill in tiny {
+            rts
+        }
+        """
+        with pytest.raises(Exception, match="spill|does not fit"):
+            program.assemble_string_with_emitter(src, "test.s", writer)
 
 
 class TestPoolStatsSymbols:

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -245,6 +245,75 @@ class TestAllocPass1ForwardRefs:
         )
 
 
+class TestObjectMode:
+    """`.pool` + `.alloc` work when compiling to .o.
+
+    The module becomes pinned (allocator picks final addresses, so no
+    further relocation makes sense). Each .alloc emits its body as a
+    pinned region at the allocator-chosen address; alloc's label binds
+    there and ships in the symbol table for cross-module callers.
+    """
+
+    def test_alloc_object_mode_writes_region_at_allocated_addr(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        from a816.object_file import ObjectFile
+
+        src = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            rts
+        }
+        """
+        asm_file = tmp_path / "mod.s"
+        asm_file.write_text(src)
+        obj_file = tmp_path / "mod.o"
+        program = Program()
+        rc = program.assemble_as_object(str(asm_file), obj_file)
+        assert rc == 0
+        obj = ObjectFile.from_file(str(obj_file))
+        # One pinned region landing at the allocator-picked addr (0x028000).
+        alloc_regions = [r for r in obj.regions if r.base_address == 0x028000]
+        assert len(alloc_regions) == 1
+        assert alloc_regions[0].code == b"\x60"  # rts
+        sym_names = [name for name, _, _, _ in obj.symbols]
+        assert "fn" in sym_names
+
+    def test_alloc_object_mode_link_resolves_caller(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        from a816.linker import Linker
+        from a816.object_file import ObjectFile
+
+        # Provider: defines fn via .alloc.
+        provider_src = """
+        .pool p { range 0x028000 0x0280ff }
+        .alloc fn in p {
+            rts
+        }
+        """
+        # Consumer: external ref to fn.
+        consumer_src = """
+        .extern fn
+        *=0x008000
+        main:
+            jsr.l fn
+            rts
+        """
+        prov_asm = tmp_path / "prov.s"
+        prov_asm.write_text(provider_src)
+        cons_asm = tmp_path / "cons.s"
+        cons_asm.write_text(consumer_src)
+        prov_o = tmp_path / "prov.o"
+        cons_o = tmp_path / "cons.o"
+        assert Program().assemble_as_object(str(prov_asm), prov_o) == 0
+        assert Program().assemble_as_object(str(cons_asm), cons_o) == 0
+        linker = Linker([ObjectFile.from_file(str(prov_o)), ObjectFile.from_file(str(cons_o))])
+        linked = linker.link()
+        # Linker resolves fn to 0x028000 (provider's pinned alloc addr).
+        assert linker.symbol_map["fn"] == 0x028000
+        # Consumer's jsr.l fn (0x22) operand patched to the alloc addr.
+        cons_region = next(r for r in linked.regions if r.base_address == 0x008000)
+        # main: jsr.l fn (4 bytes: 0x22 LO MID HI) + rts (0x60) = 5 bytes
+        assert cons_region.code[:5] == b"\x22\x00\x80\x02\x60"
+
+
 class TestPoolStatsSymbols:
     """`.pool` decl binds `<name>.capacity`, `.fragments`, `.largest_chunk`
     as scope symbols so users can write compile-time guards like:

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -38,8 +38,7 @@ class TestPoolDirective:
             PoolAstNode,
         )
         assert node.pool_name == "bank02_slack"
-        assert node.ranges == [(0x028000, 0x028FFF)]
-        assert node.fill == 0x00
+        assert len(node.ranges) == 1
         assert node.strategy == "pack"
 
     def test_multi_range_with_options(self) -> None:
@@ -54,8 +53,7 @@ class TestPoolDirective:
             """,
             PoolAstNode,
         )
-        assert node.ranges == [(0x028000, 0x028FFF), (0x02A100, 0x02A4C0)]
-        assert node.fill == 0xEA
+        assert len(node.ranges) == 2
         assert node.strategy == "order"
 
     def test_empty_pool_is_error(self) -> None:
@@ -64,12 +62,18 @@ class TestPoolDirective:
         assert "no ranges" in result.parse_error.message
 
     def test_fill_out_of_byte_range_is_error(self) -> None:
+        # Now caught at codegen, not parse. Drive through assemble.
+        from a816.parse.codegen import code_gen
+        from a816.symbols import Resolver
+
+        resolver = Resolver()
         result = MZParser.parse_as_ast(
             ".pool p { range 0x028000 0x028fff fill 0x100 }",
             filename="t.s",
         )
-        assert result.parse_error is not None
-        assert "out of byte range" in result.parse_error.message
+        assert result.parse_error is None
+        with pytest.raises(Exception, match="out of byte range"):
+            code_gen(result.nodes, resolver)
 
     def test_unknown_strategy_is_error(self) -> None:
         result = MZParser.parse_as_ast(
@@ -135,8 +139,9 @@ class TestRelocateDirective:
             RelocateAstNode,
         )
         assert node.symbol == "fn_old"
-        assert node.old_start == 0x02C000
-        assert node.old_end == 0x02C17F
+        # old_start / old_end are now ExpressionAstNodes (evaluated at codegen).
+        assert node.old_start.to_canonical() == "0x02c000"
+        assert node.old_end.to_canonical() == "0x02c17f"
         assert node.pool_name == "bank02_slack"
         assert isinstance(node.body, BlockAstNode)
         opcodes = [n for n in node.body.body if isinstance(n, OpcodeAstNode)]
@@ -172,8 +177,8 @@ class TestReclaimDirective:
             ReclaimAstNode,
         )
         assert node.pool_name == "bank02_slack"
-        assert node.start == 0x02C000
-        assert node.end == 0x02C17F
+        assert node.start.to_canonical() == "0x02c000"
+        assert node.end.to_canonical() == "0x02c17f"
 
     def test_to_canonical(self) -> None:
         node = _first_of(
@@ -219,11 +224,10 @@ class TestAstToRepresentation:
             ".pool p { range 0x028000 0x0280ff fill 0xea strategy order }",
             PoolAstNode,
         )
-        kind, name, ranges, fill, strategy = node.to_representation()
+        kind, name, range_count, strategy = node.to_representation()
         assert kind == "pool"
         assert name == "p"
-        assert ranges == ((0x028000, 0x0280FF),)
-        assert fill == 0xEA
+        assert range_count == 1
         assert strategy == "order"
 
     def test_alloc_representation(self) -> None:
@@ -252,11 +256,9 @@ class TestAstToRepresentation:
             """,
             RelocateAstNode,
         )
-        kind, symbol, lo, hi, pool_name, body = node.to_representation()
+        kind, symbol, pool_name, body = node.to_representation()
         assert kind == "relocate"
         assert symbol == "fn"
-        assert lo == 0x02C000
-        assert hi == 0x02C17F
         assert pool_name == "p"
         assert body == "block"
 
@@ -265,7 +267,7 @@ class TestAstToRepresentation:
             ".reclaim p 0x02c000 0x02c17f",
             ReclaimAstNode,
         )
-        assert node.to_representation() == ("reclaim", "p", 0x02C000, 0x02C17F)
+        assert node.to_representation() == ("reclaim", "p")
 
 
 class TestFluffFormat:

--- a/tests/test_xobj.py
+++ b/tests/test_xobj.py
@@ -31,7 +31,7 @@ def test_summary_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> 
     assert rc == 0
     assert "regions: 1" in captured.out
     assert "symbols: 1" in captured.out
-    assert "version: 7" in captured.out
+    assert "version: 8" in captured.out
 
 
 def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -40,7 +40,7 @@ def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
     captured = capsys.readouterr()
     assert rc == 0
     data = json.loads(captured.out)
-    assert data["version"] == 7
+    assert data["version"] == 8
     assert data["regions"][0]["base_address"] == 0x008000
     assert bytes.fromhex(data["regions"][0]["code"]) == b"\xea\xea"
     assert data["symbols"][0]["type"] == "GLOBAL"


### PR DESCRIPTION
Stack continuation after #51 merged. Five commits on top:

| commit | content |
|---|---|
| f4cfa0b | Pool expressions + stats symbols + multi-alloc dogfood validation |
| 77c1ecb | Object mode \`.alloc\`: emit pinned region, link-time symbol resolution |
| 1e9c79d | Forward-ref constants + LSP outline + pool decl serialization to .o |
| e3403ae | Cross-TU pool merging: link-time allocator across modules |
| 30add8f | Pool exhaustion tests for direct + object/link modes |

## What ships

### 1. Expression support in pool literals
\`.pool\` / \`.reclaim\` / \`.relocate\` accept \`ExpressionAstNode\`. Arithmetic on literals works; forward refs to user-declared constants resolve eagerly via \`_try_eager_constant_bind\` in \`generate_symbol\`.

### 2. Pool stats as scope symbols
\`<pool>.capacity\`, \`<pool>.fragments\`, \`<pool>.largest_chunk\` published at codegen time so users can write \`.if pool.capacity < N { ... }\` guards. Snapshots are local — kept out of object-mode symbol export to avoid cross-TU collisions.

### 3. Object mode \`.alloc\`
\`Program._object_emit_alloc\` defers allocation in object mode: opens a region at sandbox PC, walks body through standard object-emit path, records \`PoolAlloc(pool_name, symbol, region_idx, size)\` on object_writer.

### 4. LSP DocumentSymbol outline
A816Document indexes pool / alloc / relocate names. \`_handle_document_symbols\` surfaces them under \`SymbolKind.Namespace\` (pool) and \`SymbolKind.Function\` (alloc / relocate).

### 5. Cross-TU pool merging
**.o format extended to v0x0008** with \`PoolDecl\` + \`PoolAlloc\` records (round-trip tested).

Linker:
- \`_merge_pool_decls\` unions same-named pools (fill/strategy must agree).
- \`_allocate_pools_across_modules\` runs the allocator over the merged view across all input modules' deferred requests.
- \`_pool_delta_for_symbol\` routes CODE symbols inside pool regions through the link-time-chosen base.

Verified end-to-end: two modules each contributing a 1-byte chunk to a shared \`.pool slack\`, each declaring a 1-byte \`.alloc\`. After link, the two allocs land at distinct addresses (one per chunk) — true cross-TU sharing of pool address space.

### 6. Pool exhaustion errors loud
\`PoolOverflowError\` carries the alloc name + size. Three regression tests pin the contract: direct-mode single oversized alloc, direct-mode second-alloc spill, link-time combined overflow.

## Test plan
- [x] \`hatch run tests:tests\` — 878 passed, 1 skipped (12 new tests covering everything above)
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean (101 source files)
- [x] ff4-modules dogfood — three free-space sites converted to \`.pool\` + \`.alloc\` produce byte-identical IPS output modulo build-date timestamp drift