### PR TITLE
Bump pygls 1.3.1 -> 2.1.1, lsprotocol -> 2025.0.0, async did_* handlers

### DIFF
--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import logging
 import os
@@ -41,13 +42,14 @@ from lsprotocol.types import (
     SemanticTokens,
     SemanticTokensLegend,
     SemanticTokensParams,
+    ShowMessageParams,
     SignatureHelp,
     SignatureHelpParams,
     SignatureInformation,
     SymbolInformation,
     SymbolKind,
-    TextDocumentContentChangeEvent_Type1,
-    TextDocumentContentChangeEvent_Type2,
+    TextDocumentContentChangePartial,
+    TextDocumentContentChangeWholeDocument,
     TextDocumentPositionParams,
     TextEdit,
     WorkspaceEdit,
@@ -56,7 +58,7 @@ from lsprotocol.types import (
 from lsprotocol.types import (
     FormattingOptions as LSPFormattingOptions,
 )
-from pygls.server import LanguageServer
+from pygls.lsp.server import LanguageServer
 
 from a816.cpu.cpu_65c816 import AddressingMode, snes_opcode_table
 from a816.exceptions import FormattingError
@@ -1053,11 +1055,11 @@ class A816LanguageServer:
 
         @self.server.feature("textDocument/didOpen")
         async def did_open(ls: LanguageServer, params: DidOpenTextDocumentParams) -> None:
-            self._handle_did_open(params)
+            await self._handle_did_open(params)
 
         @self.server.feature("textDocument/didChange")
         async def did_change(ls: LanguageServer, params: DidChangeTextDocumentParams) -> None:
-            self._handle_did_change(params)
+            await self._handle_did_change(params)
 
         @self.server.feature("textDocument/didClose")
         async def did_close(ls: LanguageServer, params: DidCloseTextDocumentParams) -> None:
@@ -1065,7 +1067,7 @@ class A816LanguageServer:
 
         @self.server.feature("textDocument/didSave")
         async def did_save(ls: LanguageServer, params: DidSaveTextDocumentParams) -> None:
-            self._handle_did_save(params)
+            await self._handle_did_save(params)
 
         @self.server.feature("textDocument/completion")
         async def completions(ls: LanguageServer, params: CompletionParams) -> CompletionList:
@@ -1133,19 +1135,25 @@ class A816LanguageServer:
                 DocumentFormattingParams(text_document=params.text_document, options=params.options)
             )
 
-    def _handle_did_open(self, params: DidOpenTextDocumentParams) -> None:
+    async def _handle_did_open(self, params: DidOpenTextDocumentParams) -> None:
         workspace = self._ensure_workspace_index()
         include_paths = workspace.include_paths if workspace else []
-        doc = A816Document(params.text_document.uri, params.text_document.text, include_paths=include_paths)
+        # Heavy: scanner + parser + symbol extraction. Off the event loop.
+        doc = await asyncio.to_thread(
+            A816Document,
+            params.text_document.uri,
+            params.text_document.text,
+            include_paths,
+        )
         self.documents[params.text_document.uri] = doc
         if workspace:
-            workspace.replace_document(doc)
+            await asyncio.to_thread(workspace.replace_document, doc)
         self._publish_diagnostics(params.text_document.uri, doc.diagnostics)
 
     def _apply_content_changes(self, doc: A816Document, changes: list[Any]) -> str:
         current_content = doc.content
         for change in changes:
-            if isinstance(change, TextDocumentContentChangeEvent_Type2):
+            if isinstance(change, TextDocumentContentChangeWholeDocument):
                 current_content = change.text
                 logger.debug("Full document replacement")
             else:
@@ -1153,17 +1161,19 @@ class A816LanguageServer:
                 current_content = self._apply_text_change(current_content, change)
         return current_content
 
-    def _handle_did_change(self, params: DidChangeTextDocumentParams) -> None:
+    async def _handle_did_change(self, params: DidChangeTextDocumentParams) -> None:
         doc = self.documents.get(params.text_document.uri)
         if not doc or not params.content_changes:
             return
-        doc.update_content(self._apply_content_changes(doc, list(params.content_changes)))
+        new_content = self._apply_content_changes(doc, list(params.content_changes))
+        # Re-parse off the event loop so large-file edits don't block.
+        await asyncio.to_thread(doc.update_content, new_content)
         workspace = self._ensure_workspace_index()
         if workspace:
-            workspace.replace_document(doc)
+            await asyncio.to_thread(workspace.replace_document, doc)
         self._publish_diagnostics(params.text_document.uri, doc.diagnostics)
         try:
-            self.server.semantic_tokens_refresh()
+            self.server.workspace_semantic_tokens_refresh(None)
         except (AttributeError, RuntimeError, TypeError) as e:
             logger.debug(f"Could not refresh semantic tokens: {e}")
 
@@ -1173,17 +1183,17 @@ class A816LanguageServer:
         if workspace:
             workspace.reload_document_from_disk(params.text_document.uri)
 
-    def _handle_did_save(self, params: DidSaveTextDocumentParams) -> None:
+    async def _handle_did_save(self, params: DidSaveTextDocumentParams) -> None:
         doc = self.documents.get(params.text_document.uri)
         if not doc:
             return
         if params.text is not None:
-            doc.update_content(params.text)
+            await asyncio.to_thread(doc.update_content, params.text)
         else:
-            doc.analyze()
+            await asyncio.to_thread(doc.analyze)
         workspace = self._ensure_workspace_index()
         if workspace:
-            workspace.replace_document(doc)
+            await asyncio.to_thread(workspace.replace_document, doc)
         self._publish_diagnostics(params.text_document.uri, doc.diagnostics)
 
     def _local_completions(self, doc: A816Document) -> list[CompletionItem]:
@@ -1827,7 +1837,7 @@ class A816LanguageServer:
             return []
         except FormattingError as exc:
             logger.exception("Formatter failed for %s: %s", doc.uri, exc)
-            self.server.show_message(str(exc), MessageType.Error)
+            self.server.window_show_message(ShowMessageParams(type=MessageType.Error, message=str(exc)))
             return []
         finally:
             self.formatter = original_formatter
@@ -2440,7 +2450,7 @@ class A816LanguageServer:
             logger.debug(f"Error resolving module path '{module_name}' from '{current_uri}': {e}")
             return None
 
-    def _apply_text_change(self, content: str, change: TextDocumentContentChangeEvent_Type1) -> str:
+    def _apply_text_change(self, content: str, change: TextDocumentContentChangePartial) -> str:
         """Apply an incremental text change to content"""
 
         if not hasattr(change, "range") or change.range is None:
@@ -2492,7 +2502,9 @@ class A816LanguageServer:
 
     def _publish_diagnostics(self, uri: str, diagnostics: list[Diagnostic]) -> None:
         """Publish diagnostics for a document"""
-        self.server.publish_diagnostics(uri, diagnostics)
+        from lsprotocol.types import PublishDiagnosticsParams
+
+        self.server.text_document_publish_diagnostics(PublishDiagnosticsParams(uri=uri, diagnostics=diagnostics))
 
     def start(self) -> None:
         """Start the LSP server"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 
-dependencies = ["pygls==1.3.1", "lsprotocol==2023.0.1"]
+dependencies = ["pygls==2.1.1", "lsprotocol==2025.0.0"]
 
 dynamic = ["version"]
 
@@ -76,7 +76,7 @@ relative_files = true
 
 [tool.hatch.envs.tests]
 detached = true
-dependencies = ["pygls==1.3.1", "lsprotocol==2023.0.1", "pytest", "pytest-cov", "mypy", "ruff"]
+dependencies = ["pygls==2.1.1", "lsprotocol==2025.0.0", "pytest", "pytest-cov", "pytest-asyncio", "mypy", "ruff"]
 
 [tool.hatch.envs.tests.scripts]
 coverage = "pytest --cov-report term --cov-report xml --cov=a816 --cov=script --cov-branch tests"
@@ -101,3 +101,6 @@ dependencies = ["nuitka"]
 build = [
     "nuitka --assume-yes-for-downloads --onefile a816/cli.py  --product-name=a816  --product-version=1.0.0 --company-name=ManZ --output-filename=x816 --no-deployment-flag=self-execution",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/test_lsp_fixture.py
+++ b/tests/test_lsp_fixture.py
@@ -361,3 +361,21 @@ async def test_did_change_updates_document_content() -> None:
     )
     await server._handle_did_change(params)
     assert "; replaced" in server.documents[uri].content
+
+
+async def test_did_change_whole_document_replacement() -> None:
+    """LSP clients may send TextDocumentContentChangeWholeDocument (no range,
+    just full text). Exercises the whole-doc branch of _apply_content_changes."""
+    from lsprotocol.types import TextDocumentContentChangeWholeDocument
+
+    server = server_with_fixture_workspace()
+    await _open(server, "src/main.s")
+    uri = fixture_uri("src/main.s")
+    change = TextDocumentContentChangeWholeDocument(text="; whole-doc swap\nstart:\n    rtl\n")
+    params = DidChangeTextDocumentParams(
+        text_document=VersionedTextDocumentIdentifier(uri=uri, version=3),
+        content_changes=[change],
+    )
+    await server._handle_did_change(params)
+    assert "; whole-doc swap" in server.documents[uri].content
+    assert "start" in server.documents[uri].labels

--- a/tests/test_lsp_fixture.py
+++ b/tests/test_lsp_fixture.py
@@ -20,7 +20,7 @@ from lsprotocol.types import (
     SignatureHelpContext,
     SignatureHelpParams,
     SignatureHelpTriggerKind,
-    TextDocumentContentChangeEvent_Type1,
+    TextDocumentContentChangePartial,
     TextDocumentIdentifier,
     VersionedTextDocumentIdentifier,
     WorkspaceSymbolParams,
@@ -36,14 +36,14 @@ from tests.lsp_helpers import (
 )
 
 
-def _open(server: A816LanguageServer, rel_path: str) -> None:
-    server._handle_did_open(make_did_open_params(rel_path))
+async def _open(server: A816LanguageServer, rel_path: str) -> None:
+    await server._handle_did_open(make_did_open_params(rel_path))
 
 
-def test_main_opens_with_workspace_indexed() -> None:
+async def test_main_opens_with_workspace_indexed() -> None:
     server = server_with_fixture_workspace()
     params = make_did_open_params("src/main.s")
-    server._handle_did_open(params)
+    await server._handle_did_open(params)
 
     assert params.text_document.uri in server.documents
     doc = server.documents[params.text_document.uri]
@@ -51,33 +51,33 @@ def test_main_opens_with_workspace_indexed() -> None:
     assert "DMA_REG" not in doc.labels  # comes via .include, not local label
 
 
-def test_workspace_symbol_finds_module_label() -> None:
+async def test_workspace_symbol_finds_module_label() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     results = server._handle_workspace_symbol(WorkspaceSymbolParams(query="vwf_render"))
     assert "vwf_render" in {sym.name for sym in results}
 
 
-def test_document_symbols_includes_helpers_scope() -> None:
+async def test_document_symbols_includes_helpers_scope() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     params = DocumentSymbolParams(text_document=TextDocumentIdentifier(uri=fixture_uri("src/main.s")))
     symbols = server._handle_document_symbols(params)
     assert "main" in {sym.name for sym in symbols}
 
 
-def test_goto_def_resolves_module_label() -> None:
+async def test_goto_def_resolves_module_label() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, char = locate_in_fixture("src/main.s", "vwf_render")
     locations = server._handle_definition(make_position_params("src/main.s", line, char))
     assert locations is not None
     assert any("vwf.s" in loc.uri for loc in locations)
 
 
-def test_hover_on_opcode_describes_instruction() -> None:
+async def test_hover_on_opcode_describes_instruction() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, char = locate_in_fixture("src/main.s", "lda")
     hover = server._handle_hover(
         HoverParams(
@@ -90,9 +90,9 @@ def test_hover_on_opcode_describes_instruction() -> None:
     assert "65c816 Instruction" in hover.contents.value
 
 
-def test_hover_on_macro_includes_docstring() -> None:
+async def test_hover_on_macro_includes_docstring() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "modules/vwf.s")
+    await _open(server, "modules/vwf.s")
     line, char = locate_in_fixture("modules/vwf.s", "vwf_init")
     hover = server._handle_hover(
         HoverParams(
@@ -105,9 +105,9 @@ def test_hover_on_macro_includes_docstring() -> None:
     assert "Initialise" in hover.contents.value
 
 
-def test_completions_include_local_labels() -> None:
+async def test_completions_include_local_labels() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, _ = locate_in_fixture("src/main.s", "main:")
     params = CompletionParams(
         text_document=TextDocumentIdentifier(uri=fixture_uri("src/main.s")),
@@ -119,9 +119,9 @@ def test_completions_include_local_labels() -> None:
     assert any(op in labels for op in ("LDA", "STA", "JSR"))
 
 
-def test_signature_help_on_lda() -> None:
+async def test_signature_help_on_lda() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, _ = locate_in_fixture("src/main.s", "lda.b")
     params = SignatureHelpParams(
         text_document=TextDocumentIdentifier(uri=fixture_uri("src/main.s")),
@@ -134,10 +134,10 @@ def test_signature_help_on_lda() -> None:
     assert "LDA" in sig.signatures[0].label
 
 
-def test_references_finds_cross_file_uses() -> None:
+async def test_references_finds_cross_file_uses() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
-    _open(server, "modules/vwf.s")
+    await _open(server, "src/main.s")
+    await _open(server, "modules/vwf.s")
     line, char = locate_in_fixture("modules/vwf.s", "vwf_render")
     params = ReferenceParams(
         text_document=TextDocumentIdentifier(uri=fixture_uri("modules/vwf.s")),
@@ -151,19 +151,19 @@ def test_references_finds_cross_file_uses() -> None:
     assert any("vwf.s" in uri for uri in uris)
 
 
-def test_semantic_tokens_returns_data() -> None:
+async def test_semantic_tokens_returns_data() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     params = SemanticTokensParams(text_document=TextDocumentIdentifier(uri=fixture_uri("src/main.s")))
     tokens = server._handle_semantic_tokens_full(params)
     assert tokens is not None
     assert len(tokens.data) > 0
 
 
-def test_format_document_returns_edits_or_empty() -> None:
+async def test_format_document_returns_edits_or_empty() -> None:
     # Use vwf.s: self-contained, no .include side-effects during parse.
     server = server_with_fixture_workspace()
-    _open(server, "modules/vwf.s")
+    await _open(server, "modules/vwf.s")
     params = DocumentFormattingParams(
         text_document=TextDocumentIdentifier(uri=fixture_uri("modules/vwf.s")),
         options=FormattingOptions(tab_size=4, insert_spaces=True),
@@ -173,9 +173,9 @@ def test_format_document_returns_edits_or_empty() -> None:
     assert edits is not None
 
 
-def test_did_close_drops_document() -> None:
+async def test_did_close_drops_document() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     uri = fixture_uri("src/main.s")
     assert uri in server.documents
     from lsprotocol.types import DidCloseTextDocumentParams
@@ -184,13 +184,13 @@ def test_did_close_drops_document() -> None:
     assert uri not in server.documents
 
 
-def test_did_save_with_text_updates_document() -> None:
+async def test_did_save_with_text_updates_document() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     uri = fixture_uri("src/main.s")
     from lsprotocol.types import DidSaveTextDocumentParams
 
-    server._handle_did_save(
+    await server._handle_did_save(
         DidSaveTextDocumentParams(
             text_document=TextDocumentIdentifier(uri=uri),
             text="; saved\nmain:\n    rts\n",
@@ -199,19 +199,19 @@ def test_did_save_with_text_updates_document() -> None:
     assert "; saved" in server.documents[uri].content
 
 
-def test_did_save_without_text_reanalyzes() -> None:
+async def test_did_save_without_text_reanalyzes() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     uri = fixture_uri("src/main.s")
     from lsprotocol.types import DidSaveTextDocumentParams
 
-    server._handle_did_save(DidSaveTextDocumentParams(text_document=TextDocumentIdentifier(uri=uri), text=None))
+    await server._handle_did_save(DidSaveTextDocumentParams(text_document=TextDocumentIdentifier(uri=uri), text=None))
     assert uri in server.documents
 
 
-def test_hover_returns_none_on_unknown_word() -> None:
+async def test_hover_returns_none_on_unknown_word() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, char = locate_in_fixture("src/main.s", "main:")
     # Cursor on an empty / non-identifier column.
     hover = server._handle_hover(
@@ -223,17 +223,17 @@ def test_hover_returns_none_on_unknown_word() -> None:
     assert hover is None
 
 
-def test_definition_returns_none_for_unknown_word() -> None:
+async def test_definition_returns_none_for_unknown_word() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     locations = server._handle_definition(make_position_params("src/main.s", 0, 5))
     # First line is a comment; cursor on whitespace, no definition expected.
     assert locations is None
 
 
-def test_definition_jumps_to_include_target() -> None:
+async def test_definition_jumps_to_include_target() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, _ = locate_in_fixture("src/main.s", "constants.s")
     # Cursor inside the quoted "constants.s" path.
     char = locate_in_fixture("src/main.s", "constants.s")[1]
@@ -242,10 +242,10 @@ def test_definition_jumps_to_include_target() -> None:
     assert any("constants.s" in loc.uri for loc in locs)
 
 
-def test_references_excluding_declaration() -> None:
+async def test_references_excluding_declaration() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
-    _open(server, "modules/vwf.s")
+    await _open(server, "src/main.s")
+    await _open(server, "modules/vwf.s")
     line, char = locate_in_fixture("modules/vwf.s", "vwf_render")
     params = ReferenceParams(
         text_document=TextDocumentIdentifier(uri=fixture_uri("modules/vwf.s")),
@@ -268,9 +268,9 @@ def test_workspace_symbol_empty_workspace_returns_empty() -> None:
     assert server._handle_workspace_symbol(WorkspaceSymbolParams(query="main")) == []
 
 
-def test_hover_on_cross_file_macro() -> None:
+async def test_hover_on_cross_file_macro() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, char = locate_in_fixture("src/main.s", "vwf_init")
     hover = server._handle_hover(
         HoverParams(
@@ -283,10 +283,10 @@ def test_hover_on_cross_file_macro() -> None:
     assert "Initialise" in hover.contents.value
 
 
-def test_hover_on_import_shows_module_docstring() -> None:
+async def test_hover_on_import_shows_module_docstring() -> None:
     """Cursor on `.import "vwf"` in main.s surfaces vwf.s's leading docstring."""
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, _ = locate_in_fixture("src/main.s", '.import "vwf"')
     hover = server._handle_hover(
         HoverParams(
@@ -299,9 +299,9 @@ def test_hover_on_import_shows_module_docstring() -> None:
     assert "Variable-width font helpers" in hover.contents.value
 
 
-def test_hover_on_label_with_docstring() -> None:
+async def test_hover_on_label_with_docstring() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "modules/vwf.s")
+    await _open(server, "modules/vwf.s")
     line, char = locate_in_fixture("modules/vwf.s", "vwf_render:")
     hover = server._handle_hover(
         HoverParams(
@@ -314,9 +314,9 @@ def test_hover_on_label_with_docstring() -> None:
     assert "Render" in hover.contents.value
 
 
-def test_document_symbols_for_module_with_macros() -> None:
+async def test_document_symbols_for_module_with_macros() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "modules/vwf.s")
+    await _open(server, "modules/vwf.s")
     params = DocumentSymbolParams(text_document=TextDocumentIdentifier(uri=fixture_uri("modules/vwf.s")))
     symbols = server._handle_document_symbols(params)
     names = {sym.name for sym in symbols}
@@ -324,9 +324,9 @@ def test_document_symbols_for_module_with_macros() -> None:
     assert any(name.startswith("vwf_init") for name in names)
 
 
-def test_definition_resolves_extern_via_workspace() -> None:
+async def test_definition_resolves_extern_via_workspace() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     line, char = locate_in_fixture("src/main.s", "target_addr", occurrence=1)
     locs = server._handle_definition(make_position_params("src/main.s", line, char))
     # target_addr is declared extern in main.s and dma.s; workspace lookup may
@@ -346,12 +346,12 @@ def test_workspace_index_remove_document() -> None:
     assert "vwf_render" not in ws.labels
 
 
-def test_did_change_updates_document_content() -> None:
+async def test_did_change_updates_document_content() -> None:
     server = server_with_fixture_workspace()
-    _open(server, "src/main.s")
+    await _open(server, "src/main.s")
     uri = fixture_uri("src/main.s")
     new_text = "; replaced\nmain:\n    rts\n"
-    change = TextDocumentContentChangeEvent_Type1(
+    change = TextDocumentContentChangePartial(
         range=Range(start=Position(line=0, character=0), end=Position(line=999, character=0)),
         text=new_text,
     )
@@ -359,5 +359,5 @@ def test_did_change_updates_document_content() -> None:
         text_document=VersionedTextDocumentIdentifier(uri=uri, version=2),
         content_changes=[change],
     )
-    server._handle_did_change(params)
+    await server._handle_did_change(params)
     assert "; replaced" in server.documents[uri].content

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -385,7 +385,7 @@ main:
         doc = A816Document(uri, content)
         self.server.documents[uri] = doc
 
-        handler = self.server.server.lsp._get_handler("textDocument/hover")  # type: ignore[no-untyped-call]
+        handler = self.server.server.protocol._get_handler("textDocument/hover")
         params = HoverParams(
             text_document=TextDocumentIdentifier(uri=uri),
             position=Position(line=0, character=5),
@@ -414,7 +414,7 @@ main:
             self.server.workspace_index = index
             self.server._ensure_workspace_index = lambda: index  # type: ignore[method-assign]
 
-            handler = self.server.server.lsp._get_handler("workspace/symbol")  # type: ignore[no-untyped-call]
+            handler = self.server.server.protocol._get_handler("workspace/symbol")
             params = WorkspaceSymbolParams(query="lookup")
             results = asyncio.run(handler(params))
 
@@ -453,7 +453,7 @@ main:
             self.server._ensure_workspace_index = lambda: index  # type: ignore[method-assign]
             self.server.documents[ref_path.as_uri()] = ref_doc
 
-            handler = self.server.server.lsp._get_handler("textDocument/references")  # type: ignore[no-untyped-call]
+            handler = self.server.server.protocol._get_handler("textDocument/references")
             params = ReferenceParams(
                 text_document=TextDocumentIdentifier(uri=ref_path.as_uri()),
                 position=Position(line=0, character=10),
@@ -680,7 +680,7 @@ subroutine:
             self.server._ensure_workspace_index = lambda: index  # type: ignore[method-assign]
             self.server.documents[ref_path.as_uri()] = ref_doc
 
-            handler = self.server.server.lsp._get_handler("textDocument/rename")  # type: ignore[no-untyped-call]
+            handler = self.server.server.protocol._get_handler("textDocument/rename")
             params = RenameParams(
                 text_document=TextDocumentIdentifier(uri=ref_path.as_uri()),
                 position=Position(line=0, character=10),
@@ -701,7 +701,7 @@ subroutine:
         content = "    lda #0\n"
         doc = A816Document("test://op.s", content)
         self.server.documents[doc.uri] = doc
-        handler = self.server.server.lsp._get_handler("textDocument/prepareRename")  # type: ignore[no-untyped-call]
+        handler = self.server.server.protocol._get_handler("textDocument/prepareRename")
         params = PrepareRenameParams(
             text_document=TextDocumentIdentifier(uri=doc.uri),
             position=Position(line=0, character=5),  # inside "lda"
@@ -715,7 +715,7 @@ subroutine:
         content = "foo:\n    rtl\n    ; foo in a comment\n    .text 'foo inside string'\n    jsr foo\n"
         doc = A816Document("test://refs.s", content)
         self.server.documents[doc.uri] = doc
-        handler = self.server.server.lsp._get_handler("textDocument/references")  # type: ignore[no-untyped-call]
+        handler = self.server.server.protocol._get_handler("textDocument/references")
         params = ReferenceParams(
             text_document=TextDocumentIdentifier(uri=doc.uri),
             position=Position(line=0, character=1),
@@ -747,7 +747,7 @@ subroutine:
         )
         doc = A816Document("test://refs.s", content)
         self.server.documents[doc.uri] = doc
-        handler = self.server.server.lsp._get_handler("textDocument/references")  # type: ignore[no-untyped-call]
+        handler = self.server.server.protocol._get_handler("textDocument/references")
         params = ReferenceParams(
             text_document=TextDocumentIdentifier(uri=doc.uri),
             position=Position(line=0, character=1),


### PR DESCRIPTION
Major version bump of the LSP runtime + take the chance to move the heavy did_open/did_change/did_save paths fully off the event loop.

## API migration

| pygls 1.3 | pygls 2.1 |
|---|---|
| \`from pygls.server import LanguageServer\` | \`from pygls.lsp.server import LanguageServer\` |
| \`server.publish_diagnostics(uri, diags)\` | \`server.text_document_publish_diagnostics(PublishDiagnosticsParams(...))\` |
| \`server.semantic_tokens_refresh()\` | \`server.workspace_semantic_tokens_refresh(None)\` |
| \`server.show_message(text, type)\` | \`server.window_show_message(ShowMessageParams(...))\` |
| \`server.lsp._get_handler(...)\` | \`server.protocol._get_handler(...)\` |

| lsprotocol 2023 | lsprotocol 2025 |
|---|---|
| \`TextDocumentContentChangeEvent_Type1\` | \`TextDocumentContentChangePartial\` |
| \`TextDocumentContentChangeEvent_Type2\` | \`TextDocumentContentChangeWholeDocument\` |

## Async did_* handlers

\`_handle_did_open\` / \`_handle_did_change\` / \`_handle_did_save\` are now coroutines. Heavy work (\`A816Document\` construction, \`update_content\`, \`workspace.replace_document\`) goes through \`asyncio.to_thread\` so big-file edits don't block the LSP event loop.

LSP feature wrappers await the coroutines.

## Tests

- \`pytest-asyncio\` added; \`pyproject.toml\` sets \`asyncio_mode = "auto"\` so plain \`async def test_*\` functions run without per-test decorators.
- Fixture tests calling the did_* handlers are converted to \`async def test_*\` with proper \`await\` (24 test functions).
- Test handler-lookup via \`server.protocol._get_handler\` (was \`server.lsp._get_handler\`).

## Test plan
- [x] \`hatch run tests:tests\` — 891 passed, 1 skipped
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean (101 source files)