### PR TITLE
chore: add CI/SonarCloud badges, loosen pygls pin

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,4 +1,14 @@
 # a816
+
+[![Build](https://github.com/manz/a816/actions/workflows/build.yml/badge.svg)](https://github.com/manz/a816/actions/workflows/build.yml)
+[![Binaries](https://github.com/manz/a816/actions/workflows/binaries.yml/badge.svg)](https://github.com/manz/a816/actions/workflows/binaries.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=manz_a816&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=manz_a816)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=manz_a816&metric=coverage)](https://sonarcloud.io/summary/new_code?id=manz_a816)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=manz_a816&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=manz_a816)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=manz_a816&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=manz_a816)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=manz_a816&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=manz_a816)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Another 65c816 assembler.
 
 Targets Super Famicom / SNES ROM hacking and patching. Ships a CLI assembler,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 
-dependencies = ["pygls==2.1.1", "lsprotocol==2025.0.0"]
+dependencies = ["pygls>=2.1.1,<3", "lsprotocol>=2025.0.0,<2026"]
 
 dynamic = ["version"]
 
@@ -76,7 +76,7 @@ relative_files = true
 
 [tool.hatch.envs.tests]
 detached = true
-dependencies = ["pygls==2.1.1", "lsprotocol==2025.0.0", "pytest", "pytest-cov", "pytest-asyncio", "mypy", "ruff"]
+dependencies = ["pygls>=2.1.1,<3", "lsprotocol>=2025.0.0,<2026", "pytest", "pytest-cov", "pytest-asyncio", "mypy", "ruff"]
 
 [tool.hatch.envs.tests.scripts]
 coverage = "pytest --cov-report term --cov-report xml --cov=a816 --cov=script --cov-branch tests"


### PR DESCRIPTION
## Summary
- Add badges to README: GH Actions (build, binaries), SonarCloud (gate, coverage, maintainability, reliability, security), MIT license.
- Loosen `pygls` / `lsprotocol` pins from exact `==` to compatible ranges so the LSP stack can pick up patch releases without a code change.

## Test plan
- [x] CI green
- [x] Badges render on GitHub repo page
- [x] `hatch run tests:tests` still passes locally (893 passed pre-push)