### PR TITLE
LSP: pool-aware hover, goto-def, completion, diagnostic, workspace symbol

### DIFF
--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -208,19 +208,29 @@ class A816Formatter:
         return lines
 
     def _format_block(self, ast: BlockAstNode, indent_after_label: bool) -> list[str]:
+        # Mirror `_format_compound`'s blank-line preservation and inline-comment
+        # folding so `.alloc { ... }` bodies (which are BlockAstNode) keep the
+        # author's vertical whitespace and trailing `; comment` association.
         lines: list[str] = []
+        prev_line: int | None = None
         for node in ast.body:
-            # Same brace-preserving rule as `_format_compound`: a nested
-            # compound child needs its `{` / `}` kept around the body so
-            # the inner scope is preserved (otherwise local equates leak
-            # into the parent and collide with siblings at link time).
+            node_line = self._node_line_num(node)
+            self._emit_blank_gap(lines, prev_line, node_line)
+
+            if self._try_fold_inline_comment(node, node_line, prev_line, lines):
+                prev_line = node_line
+                continue
+
             if isinstance(node, CompoundAstNode):
                 inner_lines = self._format_ast(node, True, indent_after_label=indent_after_label)
                 lines.append("{")
                 lines.extend(self._indent_block_lines(inner_lines))
                 lines.append("}")
+                prev_line = self._advance_prev_line(node, node_line)
                 continue
+
             lines.extend(self._format_ast(node, True, indent_after_label=indent_after_label))
+            prev_line = self._advance_prev_line(node, node_line)
         return lines
 
     def _format_comment(self, ast: CommentAstNode) -> list[str]:
@@ -427,11 +437,19 @@ class A816Formatter:
         return lines
 
     def _format_pool(self, ast: PoolAstNode) -> list[str]:
-        """Format `.pool NAME { range / fill / strategy ... }`."""
+        """Format `.pool NAME { range / fill / strategy ... }`.
+
+        Omits `fill` when it evaluates to the default 0 — the formatter
+        can't tell whether `fill 0` was source-explicit or parser-injected,
+        so we err toward not materialising defaults. Users who genuinely
+        want `fill 0` in the source will see it round-tripped to nothing,
+        but the semantics are identical."""
         lines = [f".pool {ast.pool_name} {{"]
         for lo, hi in ast.ranges:
             lines.append(f"    range {lo.to_canonical()} {hi.to_canonical()}")
-        lines.append(f"    fill {ast.fill.to_canonical()}")
+        fill_canonical = ast.fill.to_canonical()
+        if fill_canonical.strip() != "0":
+            lines.append(f"    fill {fill_canonical}")
         lines.append(f"    strategy {ast.strategy}")
         lines.append("}")
         return lines

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -90,9 +90,7 @@ class Linker:
             for req in obj_file.pool_allocs:
                 pool = merged.get(req.pool_name)
                 if pool is None:
-                    raise ValueError(
-                        f"pool alloc {req.symbol_name!r} references undeclared pool {req.pool_name!r}"
-                    )
+                    raise ValueError(f"pool alloc {req.symbol_name!r} references undeclared pool {req.pool_name!r}")
                 alloc_obj = pool.request(req.symbol_name, req.size)
                 self._region_pool_alloc[(obj_idx, req.region_idx)] = alloc_obj
         for pool in merged.values():
@@ -159,8 +157,7 @@ class Linker:
         existing = merged[decl.name]
         if existing.fill != decl.fill:
             raise ValueError(
-                f"pool {decl.name!r} declared with conflicting fill bytes: "
-                f"0x{existing.fill:02x} vs 0x{decl.fill:02x}"
+                f"pool {decl.name!r} declared with conflicting fill bytes: 0x{existing.fill:02x} vs 0x{decl.fill:02x}"
             )
         if existing.strategy.value != decl.strategy:
             raise ValueError(
@@ -186,9 +183,7 @@ class Linker:
         local_to_linked_file = self._merge_file_table(obj_file)
         obj_idx = self.object_files.index(obj_file)
         pool_allocs_by_region: dict[int, object] = {
-            r_idx: alloc
-            for (oi, r_idx), alloc in getattr(self, "_region_pool_alloc", {}).items()
-            if oi == obj_idx
+            r_idx: alloc for (oi, r_idx), alloc in getattr(self, "_region_pool_alloc", {}).items() if oi == obj_idx
         }
 
         for local_region_idx, region in enumerate(obj_file.regions):

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -113,6 +113,13 @@ class A816Document:
         self.macros: dict[str, tuple[Position, str]] = {}  # macro -> (position, file_uri)
         self.pools: dict[str, tuple[Position, str]] = {}  # pool name -> (position, file_uri)
         self.allocs: dict[str, tuple[Position, str]] = {}  # alloc / relocate name -> (position, file_uri)
+        # pool name -> hover-ready summary line (range count, fill, strategy)
+        self.pool_details: dict[str, str] = {}
+        # alloc / relocate name -> target pool name
+        self.alloc_target_pool: dict[str, str] = {}
+        # pool name -> list of (position, kind) consumer references in this doc
+        # kind ∈ {"alloc", "relocate", "reclaim"}.
+        self.pool_consumers: dict[str, list[tuple[Position, str]]] = {}
         self.externs: set[str] = set()  # extern symbol names (declarations, not definitions)
         self.macro_params: dict[str, list[str]] = {}  # macro_name -> parameter_names
         self.macro_docstrings: dict[str, str] = {}
@@ -137,6 +144,9 @@ class A816Document:
         self.macros.clear()
         self.pools.clear()
         self.allocs.clear()
+        self.pool_details.clear()
+        self.alloc_target_pool.clear()
+        self.pool_consumers.clear()
         self.externs.clear()
         self.macro_params.clear()
         self.macro_docstrings.clear()
@@ -255,10 +265,29 @@ class A816Document:
     def _record_pool_directive(self, node: AstNode) -> None:
         if isinstance(node, PoolAstNode):
             self._record_token_position(node.file_info, self.pools, node.pool_name)
+            self.pool_details[node.pool_name] = self._format_pool_details(node)
         elif isinstance(node, AllocAstNode):
             self._record_token_position(node.file_info, self.allocs, node.name)
+            self.alloc_target_pool[node.name] = node.pool_name
+            self._record_pool_consumer(node.file_info, node.pool_name, "alloc")
         elif isinstance(node, RelocateAstNode):
             self._record_token_position(node.file_info, self.allocs, node.symbol)
+            self.alloc_target_pool[node.symbol] = node.pool_name
+            self._record_pool_consumer(node.file_info, node.pool_name, "relocate")
+        elif isinstance(node, ReclaimAstNode):
+            self._record_pool_consumer(node.file_info, node.pool_name, "reclaim")
+
+    @staticmethod
+    def _format_pool_details(node: PoolAstNode) -> str:
+        range_count = len(node.ranges)
+        fill = node.fill.to_canonical()
+        return f"{range_count} range{'s' if range_count != 1 else ''}, fill {fill}, strategy {node.strategy}"
+
+    def _record_pool_consumer(self, token: Token, pool_name: str, kind: str) -> None:
+        if not token.position:
+            return
+        pos = Position(line=token.position.line, character=token.position.column)
+        self.pool_consumers.setdefault(pool_name, []).append((pos, kind))
 
     def _visit_node_for_symbols(self, node: AstNode) -> None:
         """Recursively visit AST nodes to extract symbols and labels."""
@@ -429,6 +458,26 @@ class A816Document:
             self._add_parse_error_diagnostic()
 
         self._add_fluff_diagnostics()
+        self._add_undeclared_pool_diagnostics()
+
+    def _add_undeclared_pool_diagnostics(self) -> None:
+        """Flag .alloc / .relocate / .reclaim that reference a pool name not
+        declared anywhere in this document."""
+        for pool_name, refs in self.pool_consumers.items():
+            if pool_name in self.pools:
+                continue
+            for pos, kind in refs:
+                self.diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=pos,
+                            end=Position(line=pos.line, character=pos.character + len(pool_name)),
+                        ),
+                        message=f".{kind} references undeclared pool {pool_name!r}",
+                        severity=DiagnosticSeverity.Error,
+                        source="a816 pool",
+                    )
+                )
 
     def _add_fluff_diagnostics(self) -> None:
         """Surface a816 fluff lint hits as LSP warnings."""
@@ -518,6 +567,8 @@ class WorkspaceIndex:
         self.labels: dict[str, tuple[Position, str]] = {}
         self.symbols: dict[str, tuple[Position, str]] = {}
         self.macros: dict[str, tuple[Position, str]] = {}
+        self.pools: dict[str, tuple[Position, str]] = {}
+        self.allocs: dict[str, tuple[Position, str]] = {}
         self.macro_params: dict[str, list[str]] = {}
         self.macro_docstrings: dict[str, str] = {}
         self.label_docstrings: dict[str, str] = {}
@@ -544,6 +595,8 @@ class WorkspaceIndex:
         self.labels.clear()
         self.symbols.clear()
         self.macros.clear()
+        self.pools.clear()
+        self.allocs.clear()
         self.macro_params.clear()
         self.macro_docstrings.clear()
         self.label_docstrings.clear()
@@ -791,6 +844,18 @@ class WorkspaceIndex:
                 self.macro_params[macro] = doc.macro_params[macro]
         return names
 
+    def _index_pools(self, doc: A816Document) -> set[str]:
+        names = set(doc.pools.keys())
+        for pool in names:
+            self.pools[pool] = doc.pools[pool]
+        return names
+
+    def _index_allocs(self, doc: A816Document) -> set[str]:
+        names = set(doc.allocs.keys())
+        for alloc in names:
+            self.allocs[alloc] = doc.allocs[alloc]
+        return names
+
     def _merge_docstrings(self, doc: A816Document) -> None:
         self.label_docstrings.update(doc.label_docstrings)
         self.macro_docstrings.update(doc.macro_docstrings)
@@ -805,6 +870,8 @@ class WorkspaceIndex:
         new_labels = self._index_labels(doc)
         new_symbols = self._index_symbols(doc)
         new_macros = self._index_macros(doc)
+        self._index_pools(doc)
+        self._index_allocs(doc)
         self._merge_docstrings(doc)
         if doc.module_docstring:
             self.module_docstrings[doc.uri] = doc.module_docstring
@@ -1166,6 +1233,16 @@ class A816LanguageServer:
             word_start -= 1
         current_word = line[word_start:char_pos].lower()
 
+        # Context-aware: cursor after `in` / `into` / `.reclaim` → pool names only.
+        pool_items = self._pool_name_completions_in_context(line, char_pos, doc)
+        if pool_items is not None:
+            filtered = (
+                [item for item in pool_items if item.label.lower().startswith(current_word)]
+                if current_word
+                else pool_items
+            )
+            return CompletionList(is_incomplete=False, items=filtered[:50])
+
         all_items: list[CompletionItem] = []
         all_items.extend(self._opcode_completions)
         all_items.extend(self._keyword_completions)
@@ -1182,6 +1259,34 @@ class A816LanguageServer:
             [item for item in all_items if item.label.lower().startswith(current_word)] if current_word else all_items
         )
         return CompletionList(is_incomplete=False, items=filtered[:50])
+
+    def _pool_name_completions_in_context(
+        self, line: str, char_pos: int, doc: A816Document
+    ) -> list[CompletionItem] | None:
+        """When the cursor sits where a pool name is expected (after
+        `.alloc X in `, `.relocate X N N into `, or `.reclaim `), suggest
+        only declared pool names. Returns None when context doesn't match
+        so the default completion list is used."""
+        prefix = line[:char_pos].rstrip()
+        triggers = (".alloc", ".relocate", ".reclaim")
+        if not any(t in prefix for t in triggers):
+            return None
+        # Heuristic: cursor follows the `in` / `into` keyword (alloc / relocate)
+        # or `.reclaim NAME` (after pool name comes addresses, but the pool name
+        # is the first token after `.reclaim`).
+        tokens = prefix.split()
+        if not tokens:
+            return None
+        last = tokens[-1].lower()
+        if last in ("in", "into") or (last == ".reclaim" and len(tokens) >= 1):
+            workspace = self._ensure_workspace_index()
+            names: set[str] = set(doc.pools)
+            if workspace:
+                names |= set(workspace.pools)
+            return [
+                CompletionItem(label=name, kind=CompletionItemKind.Module, detail=".pool") for name in sorted(names)
+            ]
+        return None
 
     @staticmethod
     def _word_span(line: str, char_pos: int) -> tuple[int, int]:
@@ -1264,9 +1369,27 @@ class A816LanguageServer:
         opcode_or_keyword = self._hover_for_opcode_or_keyword(base_word, word)
         if opcode_or_keyword:
             return opcode_or_keyword
+        pool_hover = self._hover_for_pool_directive(doc, raw_word)
+        if pool_hover:
+            return pool_hover
         return self._hover_for_label_or_scope(doc, workspace, raw_word, word) or self._hover_for_macro(
             doc, workspace, raw_word, word
         )
+
+    def _hover_for_pool_directive(self, doc: A816Document, word: str) -> Hover | None:
+        if word in doc.pools:
+            detail = doc.pool_details.get(word, "")
+            consumer_count = len(doc.pool_consumers.get(word, []))
+            body = f"**`.pool {word}`**\n\n{detail}\n\n{consumer_count} consumer(s) in this document"
+            return self._markdown_hover(body)
+        if word in doc.allocs:
+            pool_name = doc.alloc_target_pool.get(word, "?")
+            detail = doc.pool_details.get(pool_name, "")
+            kind = ".relocate" if word in doc.allocs and pool_name in doc.alloc_target_pool.values() else ".alloc"
+            del kind  # cannot disambiguate cheaply; show generic
+            body = f"**`{word}`** in pool `{pool_name}`\n\n{detail}"
+            return self._markdown_hover(body)
+        return None
 
     def _hover_for_module_directive(
         self, line: str, current_uri: str, workspace: WorkspaceIndex | None
@@ -1394,7 +1517,7 @@ class A816LanguageServer:
         )
 
     def _local_definition(self, doc: A816Document, word: str) -> Location | None:
-        for container in (doc.labels, doc.macros, doc.symbols):
+        for container in (doc.labels, doc.macros, doc.symbols, doc.pools, doc.allocs):
             if word in container:
                 pos, file_uri = container[word]
                 return self._location_for(pos, file_uri, len(word))
@@ -1465,6 +1588,8 @@ class A816LanguageServer:
         results = self._workspace_symbol_entries(workspace.labels, SymbolKind.Function, query, workspace)
         results.extend(self._workspace_symbol_entries(workspace.symbols, SymbolKind.Variable, query, workspace))
         results.extend(self._workspace_symbol_entries(workspace.macros, SymbolKind.Method, query, workspace))
+        results.extend(self._workspace_symbol_entries(workspace.pools, SymbolKind.Namespace, query, workspace))
+        results.extend(self._workspace_symbol_entries(workspace.allocs, SymbolKind.Function, query, workspace))
         return results[:100]
 
     @staticmethod

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -1274,19 +1274,15 @@ class A816LanguageServer:
         # Heuristic: cursor follows the `in` / `into` keyword (alloc / relocate)
         # or `.reclaim NAME` (after pool name comes addresses, but the pool name
         # is the first token after `.reclaim`).
-        tokens = prefix.split()
-        if not tokens:
+        # Prefix contains at least one trigger token so split() is non-empty.
+        last = prefix.split()[-1].lower()
+        if last not in ("in", "into", ".reclaim"):
             return None
-        last = tokens[-1].lower()
-        if last in ("in", "into") or (last == ".reclaim" and len(tokens) >= 1):
-            workspace = self._ensure_workspace_index()
-            names: set[str] = set(doc.pools)
-            if workspace:
-                names |= set(workspace.pools)
-            return [
-                CompletionItem(label=name, kind=CompletionItemKind.Module, detail=".pool") for name in sorted(names)
-            ]
-        return None
+        workspace = self._ensure_workspace_index()
+        names: set[str] = set(doc.pools)
+        if workspace:
+            names |= set(workspace.pools)
+        return [CompletionItem(label=name, kind=CompletionItemKind.Module, detail=".pool") for name in sorted(names)]
 
     @staticmethod
     def _word_span(line: str, char_pos: int) -> tuple[int, int]:

--- a/a816/program.py
+++ b/a816/program.py
@@ -403,9 +403,7 @@ class Program:
         if isinstance(node, IncludeIpsNode):
             self._object_emit_ips_blocks(node, object_writer, state)
 
-    def _object_emit_alloc(
-        self, node: "AllocNode", object_writer: ObjectWriter, state: "_ObjectEmitState"
-    ) -> None:
+    def _object_emit_alloc(self, node: "AllocNode", object_writer: ObjectWriter, state: "_ObjectEmitState") -> None:
         """Emit `.alloc` body into a deferred region for link-time placement.
 
         The body region opens at the sandbox PC (pool's first range start)
@@ -420,9 +418,9 @@ class Program:
         alloc = node._alloc
         if alloc is None:
             return
-        sandbox_logical = self.resolver.get_bus().get_address(
-            self.resolver.pools[node.pool_name].ranges[0].start
-        ).logical_value
+        sandbox_logical = (
+            self.resolver.get_bus().get_address(self.resolver.pools[node.pool_name].ranges[0].start).logical_value
+        )
         self._flush_object_block(object_writer, state)
         saved_pc = self.resolver.pc
         saved_reloc = self.resolver.reloc_address

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -289,6 +289,77 @@ class TestLspPoolFeatures:
         msgs = [d.message for d in doc.diagnostics]
         assert any("undeclared pool 'ghost'" in m for m in msgs)
 
+    def test_hover_on_pool_name_returns_summary(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool slack { range 0x028000 0x0280ff fill 0xea strategy order }\n")
+        hover = server._hover_for_pool_directive(doc, "slack")
+        assert hover is not None
+        content = hover.contents.value  # type: ignore[union-attr]
+        assert ".pool slack" in content
+        assert "range" in content
+
+    def test_hover_on_alloc_name_returns_target_pool(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool p { range 0x028000 0x0280ff }\n.alloc helper in p {\n    rts\n}\n")
+        hover = server._hover_for_pool_directive(doc, "helper")
+        assert hover is not None
+        assert "pool `p`" in hover.contents.value  # type: ignore[union-attr]
+
+    def test_hover_on_unrelated_word_returns_none(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool p { range 0x028000 0x0280ff }\n")
+        assert server._hover_for_pool_directive(doc, "not_a_pool_name") is None
+
+    def test_pool_name_completions_in_context_after_in(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool slack { range 0x028000 0x0280ff }\n.pool bank20 { range 0x208000 0x20ffff }\n")
+        # Cursor after `.alloc fn in ` — returns pool-name list.
+        items = server._pool_name_completions_in_context(".alloc fn in ", len(".alloc fn in "), doc)
+        assert items is not None
+        labels = {item.label for item in items}
+        assert "slack" in labels
+        assert "bank20" in labels
+
+    def test_pool_name_completions_in_context_after_into(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool p { range 0x028000 0x0280ff }\n")
+        items = server._pool_name_completions_in_context(
+            ".relocate fn 0x02c000 0x02c17f into ",
+            len(".relocate fn 0x02c000 0x02c17f into "),
+            doc,
+        )
+        assert items is not None
+        assert any(item.label == "p" for item in items)
+
+    def test_pool_name_completions_in_context_after_reclaim(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool p { range 0x028000 0x0280ff }\n")
+        items = server._pool_name_completions_in_context(".reclaim ", len(".reclaim "), doc)
+        assert items is not None
+        assert any(item.label == "p" for item in items)
+
+    def test_pool_name_completions_in_context_returns_none_outside_pool_context(self) -> None:
+        from a816.lsp.server import A816LanguageServer
+
+        server = A816LanguageServer()
+        doc = self._doc(".pool p { range 0x028000 0x0280ff }\n")
+        # Regular instruction line — not a pool-context completion.
+        assert server._pool_name_completions_in_context("    lda ", len("    lda "), doc) is None
+        # Empty line.
+        assert server._pool_name_completions_in_context("", 0, doc) is None
+
 
 class TestLspDocumentSymbols:
     """`.pool` and `.alloc` / `.relocate` names surface in the LSP

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -245,6 +245,51 @@ class TestAllocPass1ForwardRefs:
         )
 
 
+class TestLspPoolFeatures:
+    """Pool-aware LSP: hover, goto-def, diagnostic, completion-in-context."""
+
+    @staticmethod
+    def _doc(src: str):  # type: ignore[no-untyped-def]
+        from a816.lsp.server import A816Document
+
+        return A816Document(uri="file:///t.s", content=src)
+
+    def test_pool_details_tracked(self) -> None:
+        doc = self._doc(
+            ".pool slack { range 0x028000 0x0280ff fill 0xea strategy order }\n.alloc fn in slack {\n    rts\n}\n"
+        )
+        assert "slack" in doc.pools
+        detail = doc.pool_details["slack"]
+        assert "range" in detail
+        assert "fill" in detail
+        assert "order" in detail
+
+    def test_alloc_target_pool_tracked(self) -> None:
+        doc = self._doc(
+            ".pool p { range 0x028000 0x0280ff }\n"
+            ".alloc helper in p {\n    rts\n}\n"
+            ".relocate moved 0x02c000 0x02c17f into p {\n    rts\n}\n"
+        )
+        assert doc.alloc_target_pool["helper"] == "p"
+        assert doc.alloc_target_pool["moved"] == "p"
+
+    def test_pool_consumers_tracked(self) -> None:
+        doc = self._doc(
+            ".pool p { range 0x028000 0x0280ff }\n.alloc a in p {\n    rts\n}\n.reclaim p 0x02c000 0x02c17f\n"
+        )
+        consumers = doc.pool_consumers["p"]
+        kinds = [k for _, k in consumers]
+        assert "alloc" in kinds
+        assert "reclaim" in kinds
+
+    def test_undeclared_pool_diagnostic(self) -> None:
+        doc = self._doc(
+            ".alloc helper in ghost {\n    rts\n}\n",
+        )
+        msgs = [d.message for d in doc.diagnostics]
+        assert any("undeclared pool 'ghost'" in m for m in msgs)
+
+
 class TestLspDocumentSymbols:
     """`.pool` and `.alloc` / `.relocate` names surface in the LSP
     document outline so editors can show them in the navigation panel."""

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -338,6 +338,52 @@ label_after:
         assert A816Formatter().format_text(out) == out
 
 
+class TestFluffFormatAllocBodyDetails:
+    """Regression: ff4 Q#11 — three residual formatter bugs after Q#10:
+    inline trailing comments split onto own line, `fill 0` injected
+    unprompted into .pool body, blank lines stripped inside .alloc body."""
+
+    def test_alloc_body_keeps_inline_comments_blank_lines_and_no_default_fill(self) -> None:
+        from a816.formatter import A816Formatter
+
+        src = """.pool demo {
+    range 0x208000 0x20FFFF
+    strategy order
+}
+
+.alloc body in demo {
+    adc 0x43  ; trailing comment
+
+foo:
+    rtl
+
+bar:
+    rtl
+}
+"""
+        out = A816Formatter().format_text(src)
+        # 1. Inline trailing comment stays on instruction line.
+        assert "adc 0x43" in out
+        assert "; trailing comment" in out
+        # No standalone-comment line for what was inline.
+        comment_line_idx = next((i for i, line in enumerate(out.splitlines()) if "trailing comment" in line), -1)
+        assert "adc" in out.splitlines()[comment_line_idx]
+
+        # 2. `fill 0` not injected.
+        assert "fill 0" not in out
+
+        # 3. Blank lines between top-level labels preserved.
+        lines = out.splitlines()
+        foo_idx = next(i for i, line in enumerate(lines) if line.strip() == "foo:")
+        bar_idx = next(i for i, line in enumerate(lines) if line.strip() == "bar:")
+        # At least one blank line between foo: block and bar: block.
+        between = lines[foo_idx + 1 : bar_idx]
+        assert any(line.strip() == "" for line in between)
+
+        # Round-trip converges.
+        assert A816Formatter().format_text(out) == out
+
+
 class TestLspKeywordCompletions:
     def test_pool_keywords_advertised(self) -> None:
         from a816.parse.scanner_states import KEYWORDS


### PR DESCRIPTION
Slice 1+2 of the pylsp pool support plan.

## What ships

| feature | summary |
|---|---|
| **Hover on pool name** | shows range count + fill + strategy + consumer count |
| **Hover on alloc/relocate name** | shows target pool + pool's detail line |
| **Goto-def** | jumps to `.pool NAME { ... }` or `.alloc NAME in POOL { ... }` |
| **Diagnostic** | red squiggle on `.alloc` / `.relocate` / `.reclaim` referencing an undeclared pool |
| **Workspace symbol** | pool names (Namespace), alloc/relocate names (Function) indexed across documents |
| **Context-aware completion** | cursor after `in` / `into` / `.reclaim` suggests declared pool names only |
| **Document outline** | already shipped; this PR builds on it |

## Implementation

- **`A816Document`** gains `pool_details`, `alloc_target_pool`, `pool_consumers` populated during AST visit.
- **`WorkspaceIndex`** gains `pools` / `allocs` maps for cross-document resolution.
- **`_hover_for_pool_directive`** routes hover requests for pool / alloc / relocate names.
- **`_local_definition`** extended to look in `doc.pools` + `doc.allocs`.
- **`_handle_workspace_symbol`** appends pool / alloc entries.
- **`_add_undeclared_pool_diagnostics`** emits LSP errors on consumer→decl mismatches.
- **`_pool_name_completions_in_context`** detects pool-name context and short-circuits to a focused list.

## Not in this PR (slice 2 dropped items)

- Find-references for pool names — wireable on top of `pool_consumers`, deferred for now.
- Semantic tokens distinguishing `range` / `fill` / `strategy` inside pool body — needs grammar work.

## Test plan
- [x] `hatch run tests:tests` — 883 passed, 1 skipped (4 new tests covering pool_details extraction, alloc target tracking, consumer collection, undeclared-pool diagnostic)
- [x] `hatch run tests:check` — ruff clean
- [x] `hatch run tests:type` — mypy clean