### PR TITLE
Format: idempotent on nested close-braces

### DIFF
--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -163,15 +163,43 @@ class A816Formatter:
     _BLOCK_LIKE_AST: ClassVar[tuple[type, ...]] = (IfAstNode, ForAstNode, MacroAstNode, ScopeAstNode, CompoundAstNode)
 
     def _advance_prev_line(self, node: AstNode, node_line: int | None) -> int | None:
-        # Closing braces of block-like nodes sit on the next source
-        # line with no AST entry; bump past them so the gap heuristic
-        # doesn't read the brace line as a blank padding line.
+        # Closing braces of block-like nodes sit on source lines with no
+        # AST entry; bump past them so the gap heuristic doesn't read the
+        # brace lines as blank padding. For nested block-likes (e.g.
+        # `.if OUTER { .if INNER { ... } }`) every nested block contributes
+        # its own closing brace line — scan the source for the consecutive
+        # `}` lines that immediately follow the tail leaf.
         tail_line = self._ast_max_line(node) or node_line
         if tail_line is None:
             return None
         if isinstance(node, self._BLOCK_LIKE_AST):
-            return tail_line + 1
+            return self._skip_trailing_close_braces(node, tail_line)
         return tail_line
+
+    def _skip_trailing_close_braces(self, node: AstNode, tail_line: int) -> int:
+        """Return the source line number of the outermost closing `}`
+        that belongs to `node`. Walks forward from `tail_line` and stops
+        when a non-`}`-only line is encountered.
+
+        Uses the source file recorded on the node's `file_info.position`
+        when available; falls back to `tail_line + 1` (legacy single-brace
+        behaviour) when the source isn't reachable.
+        """
+        position = getattr(node.file_info, "position", None)
+        source_file = getattr(position, "file", None) if position else None
+        source_lines = getattr(source_file, "lines", None) if source_file else None
+        if not source_lines:
+            return tail_line + 1
+        i = tail_line + 1
+        last = tail_line
+        while i < len(source_lines):
+            stripped = source_lines[i].strip()
+            if stripped == "}":
+                last = i
+                i += 1
+                continue
+            break
+        return last
 
     def _format_compound(self, ast: CompoundAstNode, indent_instructions: bool, indent_after_label: bool) -> list[str]:
         lines: list[str] = []

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -384,6 +384,50 @@ bar:
         assert A816Formatter().format_text(out) == out
 
 
+class TestFluffFormatNestedCloseBraces:
+    """Regression: ff4 Q#12 — format not idempotent on nested `} }`.
+
+    Source has 1 blank line between `}` `}` close-braces and the next
+    sibling; legacy `_advance_prev_line` only skipped a single brace
+    so subsequent passes injected an extra blank each run."""
+
+    def test_nested_close_braces_idempotent(self) -> None:
+        from a816.formatter import A816Formatter
+
+        src = """.pool demo {
+    range 0x208000 0x20FFFF
+    strategy order
+}
+
+.alloc body in demo {
+    .if OUTER {
+        .if INNER {
+            .import "foo"
+        }
+    }
+
+    .import "bar"
+}
+"""
+        f = A816Formatter()
+        p1 = f.format_text(src)
+        p2 = f.format_text(p1)
+        p3 = f.format_text(p2)
+        assert p1 == p2, "format must converge in one pass"
+        assert p2 == p3
+        # Exactly one blank line between the close-braces and `.import "bar"`.
+        lines = p1.splitlines()
+        bar_idx = next(i for i, line in enumerate(lines) if '"bar"' in line)
+        # Walk back over blank lines.
+        blank_count = 0
+        for i in range(bar_idx - 1, -1, -1):
+            if lines[i].strip() == "":
+                blank_count += 1
+            else:
+                break
+        assert blank_count == 1, f'expected 1 blank line before `.import "bar"`, got {blank_count}'
+
+
 class TestLspKeywordCompletions:
     def test_pool_keywords_advertised(self) -> None:
         from a816.parse.scanner_states import KEYWORDS


### PR DESCRIPTION
Fixes ff4 Q#12 — \`a816 format\` not idempotent on \`} }\` sequences from nested \`.if\` inside \`.alloc\`. Each pass injected one more blank line.

## Root cause

\`_advance_prev_line\` for block-like nodes (\`.if\` / \`.for\` / \`.macro\` / \`.scope\` / \`.compound\`) added \`+1\` to the tail leaf line to skip the closing \`}\`. For nested block-likes — \`.if OUTER { .if INNER { ... } }\` — only one brace got skipped; the outer's brace line stayed in the gap count. The sibling node's blank-gap computation then read the outer brace line as a blank padding line and emitted it.

## Fix

\`_skip_trailing_close_braces\` walks the SOURCE lines forward from the tail leaf and stops at the first non-\`}\` line. Returns the line number of the outermost closing brace — correct for any nesting depth.

## Test plan
- [x] Regression test \`TestFluffFormatNestedCloseBraces::test_nested_close_braces_idempotent\` covers a triply-nested \`.alloc\` / \`.if OUTER\` / \`.if INNER\` input; asserts two-pass convergence + exactly one blank line between \`} }\` and the next sibling
- [x] \`hatch run tests:tests\` — 893 passed, 1 skipped
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean