### PR TITLE
Dedup .import inside .alloc body against outer duplicates

### DIFF
--- a/a816/program.py
+++ b/a816/program.py
@@ -139,14 +139,28 @@ class Program:
         no-ops in both `pc_after` and `emit`. Marking happens before
         `resolve_labels` so the winner/loser distinction is consistent
         across the address-resolution and emission passes.
+
+        Walks into `AllocNode.body` so a `.import` nested inside a
+        `.alloc` block participates in the same dedup as top-level
+        imports — otherwise the same module emits twice (once at the
+        surrounding org pointer, once at the allocator-chosen address).
         """
-        last_idx: dict[str, int] = {}
-        for idx, node in enumerate(program_nodes):
+        winners: dict[str, LinkedModuleNode] = {}
+        all_nodes: list[LinkedModuleNode] = []
+        Program._collect_linked_modules(program_nodes, all_nodes)
+        # Last-occurrence wins, matching the historical top-level rule.
+        for node in all_nodes:
+            winners[node.module_name] = node
+        for node in all_nodes:
+            node.is_loser = winners[node.module_name] is not node
+
+    @staticmethod
+    def _collect_linked_modules(nodes: list[NodeProtocol], out: list[LinkedModuleNode]) -> None:
+        for node in nodes:
             if isinstance(node, LinkedModuleNode):
-                last_idx[node.module_name] = idx
-        for idx, node in enumerate(program_nodes):
-            if isinstance(node, LinkedModuleNode):
-                node.is_loser = last_idx[node.module_name] != idx
+                out.append(node)
+            elif isinstance(node, AllocNode):
+                Program._collect_linked_modules(node.body, out)
 
     def resolve_labels(self, program_nodes: list[NodeProtocol]) -> None:
         """Resolve all labels and symbols through multi-pass processing.

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -646,6 +646,61 @@ class TestObjectMode:
         assert cons_region.code[:5] == b"\x22\x00\x80\x02\x60"
 
 
+class TestAllocImportDedupe:
+    """ff4 Q#13: `.import` of the same .o module via both `.include`'d patch
+    file AND inside `.alloc` body double-emitted because
+    `_mark_import_winners` walked only top-level program nodes, missing
+    LinkedModuleNode children inside AllocNode.body."""
+
+    def test_o_import_inside_alloc_dedupes_against_outer_include(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # Build dialog.s -> dialog.o so import resolves through LinkedModuleNode
+        dialog_s = tmp_path / "dialog.s"
+        dialog_s.write_text("get_bank1:\n    rep #0x20\n    lda.l 0x218000\n    sta 0x20\n    rts\n")
+        Program().assemble_as_object(str(dialog_s), tmp_path / "dialog.o")
+
+        included = tmp_path / "patches.i"
+        included.write_text('*=0x018798\n    jsr.w 0x9876\n.import "dialog"\n')
+
+        main = tmp_path / "main.s"
+        main.write_text(
+            ".pool slack { range 0x208000 0x20ffff strategy order }\n"
+            '.include "patches.i"\n'
+            '.alloc bank20_main in slack {\n    .import "dialog"\n}\n'
+        )
+        program = Program()
+        program.add_module_path(str(tmp_path))
+        program.add_include_path(str(tmp_path))
+        program.assemble_as_patch(str(main), tmp_path / "out.ips")
+
+        # Parse IPS records: expect only the patch (3B) + alloc body (single
+        # copy of dialog) — no duplicate at the patch's surrounding org.
+        d = (tmp_path / "out.ips").read_bytes()
+        pos = 5
+        records: list[tuple[int, bytes]] = []
+        while True:
+            if d[pos : pos + 3] == b"EOF":
+                break
+            addr = int.from_bytes(d[pos : pos + 3], "big")
+            pos += 3
+            sz = int.from_bytes(d[pos : pos + 2], "big")
+            pos += 2
+            if sz == 0:
+                run = int.from_bytes(d[pos : pos + 2], "big")
+                pos += 2
+                byte = d[pos : pos + 1]
+                pos += 1
+                records.append((addr, byte * run))
+            else:
+                records.append((addr, d[pos : pos + sz]))
+                pos += sz
+        # Patch at $01:8798 stays 3B (the jsr.w), dialog body lands ONLY in
+        # the alloc region. Pre-fix: patch record swelled by 18B (dialog bytes).
+        patch_record = next(b for a, b in records if a == 0x008798)
+        assert len(patch_record) == 3, (
+            f"patch record should be 3 bytes (jsr.w only); got {len(patch_record)} — duplicate import emission"
+        )
+
+
 class TestPoolExhaustion:
     """Pool overflow errors are surfaced loudly in both modes."""
 


### PR DESCRIPTION
Fixes ff4 Q#13 — \`.import\` of the same module via \`.include\`'d patch file AND inside \`.alloc\` body emitted twice (once at parent \`*=\` org pointer, once at allocator-chosen address).

## Repro

\`\`\`
; system_menus_text.i
*=0x018798
    jsr.w 0x9876
.import "dialog"

; main.s
.pool slack { range 0x208000 0x20ffff strategy order }
.include "system_menus_text.i"
.alloc bank20 in slack {
    .import "dialog"
}
\`\`\`

Pre-fix IPS: \`0x008798 21B\` (jsr.w + dialog body) + \`0x100000 18B\` (dialog body at alloc.addr).
Post-fix IPS: \`0x008798 3B\` (bare jsr.w) + \`0x100000 18B\` (dialog body at alloc.addr).

## Root cause

\`_mark_import_winners\` walked only top-level program nodes for last-occurrence LinkedModuleNode dedup. \`AllocNode\` wraps its body's \`LinkedModuleNode\` children, so they stayed hidden from the dedup pass and emitted independently.

## Fix

\`_collect_linked_modules\` recurses into \`AllocNode.body\` so every \`LinkedModuleNode\` — at any nesting depth — participates in the same winner-pick. Last-occurrence wins (matches the historical rule): the \`.alloc\`-wrapped import takes precedence over the \`.include\`'d duplicate.

## Known limitation

Source-import (\`.s\` file) duplicates still emit twice — AST inlining flattens module nodes before dedup runs, so \`_mark_import_winners\` can't see them. Affects only direct-mode \`.s\` imports without precompiled \`.o\` files. Workaround: precompile modules to \`.o\` (build.py path already does this). Real fix is a separate follow-up; needs to either deduplicate at \`_import_from_source\` time or annotate inlined nodes with their source for post-codegen dedup.

## Test plan
- [x] \`hatch run tests:tests\` — 894 passed, 1 skipped (1 new test \`TestAllocImportDedupe\` covering the .o-import path)
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean