### PR TITLE
AllocNode.emit_blocks skips loser .import duplicates

### DIFF
--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -783,6 +783,9 @@ class AllocNode(NodeProtocol):
         alloc = self._alloc
         if alloc is None or not alloc.placed:
             return []
+        # Lazy import to avoid the import cycle through codegen.
+        from a816.parse.nodes import LinkedModuleNode
+
         saved_pc = self.resolver.pc
         saved_reloc = self.resolver.reloc_address
         try:
@@ -790,6 +793,14 @@ class AllocNode(NodeProtocol):
             out = b""
             cur = self.resolver.reloc_address
             for node in self.body:
+                # Skip loser `.import` duplicates inside the body — their
+                # pc_after returned unchanged so subsequent siblings are
+                # already laid out at the right offsets, and emitting the
+                # loser bytes would both double-emit and overlap the
+                # winner's placement. Mirrors the top-level
+                # `_emit_linked_module` is_loser guard.
+                if isinstance(node, LinkedModuleNode) and node.is_loser:
+                    continue
                 emitted = node.emit(cur)
                 if emitted:
                     out += emitted

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -656,26 +656,22 @@ class TestAllocImportLoserSkip:
     placement at the same target address."""
 
     def test_alloc_body_with_duplicate_imports_does_not_double_emit(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
-        # Build two modules that both import the same shared dep.
-        (tmp_path / "shared.s").write_text("shared_fn:\n    rts\n")
-        (tmp_path / "a.s").write_text('.import "shared"\na_fn:\n    rts\n')
-        (tmp_path / "b.s").write_text('.import "shared"\nb_fn:\n    rts\n')
-        Program().assemble_as_object(str(tmp_path / "shared.s"), tmp_path / "shared.o")
-        Program().assemble_as_object(str(tmp_path / "a.s"), tmp_path / "a.o")
-        Program().assemble_as_object(str(tmp_path / "b.s"), tmp_path / "b.o")
+        # Same module imported twice inside one .alloc body — last-wins
+        # makes the first a loser; emit_blocks must skip it so bytes don't
+        # double-emit and overlap the winner at the same offset.
+        dialog_s = tmp_path / "dialog.s"
+        dialog_s.write_text("dialog_fn:\n    rts\n    rts\n    rts\n")
+        Program().assemble_as_object(str(dialog_s), tmp_path / "dialog.o")
 
         main = tmp_path / "main.s"
         main.write_text(
             ".pool slack { range 0x208000 0x20ffff strategy order }\n"
-            '.alloc all in slack {\n    .import "a"\n    .import "b"\n}\n'
+            '.alloc body in slack {\n    .import "dialog"\n    .import "dialog"\n}\n'
         )
         program = Program()
         program.add_module_path(str(tmp_path))
         program.assemble_as_patch(str(main), tmp_path / "out.ips")
 
-        # Parse IPS — the alloc body's region should hold a.o bytes + b.o
-        # bytes (each containing one rts) + shared.o bytes ONCE (not twice
-        # despite being imported transitively by both a and b).
         d = (tmp_path / "out.ips").read_bytes()
         pos = 5
         total = 0
@@ -690,9 +686,9 @@ class TestAllocImportLoserSkip:
                 continue
             total += sz
             pos += sz
-        # Each module body = 1 byte (rts = 0x60). With dedup: 1 + 1 + 1 = 3 bytes.
-        # Without dedup (the bug): would be 5 bytes (shared imported twice + a + b).
-        assert total <= 3, f"expected <=3 bytes (a + b + shared once); got {total} — duplicate import emission"
+        # dialog body is 3 bytes (rts × 3). Pre-fix: 6 bytes (two copies
+        # overlapping at same offset). Post-fix: 3 bytes (loser skipped).
+        assert total == 3, f"expected 3 bytes (dialog body once); got {total} — loser emission"
 
 
 class TestAllocImportDedupe:

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -646,6 +646,55 @@ class TestObjectMode:
         assert cons_region.code[:5] == b"\x22\x00\x80\x02\x60"
 
 
+class TestAllocImportLoserSkip:
+    """ff4 Q#14 regression: when .alloc body has multiple .import directives,
+    transitive duplicates (same module pulled in by two different parent
+    modules) get marked is_loser=True for the earlier occurrences. Those
+    losers' pc_after returns current_pc unchanged so winners after them
+    place correctly — but AllocNode.emit_blocks used to call .emit() on
+    losers anyway, accumulating their bytes and overlapping the winner's
+    placement at the same target address."""
+
+    def test_alloc_body_with_duplicate_imports_does_not_double_emit(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # Build two modules that both import the same shared dep.
+        (tmp_path / "shared.s").write_text("shared_fn:\n    rts\n")
+        (tmp_path / "a.s").write_text('.import "shared"\na_fn:\n    rts\n')
+        (tmp_path / "b.s").write_text('.import "shared"\nb_fn:\n    rts\n')
+        Program().assemble_as_object(str(tmp_path / "shared.s"), tmp_path / "shared.o")
+        Program().assemble_as_object(str(tmp_path / "a.s"), tmp_path / "a.o")
+        Program().assemble_as_object(str(tmp_path / "b.s"), tmp_path / "b.o")
+
+        main = tmp_path / "main.s"
+        main.write_text(
+            ".pool slack { range 0x208000 0x20ffff strategy order }\n"
+            '.alloc all in slack {\n    .import "a"\n    .import "b"\n}\n'
+        )
+        program = Program()
+        program.add_module_path(str(tmp_path))
+        program.assemble_as_patch(str(main), tmp_path / "out.ips")
+
+        # Parse IPS — the alloc body's region should hold a.o bytes + b.o
+        # bytes (each containing one rts) + shared.o bytes ONCE (not twice
+        # despite being imported transitively by both a and b).
+        d = (tmp_path / "out.ips").read_bytes()
+        pos = 5
+        total = 0
+        while True:
+            if d[pos : pos + 3] == b"EOF":
+                break
+            pos += 3
+            sz = int.from_bytes(d[pos : pos + 2], "big")
+            pos += 2
+            if sz == 0:
+                pos += 3
+                continue
+            total += sz
+            pos += sz
+        # Each module body = 1 byte (rts = 0x60). With dedup: 1 + 1 + 1 = 3 bytes.
+        # Without dedup (the bug): would be 5 bytes (shared imported twice + a + b).
+        assert total <= 3, f"expected <=3 bytes (a + b + shared once); got {total} — duplicate import emission"
+
+
 class TestAllocImportDedupe:
     """ff4 Q#13: `.import` of the same .o module via both `.include`'d patch
     file AND inside `.alloc` body double-emitted because


### PR DESCRIPTION
Fixes ff4 Q#14 — a21's \`_collect_linked_modules\` recursion (Q#13 fix) marked .alloc-body LinkedModuleNode duplicates as losers correctly, but \`AllocNode.emit_blocks\` still called \`.emit()\` on losers. Their bytes accumulated AND overlapped winner placements → ff4-modules IPS dropped from 262KB to 6KB.

## Repro (ff4 \`dev/pool-bank20-reloc\` HEAD bc17dbe)

\`\`\`
git clone github.com:manz/ff4.git && cd ff4 && git checkout bc17dbe
pip install -r requirements.txt  # a816==1.1.0a21
python3 build.py
ls -la build/ff4.ips
\`\`\`

Pre-fix (a21): 6432 B IPS, missing 31KB of bank-20 module bodies.
Post-fix: 262172 B IPS, byte-identical to no-wrap baseline modulo \`BUILD_DATE\`.

## Root cause

a21 dedup correctly identifies loser LinkedModuleNodes inside \`.alloc\` body when the same module is imported transitively (e.g. \`libmz\` pulled by both \`dialog\` and \`vwf\` in a multi-import block).

Losers' \`pc_after\` returns current_pc unchanged so subsequent winners place at the right offset — but \`AllocNode.emit_blocks\` ignored \`is_loser\` and called \`.emit()\` on every body node. Loser bytes accumulated in the alloc output. Worse, each loser had \`_delta\` pointing at the SAME address as the winner that came after it (since the loser didn't advance pc), so emit ordering created overlapping placements.

## Fix

\`AllocNode.emit_blocks\` mirrors the top-level \`_emit_linked_module\` is_loser guard: skip loser body nodes entirely. Their pc_after already returned current_pc unchanged so winner offsets are already correct.

## Test plan
- [x] \`hatch run tests:tests\` — 895 passed, 1 skipped (1 new regression \`TestAllocImportLoserSkip\` covers transitive duplicate imports inside .alloc body)
- [x] \`hatch run tests:check\` — ruff clean
- [x] \`hatch run tests:type\` — mypy clean
- [x] ff4 \`dev/pool-bank20-reloc\` IPS byte-identical to no-wrap baseline modulo \`BUILD_DATE\`