### PR TITLE
Formatter: recurse into .alloc / .relocate body via _format_ast

### DIFF
--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 from a816.cpu.cpu_65c816 import AddressingMode
 from a816.exceptions import FormattingError
 from a816.parse.ast.nodes import (
+    AllocAstNode,
     AsciiAstNode,
     AstNode,
     BlockAstNode,
@@ -28,6 +29,9 @@ from a816.parse.ast.nodes import (
     MacroApplyAstNode,
     MacroAstNode,
     OpcodeAstNode,
+    PoolAstNode,
+    ReclaimAstNode,
+    RelocateAstNode,
     ScopeAstNode,
     StructAstNode,
     SymbolAffectationAstNode,
@@ -273,6 +277,14 @@ class A816Formatter:
             return self._format_comment(ast)
         if isinstance(ast, ScopeAstNode):
             return self._format_scope(ast)
+        if isinstance(ast, AllocAstNode):
+            return self._format_alloc(ast)
+        if isinstance(ast, RelocateAstNode):
+            return self._format_relocate(ast)
+        if isinstance(ast, PoolAstNode):
+            return self._format_pool(ast)
+        if isinstance(ast, ReclaimAstNode):
+            return [self._format_reclaim(ast)]
         if isinstance(ast, MacroAstNode):
             return self._format_macro(ast)
         if isinstance(ast, DocstringAstNode):
@@ -397,6 +409,35 @@ class A816Formatter:
             return f"{apply_ast.name}({arg_str})"
         else:
             return f"{apply_ast.name}()"
+
+    def _format_alloc(self, ast: AllocAstNode) -> list[str]:
+        """Format `.alloc NAME in POOL { body }`."""
+        lines = [f".alloc {ast.name} in {ast.pool_name} {{"]
+        lines.extend(self._indent_block_lines(self._format_ast(ast.body, True)))
+        lines.append("}")
+        return lines
+
+    def _format_relocate(self, ast: RelocateAstNode) -> list[str]:
+        """Format `.relocate SYMBOL OLD_START OLD_END into POOL { body }`."""
+        old_start = ast.old_start.to_canonical()
+        old_end = ast.old_end.to_canonical()
+        lines = [f".relocate {ast.symbol} {old_start} {old_end} into {ast.pool_name} {{"]
+        lines.extend(self._indent_block_lines(self._format_ast(ast.body, True)))
+        lines.append("}")
+        return lines
+
+    def _format_pool(self, ast: PoolAstNode) -> list[str]:
+        """Format `.pool NAME { range / fill / strategy ... }`."""
+        lines = [f".pool {ast.pool_name} {{"]
+        for lo, hi in ast.ranges:
+            lines.append(f"    range {lo.to_canonical()} {hi.to_canonical()}")
+        lines.append(f"    fill {ast.fill.to_canonical()}")
+        lines.append(f"    strategy {ast.strategy}")
+        lines.append("}")
+        return lines
+
+    def _format_reclaim(self, ast: ReclaimAstNode) -> str:
+        return f".reclaim {ast.pool_name} {ast.start.to_canonical()} {ast.end.to_canonical()}"
 
     def _format_if(self, if_ast: IfAstNode) -> list[str]:
         """Format an if statement with explicit braces"""

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -298,6 +298,46 @@ class TestFluffFormat:
             assert opcode in out
 
 
+class TestFluffFormatNestedIf:
+    """Regression: ff4 reported the formatter mangled `.if {}` inside `.alloc {}`:
+    flattened braces to `.endif`, glued closing brace to preceding instruction,
+    stripped immediate `#` prefix from operands."""
+
+    def test_alloc_with_nested_if_round_trips(self) -> None:
+        from a816.formatter import A816Formatter
+
+        src = """
+.pool demo_pool {
+    range 0x208000 0x20FFFF
+    strategy order
+}
+
+.alloc demo in demo_pool {
+.if FLAG_A {
+    lda #0x00
+    rtl
+}
+
+label_after:
+    lda 0x43
+    rtl
+
+.if FLAG_B {
+    .import "some_module"
+}
+}
+"""
+        out = A816Formatter().format_text(src)
+        # No .endif (a816 uses braces, not keyword endif).
+        assert ".endif" not in out
+        # No glued braces (rtl.endif / "....endif).
+        assert "rtl}" not in out
+        # Immediate `#` prefix preserved.
+        assert "lda #0x00" in out
+        # Stable across two passes.
+        assert A816Formatter().format_text(out) == out
+
+
 class TestLspKeywordCompletions:
     def test_pool_keywords_advertised(self) -> None:
         from a816.parse.scanner_states import KEYWORDS


### PR DESCRIPTION
ff4 [filed via overflow](https://github.com/manz/a816/pull/26) — formatter mangled \`.alloc\` bodies:

1. \`.if X { }\` → \`.if X ... .endif\` (a816 doesn't support \`.endif\`)
2. Closing brace glued to preceding instruction: \`rtl.endif\`
3. \`lda #0x00\` immediate \`#\` stripped → \`lda 0x00\` (changes semantics)
4. Comments separated onto own line

## Root cause

\`AllocAstNode.to_canonical\` fell back to \`_indent_block_body\` which calls each child's raw \`to_canonical\`. That bypasses the formatter's type-aware logic (operand addressing modes, if-block braces, comment folding).

## Fix

Formatter-side handlers for the four pool directives so they go through the same dispatch path as \`.scope\` / \`.if\` / \`.for\`:

- \`_format_alloc\` / \`_format_relocate\`: emit directive header, recurse body via \`_format_ast\` so children get their proper formatter (\`_format_if\` for if-blocks, \`_format_opcode\` for immediates, etc.).
- \`_format_pool\`: emit range / fill / strategy with proper indent.
- \`_format_reclaim\`: single-line directive.

## Verify

Regression test on exact ff4 repro: \`.alloc\` wrapping nested \`.if\` with immediate operands and \`.import\`. Asserts:
- no \`.endif\` keyword
- no glued braces
- immediate \`#\` preserved
- converges in two passes

## Test plan
- [x] \`hatch run tests:tests\` — 879 passed, 1 skipped (1 new regression test)
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean