### PR TITLE
Add `as` cast and typed `:=` bind for struct fields

### DIFF
--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -883,6 +883,40 @@ def _inner_canonical(tokens: list[ExprNode]) -> str:
     return " ".join(tok.to_canonical() for tok in tokens)
 
 
+def _iter_casts(
+    ctx: LintContext,
+) -> Iterable[tuple[AstNode, CastAccessExprNode | CastValueExprNode]]:
+    """Yield `(parent_node, cast)` pairs for every cast in the program."""
+    for parent in ctx.flat_nodes:
+        for expr in _expressions_in_node(parent):
+            for cast in _walk_cast_nodes(expr.tokens):
+                yield parent, cast
+
+
+def _single_identifier_name(cast: CastAccessExprNode | CastValueExprNode) -> str | None:
+    """Return the bare identifier `cast` wraps, or None when it wraps a richer expression."""
+    if len(cast.inner) != 1:
+        return None
+    inner = cast.inner[0]
+    if not hasattr(inner, "token"):
+        return None
+    return inner.token.value
+
+
+def _is_typed_bind_owner(
+    parent: AstNode,
+    cast: CastAccessExprNode | CastValueExprNode,
+    instances: dict[str, str],
+) -> bool:
+    """True when `cast` is the very RHS of `parent`'s typed bind — counting that
+    line against the user would penalize the `:=` we want them to write.
+    """
+    return (
+        isinstance(parent, AssignAstNode)
+        and instances.get(parent.symbol) == cast.type_name
+    )
+
+
 class UnknownStructTypeCast(Rule):
     code = "S001"
     description = "cast references an undeclared struct type"
@@ -897,15 +931,13 @@ class UnknownStructTypeCast(Rule):
 
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
         known = _collect_known_struct_types(ctx)
-        for parent in ctx.flat_nodes:
-            for expr in _expressions_in_node(parent):
-                for cast in _walk_cast_nodes(expr.tokens):
-                    if cast.type_name not in known:
-                        yield self.diagnose(
-                            ctx,
-                            parent,
-                            f"cast targets unknown struct type '{cast.type_name}'",
-                        )
+        for parent, cast in _iter_casts(ctx):
+            if cast.type_name not in known:
+                yield self.diagnose(
+                    ctx,
+                    parent,
+                    f"cast targets unknown struct type '{cast.type_name}'",
+                )
 
 
 class RedundantTypedCast(Rule):
@@ -922,22 +954,16 @@ class RedundantTypedCast(Rule):
 
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
         instances = _collect_typed_instances(ctx)
-        for parent in ctx.flat_nodes:
-            for expr in _expressions_in_node(parent):
-                for cast in _walk_cast_nodes(expr.tokens):
-                    if len(cast.inner) != 1:
-                        continue
-                    inner = cast.inner[0]
-                    if not hasattr(inner, "token"):
-                        continue
-                    name = inner.token.value
-                    bound_type = instances.get(name)
-                    if bound_type is not None and bound_type == cast.type_name:
-                        yield self.diagnose(
-                            ctx,
-                            parent,
-                            f"redundant cast: '{name}' is already bound as '{cast.type_name}'",
-                        )
+        for parent, cast in _iter_casts(ctx):
+            name = _single_identifier_name(cast)
+            if name is None:
+                continue
+            if instances.get(name) == cast.type_name:
+                yield self.diagnose(
+                    ctx,
+                    parent,
+                    f"redundant cast: '{name}' is already bound as '{cast.type_name}'",
+                )
 
 
 class RepeatedInlineCast(Rule):
@@ -954,30 +980,18 @@ class RepeatedInlineCast(Rule):
 
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
         instances = _collect_typed_instances(ctx)
-        # signature → (count, first parent node)
         seen: dict[tuple[str, str], list[AstNode]] = {}
-        for parent in ctx.flat_nodes:
-            for expr in _expressions_in_node(parent):
-                for cast in _walk_cast_nodes(expr.tokens):
-                    # Skip casts that came from a typed bind itself —
-                    # otherwise the bind line counts against the user.
-                    if (
-                        isinstance(parent, AssignAstNode)
-                        and parent.symbol in instances
-                        and instances[parent.symbol] == cast.type_name
-                    ):
-                        continue
-                    sig = (_inner_canonical(cast.inner), cast.type_name)
-                    seen.setdefault(sig, []).append(parent)
+        for parent, cast in _iter_casts(ctx):
+            if _is_typed_bind_owner(parent, cast, instances):
+                continue
+            sig = (_inner_canonical(cast.inner), cast.type_name)
+            seen.setdefault(sig, []).append(parent)
         for (inner_str, type_name), parents in seen.items():
             if len(parents) < 2:
                 continue
+            message = f"cast `({inner_str} as {type_name})` repeated {len(parents)}× — prefer typed bind"
             for parent in parents:
-                yield self.diagnose(
-                    ctx,
-                    parent,
-                    f"cast `({inner_str} as {type_name})` repeated {len(parents)}× — prefer typed bind",
-                )
+                yield self.diagnose(ctx, parent, message)
 
 
 # ---------------------------------------------------------------------------

--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -26,15 +26,23 @@ from a816.parse.ast.nodes import (
     AssignAstNode,
     AstNode,
     BlockAstNode,
+    CastAccessExprNode,
+    CastValueExprNode,
     CommentAstNode,
     CompoundAstNode,
+    DataNode,
     DocstringAstNode,
+    ExpressionAstNode,
+    ExprNode,
     ForAstNode,
     IfAstNode,
+    IncludeIpsAstNode,
     LabelAstNode,
     LabelDeclAstNode,
     MacroAstNode,
+    OpcodeAstNode,
     ScopeAstNode,
+    StructAstNode,
     SymbolAffectationAstNode,
 )
 from a816.parse.mzparser import MZParser
@@ -822,6 +830,157 @@ class ConstantNaming(Rule):
 
 
 # ---------------------------------------------------------------------------
+# S001 / S003 / S004 — struct ergonomics
+# ---------------------------------------------------------------------------
+
+
+def _expressions_in_node(node: AstNode) -> Iterable[ExpressionAstNode]:
+    """Yield every ExpressionAstNode reachable from `node` without descending
+    into child blocks (the flat-node walker visits those separately)."""
+    match node:
+        case AssignAstNode() | SymbolAffectationAstNode() | LabelDeclAstNode():
+            if isinstance(node.value, ExpressionAstNode):
+                yield node.value
+        case OpcodeAstNode():
+            if node.operand is not None:
+                yield node.operand
+        case DataNode():
+            for expr in node.data:
+                if isinstance(expr, ExpressionAstNode):
+                    yield expr
+        case IncludeIpsAstNode():
+            if isinstance(node.expression, ExpressionAstNode):
+                yield node.expression
+
+
+def _walk_cast_nodes(
+    tokens: list[ExprNode],
+) -> Iterable[CastAccessExprNode | CastValueExprNode]:
+    """Yield Cast* terms in `tokens`, recursing into their inner expressions."""
+    for tok in tokens:
+        if isinstance(tok, CastAccessExprNode | CastValueExprNode):
+            yield tok
+            yield from _walk_cast_nodes(tok.inner)
+
+
+def _collect_known_struct_types(ctx: LintContext) -> set[str]:
+    return {n.name for n in ctx.flat_nodes if isinstance(n, StructAstNode)}
+
+
+def _collect_typed_instances(ctx: LintContext) -> dict[str, str]:
+    """Map instance name → struct type for every `p := (... as T)` bind."""
+    instances: dict[str, str] = {}
+    for node in ctx.flat_nodes:
+        if not isinstance(node, AssignAstNode) or not isinstance(node.value, ExpressionAstNode):
+            continue
+        tokens = node.value.tokens
+        if len(tokens) == 1 and isinstance(tokens[0], CastValueExprNode):
+            instances[node.symbol] = tokens[0].type_name
+    return instances
+
+
+def _inner_canonical(tokens: list[ExprNode]) -> str:
+    return " ".join(tok.to_canonical() for tok in tokens)
+
+
+class UnknownStructTypeCast(Rule):
+    code = "S001"
+    description = "cast references an undeclared struct type"
+    rationale = (
+        "`(expr as T).field` and `p := (expr as T)` resolve `T` against the "
+        "structs declared in the current translation unit. Casting to a "
+        "type the file doesn't know about is almost always a typo — and "
+        "would otherwise blow up at codegen instead of lint time."
+    )
+    bad = '"""Module."""\nlda.w (0x2100 as Unknown).x\n'
+    good = '"""Module."""\n.struct PPU {\n    word OAMADDR\n}\nlda.w (0x2100 as PPU).OAMADDR\n'
+
+    def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
+        known = _collect_known_struct_types(ctx)
+        for parent in ctx.flat_nodes:
+            for expr in _expressions_in_node(parent):
+                for cast in _walk_cast_nodes(expr.tokens):
+                    if cast.type_name not in known:
+                        yield self.diagnose(
+                            ctx,
+                            parent,
+                            f"cast targets unknown struct type '{cast.type_name}'",
+                        )
+
+
+class RedundantTypedCast(Rule):
+    code = "S003"
+    description = "cast on an already-typed binding is redundant"
+    rationale = (
+        "When `p := (addr as Player)` is in scope, `p.field` already "
+        "resolves through the typed binding. Re-casting `(p as Player)` "
+        "adds noise and signals confusion about which binding is in "
+        "effect."
+    )
+    bad = '"""Module."""\n.struct Pt {\n    word x\n}\np := (0x100 as Pt)\nlda.w (p as Pt).x\n'
+    good = '"""Module."""\n.struct Pt {\n    word x\n}\np := (0x100 as Pt)\nlda.w p.x\n'
+
+    def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
+        instances = _collect_typed_instances(ctx)
+        for parent in ctx.flat_nodes:
+            for expr in _expressions_in_node(parent):
+                for cast in _walk_cast_nodes(expr.tokens):
+                    if len(cast.inner) != 1:
+                        continue
+                    inner = cast.inner[0]
+                    if not hasattr(inner, "token"):
+                        continue
+                    name = inner.token.value
+                    bound_type = instances.get(name)
+                    if bound_type is not None and bound_type == cast.type_name:
+                        yield self.diagnose(
+                            ctx,
+                            parent,
+                            f"redundant cast: '{name}' is already bound as '{cast.type_name}'",
+                        )
+
+
+class RepeatedInlineCast(Rule):
+    code = "S004"
+    description = "same cast expression used more than once — prefer `:=`"
+    rationale = (
+        "Repeating `(expr as T)` in several operands is a sign the "
+        "address deserves a typed binding. `p := (expr as T)` lets the "
+        "subsequent code say `p.field` and keeps the address change "
+        "scoped to a single line if it ever moves."
+    )
+    bad = '"""Module."""\n.struct Pt {\n    word x\n    word y\n}\nlda.w (0x100 as Pt).x\nlda.w (0x100 as Pt).y\n'
+    good = '"""Module."""\n.struct Pt {\n    word x\n    word y\n}\np := (0x100 as Pt)\nlda.w p.x\nlda.w p.y\n'
+
+    def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
+        instances = _collect_typed_instances(ctx)
+        # signature → (count, first parent node)
+        seen: dict[tuple[str, str], list[AstNode]] = {}
+        for parent in ctx.flat_nodes:
+            for expr in _expressions_in_node(parent):
+                for cast in _walk_cast_nodes(expr.tokens):
+                    # Skip casts that came from a typed bind itself —
+                    # otherwise the bind line counts against the user.
+                    if (
+                        isinstance(parent, AssignAstNode)
+                        and parent.symbol in instances
+                        and instances[parent.symbol] == cast.type_name
+                    ):
+                        continue
+                    sig = (_inner_canonical(cast.inner), cast.type_name)
+                    seen.setdefault(sig, []).append(parent)
+        for (inner_str, type_name), parents in seen.items():
+            if len(parents) < 2:
+                continue
+            for parent in parents:
+                yield self.diagnose(
+                    ctx,
+                    parent,
+                    f"cast `({inner_str} as {type_name})` repeated {len(parents)}× — prefer typed bind",
+                )
+
+
+# ---------------------------------------------------------------------------
 # Registry + entry points
 # ---------------------------------------------------------------------------
 
@@ -837,6 +996,9 @@ RULES: list[Rule] = [
     LineTooLong(),
     LabelNaming(),
     ConstantNaming(),
+    UnknownStructTypeCast(),
+    RedundantTypedCast(),
+    RepeatedInlineCast(),
 ]
 Rule.registry = {rule.code: rule for rule in RULES}
 

--- a/a816/parse/ast/expression.py
+++ b/a816/parse/ast/expression.py
@@ -3,7 +3,15 @@ import re
 from collections.abc import Callable
 
 from a816.exceptions import ExternalExpressionReference, ExternalSymbolReference
-from a816.parse.ast.nodes import BinOp, ExpressionAstNode, ExprNode, Term, UnaryOp
+from a816.parse.ast.nodes import (
+    BinOp,
+    CastAccessExprNode,
+    CastValueExprNode,
+    ExpressionAstNode,
+    ExprNode,
+    Term,
+    UnaryOp,
+)
 from a816.parse.tokens import TokenType
 from a816.symbols import Resolver
 
@@ -63,7 +71,7 @@ def shunting_yard(expr_nodes: list[ExprNode]) -> list[ExprNode]:
     operator_stack: list[ExprNode] = []
 
     for expr in expr_nodes:
-        if isinstance(expr, Term):
+        if isinstance(expr, Term | CastAccessExprNode | CastValueExprNode):
             output_queue.append(expr)
         elif isinstance(expr, BinOp | UnaryOp):
             current_precedence = OPERATOR_PRECEDENCE[expr.token.value] if isinstance(expr, BinOp) else 2
@@ -157,7 +165,27 @@ def _collect_external_symbols(ordered: list[ExprNode], resolver: Resolver) -> se
     return external_symbols
 
 
+def _eval_inner(inner: list[ExprNode], resolver: Resolver) -> int | str:
+    return eval_expression(ExpressionAstNode(list(inner)), resolver)
+
+
 def _push_term(current: ExprNode, resolver: Resolver, values_stack: list[int | str]) -> None:
+    if isinstance(current, CastAccessExprNode):
+        base = _eval_inner(current.inner, resolver)
+        if not isinstance(base, int):
+            raise RuntimeError(f"Cast base does not evaluate to an address: {base!r}")
+        field_symbol = ".".join([current.type_name, *current.field_path])
+        offset = resolver.current_scope.value_for(field_symbol)
+        if not isinstance(offset, int):
+            raise RuntimeError(f"Struct field {field_symbol!r} did not resolve to an offset")
+        values_stack.append(base + offset)
+        return
+    if isinstance(current, CastValueExprNode):
+        base = _eval_inner(current.inner, resolver)
+        if not isinstance(base, int):
+            raise RuntimeError(f"Cast base does not evaluate to an address: {base!r}")
+        values_stack.append(base)
+        return
     if current.token.type == TokenType.NUMBER:
         values_stack.append(eval_number(current.token.value))
     elif current.token.type == TokenType.QUOTED_STRING:

--- a/a816/parse/ast/nodes.py
+++ b/a816/parse/ast/nodes.py
@@ -34,6 +34,10 @@ class ExprNode:
 
         return self.token == other.token
 
+    def to_canonical(self) -> str:
+        """Render this token in the canonical expression form."""
+        return self.token.value
+
 
 class BinOp(ExprNode):
     """Represents a Binary expression operation"""
@@ -51,6 +55,43 @@ class Parenthesis(ExprNode):
     """Represents a Parenthesis expression"""
 
 
+def _inner_canonical(inner: list["ExprNode"]) -> str:
+    return " ".join(node.to_canonical() for node in inner)
+
+
+class CastAccessExprNode(ExprNode):
+    """`(inner as TYPE).field` — atomic term resolving to `eval(inner) + TYPE.field`.
+
+    Supports chained access (`).a.b.c`) via the `field_path` list. Only the
+    leaf access produces a value; intermediate names look up nested struct
+    sub-fields registered as `TYPE.a.b.c` during struct codegen.
+    """
+
+    def __init__(self, token: Token, inner: list[ExprNode], type_name: str, field_path: list[str]):
+        super().__init__(token)
+        self.inner = inner
+        self.type_name = type_name
+        self.field_path = field_path
+
+    def to_canonical(self) -> str:
+        suffix = ".".join(self.field_path)
+        return f"({_inner_canonical(self.inner)} as {self.type_name}).{suffix}"
+
+
+class CastValueExprNode(ExprNode):
+    """`(inner as TYPE)` — atomic term that evaluates to `eval(inner)` and carries
+    the type tag so an assign RHS can eager-expand into per-field instance symbols.
+    """
+
+    def __init__(self, token: Token, inner: list[ExprNode], type_name: str):
+        super().__init__(token)
+        self.inner = inner
+        self.type_name = type_name
+
+    def to_canonical(self) -> str:
+        return f"({_inner_canonical(self.inner)} as {self.type_name})"
+
+
 class ExpressionAstNode(AstNode):
     tokens: list[ExprNode]
 
@@ -59,10 +100,10 @@ class ExpressionAstNode(AstNode):
         self.tokens = tokens
 
     def to_representation(self) -> tuple[Any, ...]:
-        return (" ".join([expr_node.token.value for expr_node in self.tokens]),)
+        return (" ".join([expr_node.to_canonical() for expr_node in self.tokens]),)
 
     def to_canonical(self) -> str:
-        return " ".join([expr_node.token.value for expr_node in self.tokens])
+        return " ".join([expr_node.to_canonical() for expr_node in self.tokens])
 
 
 class BlockAstNode(AstNode):

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -10,6 +10,7 @@ from a816.parse.ast.nodes import (
     AssignAstNode,
     AstNode,
     BlockAstNode,
+    CastValueExprNode,
     CodeLookupAstNode,
     CodePositionAstNode,
     CodeRelocationAstNode,
@@ -139,21 +140,67 @@ def generate_scope(
 _STRUCT_FIELD_SIZES = {"byte": 1, "word": 2, "long": 3, "dword": 4}
 
 
+def _layout_struct_fields(
+    node: StructAstNode,
+    resolver: Resolver,
+    file_info: Token,
+) -> tuple[list[tuple[str, int]], int]:
+    """Compute flat (field_path, offset) entries + total size for a struct.
+
+    Primitive fields contribute one entry. Fields whose declared type is a
+    previously registered struct contribute the field's own offset plus the
+    nested struct's flattened entries with the field name prefixed
+    (`pos`, `pos.x`, `pos.y`). Forward refs and self-references raise a
+    NodeError because the layout would be unresolvable.
+    """
+    entries: list[tuple[str, int]] = []
+    offset = 0
+    for field_name, field_type in node.fields:
+        if field_type in _STRUCT_FIELD_SIZES:
+            entries.append((field_name, offset))
+            offset += _STRUCT_FIELD_SIZES[field_type]
+            continue
+        if field_type == node.name:
+            raise NodeError(
+                f"Struct {node.name!r} field {field_name!r} cannot reference its own type.",
+                file_info,
+            )
+        if field_type not in resolver.struct_layouts:
+            raise NodeError(
+                f"Unknown struct field type {field_type!r} for {node.name}.{field_name}; "
+                f"declare `.struct {field_type}` before use.",
+                file_info,
+            )
+        nested_layout = resolver.struct_layouts[field_type]
+        nested_size = resolver.struct_sizes[field_type]
+        entries.append((field_name, offset))
+        for sub_path, sub_offset in nested_layout:
+            entries.append((f"{field_name}.{sub_path}", offset + sub_offset))
+        offset += nested_size
+    return entries, offset
+
+
 def generate_struct(
     node: StructAstNode,
     resolver: Resolver,
     macro_definitions: MacroDefinitions,
     file_info: Token,
 ) -> GenNodes:
-    """Push a NamedScope, register one offset symbol per field, then export."""
+    """Push a NamedScope, register one offset symbol per (possibly nested)
+    field, register the layout for later typed-bind expansion, then export.
+    """
+    if node.name in resolver.struct_layouts:
+        raise NodeError(f"Struct {node.name!r} redefined.", file_info)
+    entries, total_size = _layout_struct_fields(node, resolver, file_info)
+    resolver.struct_layouts[node.name] = entries
+    resolver.struct_sizes[node.name] = total_size
+
     resolver.append_named_scope(node.name)
     resolver.use_next_scope()
     code: list[NodeProtocol] = [ScopeNode(resolver)]
-    offset = 0
-    for field_name, field_type in node.fields:
-        resolver.current_scope.add_symbol(field_name, offset)
-        offset += _STRUCT_FIELD_SIZES[field_type]
-    resolver.current_scope.add_symbol("__size", offset)
+    for field_path, offset in entries:
+        resolver.current_scope.add_symbol(field_path, offset)
+    resolver.current_scope.add_symbol("__size", total_size)
     code.append(PopScopeNode(resolver))
     # exports=True promotes Name.field and Name.__size to the parent scope.
     resolver.restore_scope(exports=True)
@@ -616,6 +663,37 @@ def generate_register_size(
     return [RegisterSizeNode(node.register, node.size, resolver)]
 
 
+def _try_typed_bind(node: AssignAstNode, resolver: Resolver, file_info: Token) -> bool:
+    """If RHS is `(expr as T)`, eager-expand the instance's flat field symbols.
+
+    Returns True iff the RHS was a typed cast and the expansion succeeded.
+    Externs in the cast base aren't supported here — the user would lose the
+    static field-access ergonomics anyway, so raise rather than silently
+    falling back to a plain alias.
+    """
+    tokens = node.value.tokens
+    if len(tokens) != 1 or not isinstance(tokens[0], CastValueExprNode):
+        return False
+    cast = tokens[0]
+    type_name = cast.type_name
+    if type_name not in resolver.struct_layouts:
+        raise NodeError(
+            f"Typed bind {node.symbol!r}: unknown struct type {type_name!r}.",
+            file_info,
+        )
+    base = eval_expression(ExpressionAstNode(list(cast.inner)), resolver)
+    if not isinstance(base, int):
+        raise NodeError(
+            f"Typed bind {node.symbol!r}: base expression must evaluate to an integer address.",
+            file_info,
+        )
+    resolver.current_scope.add_symbol(node.symbol, base)
+    for field_path, offset in resolver.struct_layouts[type_name]:
+        resolver.current_scope.add_symbol(f"{node.symbol}.{field_path}", base + offset)
+    resolver.typed_instances[node.symbol] = type_name
+    return True
+
+
 def generate_assign(
     node: AssignAstNode,
     resolver: Resolver,
@@ -623,6 +701,9 @@ def generate_assign(
     file_info: Token,
 ) -> GenNodes:
     from a816.exceptions import ExternalExpressionReference, ExternalSymbolReference
+
+    if _try_typed_bind(node, resolver, file_info):
+        return []
 
     try:
         value = eval_expression(node.value, resolver)

--- a/a816/parse/parser_states.py
+++ b/a816/parse/parser_states.py
@@ -12,6 +12,8 @@ from a816.parse.ast.nodes import (
     AstNode,
     BinOp,
     BlockAstNode,
+    CastAccessExprNode,
+    CastValueExprNode,
     CodeLookupAstNode,
     CodePositionAstNode,
     CodeRelocationAstNode,
@@ -240,6 +242,8 @@ def parse_for(p: Parser) -> ForAstNode:
     return ForAstNode(variable.value, start, end, block, current)
 
 
+# Primitive struct field types. Field types outside this set are resolved at
+# codegen time against registered struct types so nested layouts compose.
 STRUCT_FIELD_TYPES = {"byte", "word", "long", "dword"}
 
 
@@ -264,12 +268,6 @@ def parse_struct(p: Parser) -> StructAstNode:
 
         type_token = p.current()
         expect_token(type_token, TokenType.IDENTIFIER)
-        if type_token.value not in STRUCT_FIELD_TYPES:
-            raise ParserSyntaxError(
-                f"Unknown struct field type {type_token.value!r}; expected one of {sorted(STRUCT_FIELD_TYPES)}",
-                type_token,
-                TokenType.IDENTIFIER,
-            )
         p.next()
 
         name_token = p.current()
@@ -617,14 +615,57 @@ def parse_expression_ep(p: Parser) -> list[AstNode]:
     return [parse_expression(p)]
 
 
+def _consume_dot_field_path(p: Parser) -> list[str]:
+    """Consume a `.IDENT(.IDENT)*` postfix from the token stream."""
+    path: list[str] = []
+    while p.current().type == TokenType.DOT:
+        p.next()
+        field_token = p.next()
+        expect_token(field_token, TokenType.IDENTIFIER)
+        path.append(field_token.value)
+    return path
+
+
+def _parse_lparen_expression(p: Parser, lparen: Token) -> list[ExprNode]:
+    """Parse `(inner [as TYPE]) [.field...]`.
+
+    Three shapes emerge:
+      - `(inner)` plain parenthesised expression
+      - `(inner as T)` typed value carrying a type tag for assign RHS
+      - `(inner as T).field(.sub)*` field access into the type's layout
+    """
+    inner = _parse_expression(p)
+    type_name: str | None = None
+    as_token = p.current()
+    if as_token.type == TokenType.IDENTIFIER and as_token.value == "as":
+        p.next()
+        type_token = p.next()
+        expect_token(type_token, TokenType.IDENTIFIER)
+        type_name = type_token.value
+    expect_token(p.current(), TokenType.RPAREN)
+    p.next()  # consume RPAREN
+
+    field_path = _consume_dot_field_path(p)
+
+    if type_name is not None and field_path:
+        return [CastAccessExprNode(lparen, inner, type_name, field_path)]
+    if type_name is not None:
+        return [CastValueExprNode(lparen, inner, type_name)]
+    if field_path:
+        raise ParserSyntaxError(
+            "Field access requires a typed cast: `(expr as Type).field`.",
+            lparen,
+        )
+    # Plain parenthesised expression — restore the wrapping tokens for shunting yard.
+    rparen = Token(TokenType.RPAREN, ")", lparen.position)
+    return [Parenthesis(lparen), *inner, Parenthesis(rparen)]
+
+
 def _parse_expression(p: Parser) -> list[ExprNode]:
     tokens: list[ExprNode] = []
     current_token = p.next()
     if accept_token(current_token, TokenType.LPAREN):
-        tokens.append(Parenthesis(current_token))
-        tokens += _parse_expression(p)
-        expect_token(p.current(), TokenType.RPAREN)
-        tokens.append(Parenthesis(p.next()))
+        tokens += _parse_lparen_expression(p, current_token)
     elif accept_tokens(
         current_token, [TokenType.NUMBER, TokenType.BOOLEAN, TokenType.QUOTED_STRING, TokenType.IDENTIFIER]
     ):
@@ -661,6 +702,21 @@ def parse_symbol_affectation(
         node_type = AssignAstNode
 
     expression = parse_expression(p)
+
+    # `p := expr as T` (no parens) — wrap RHS as a typed cast so codegen can
+    # eager-expand the per-field instance symbols.
+    as_token = p.current()
+    if as_token.type == TokenType.IDENTIFIER and as_token.value == "as":
+        if operator.type != TokenType.ASSIGN:
+            raise ParserSyntaxError(
+                "Typed-bind cast `as T` requires `:=`, not `=`.",
+                as_token,
+            )
+        p.next()
+        type_token = p.next()
+        expect_token(type_token, TokenType.IDENTIFIER)
+        cast_term = CastValueExprNode(current, list(expression.tokens), type_token.value)
+        expression = ExpressionAstNode([cast_term])
 
     return node_type(symbol.value, expression, current)
 
@@ -715,6 +771,11 @@ def parse_operand_and_addressing(
         try:
             p.next()
             operand = parse_expression(p)
+            # Cast inside operand parens (`(addr as T).field`) is not an
+            # indirect addressing mode; bail to the direct path so
+            # `_parse_lparen_expression` handles the cast.
+            if p.current().type == TokenType.IDENTIFIER and p.current().value == "as":
+                raise SyntaxError()
             if accept_token(p.current(), TokenType.ADDRESSING_MODE_INDEX):
                 addressing_mode = AddressingMode.dp_or_sr_indirect_indexed
                 inner_index = p.current().value
@@ -724,7 +785,7 @@ def parse_operand_and_addressing(
 
             expect_token(p.current(), TokenType.RPAREN)
 
-            if accept_token(p.peek(), TokenType.OPERATOR):
+            if accept_tokens(p.peek(), [TokenType.OPERATOR, TokenType.DOT]):
                 raise SyntaxError()
             p.next()
         except SyntaxError:

--- a/a816/parse/parser_states.py
+++ b/a816/parse/parser_states.py
@@ -755,51 +755,68 @@ def parse_opcode(p: Parser) -> OpcodeAstNode:
     )
 
 
+def _parse_immediate_operand(p: Parser) -> tuple[AddressingMode, None, ExpressionAstNode]:
+    p.next()
+    if accept_token(p.current(), TokenType.EOF):
+        raise ParserSyntaxError("Unexpected end of input.", p.current(), None)
+    return AddressingMode.immediate, None, parse_expression(p)
+
+
+def _parse_indirect_inner(
+    p: Parser,
+) -> tuple[AddressingMode, str | None, ExpressionAstNode]:
+    """Parse `(expr [,X|Y|S])`. Caller-side try/except converts SyntaxError
+    raised here into a fallback to direct addressing.
+    """
+    p.next()
+    operand = parse_expression(p)
+    # Cast inside operand parens (`(addr as T).field`) is not an indirect
+    # addressing mode; bail to the direct path.
+    if p.current().type == TokenType.IDENTIFIER and p.current().value == "as":
+        raise SyntaxError()
+    inner_index: str | None = None
+    addressing_mode = AddressingMode.indirect
+    if accept_token(p.current(), TokenType.ADDRESSING_MODE_INDEX):
+        addressing_mode = AddressingMode.dp_or_sr_indirect_indexed
+        inner_index = p.current().value
+        p.next()
+    expect_token(p.current(), TokenType.RPAREN)
+    if accept_tokens(p.peek(), [TokenType.OPERATOR, TokenType.DOT]):
+        raise SyntaxError()
+    p.next()
+    return addressing_mode, inner_index, operand
+
+
+def _parse_paren_operand(
+    p: Parser,
+) -> tuple[AddressingMode, str | None, ExpressionAstNode]:
+    saved_position = p.pos
+    try:
+        return _parse_indirect_inner(p)
+    except SyntaxError:
+        p.pos = saved_position
+        return AddressingMode.direct, None, parse_expression(p)
+
+
+def _parse_indirect_long_operand(p: Parser) -> tuple[AddressingMode, None, ExpressionAstNode]:
+    p.next()
+    operand = parse_expression(p)
+    expect_token(p.next(), TokenType.RBRAKET)
+    return AddressingMode.indirect_long, None, operand
+
+
 def parse_operand_and_addressing(
     addressing_mode: AddressingMode, opcode: Token, p: Parser
 ) -> tuple[AddressingMode, str | None, ExpressionAstNode | None]:
-    inner_index = None
-    operand = None
     if accept_token(p.current(), TokenType.SHARP):
-        addressing_mode = AddressingMode.immediate
-        p.next()
-        if accept_token(p.current(), TokenType.EOF):
-            raise ParserSyntaxError("Unexpected end of input.", p.current(), None)
-        operand = parse_expression(p)
-    elif accept_token(p.current(), TokenType.LPAREN):
-        saved_position = p.pos
-        try:
-            p.next()
-            operand = parse_expression(p)
-            # Cast inside operand parens (`(addr as T).field`) is not an
-            # indirect addressing mode; bail to the direct path so
-            # `_parse_lparen_expression` handles the cast.
-            if p.current().type == TokenType.IDENTIFIER and p.current().value == "as":
-                raise SyntaxError()
-            if accept_token(p.current(), TokenType.ADDRESSING_MODE_INDEX):
-                addressing_mode = AddressingMode.dp_or_sr_indirect_indexed
-                inner_index = p.current().value
-                p.next()
-            else:
-                addressing_mode = AddressingMode.indirect
-
-            expect_token(p.current(), TokenType.RPAREN)
-
-            if accept_tokens(p.peek(), [TokenType.OPERATOR, TokenType.DOT]):
-                raise SyntaxError()
-            p.next()
-        except SyntaxError:
-            p.pos = saved_position
-            operand = parse_expression(p)
-            addressing_mode = AddressingMode.direct
-    elif accept_token(p.current(), TokenType.LBRAKET):
-        p.next()
-        operand = parse_expression(p)
-        expect_token(p.next(), TokenType.RBRAKET)
-        addressing_mode = AddressingMode.indirect_long
-    elif accept_token(opcode, TokenType.OPCODE):
-        operand = parse_expression(p)
-    return addressing_mode, inner_index, operand
+        return _parse_immediate_operand(p)
+    if accept_token(p.current(), TokenType.LPAREN):
+        return _parse_paren_operand(p)
+    if accept_token(p.current(), TokenType.LBRAKET):
+        return _parse_indirect_long_operand(p)
+    if accept_token(opcode, TokenType.OPCODE):
+        return addressing_mode, None, parse_expression(p)
+    return addressing_mode, None, None
 
 
 def parse_code_lookup(p: Parser) -> CodeLookupAstNode:

--- a/a816/parse/scanner_states.py
+++ b/a816/parse/scanner_states.py
@@ -24,8 +24,8 @@ def lex_identifier(s: "Scanner") -> None:
         s.next()
         s.ignore()
     else:
-        # handle scoped identifiers
-        if s.peek() == ".":
+        # handle scoped identifiers, including nested struct fields (a.b.c).
+        while s.peek() == "." and s.peek(1) is not None and s.peek(1) in IDENTIFIER_START_CHARS:
             s.next()
             s.accept_run(IDENTIFIER_CHARS)
 
@@ -93,6 +93,20 @@ def accept_opcode(s: "Scanner") -> bool:
     return False
 
 
+def _lex_postfix_dot_chain(s: "Scanner") -> None:
+    """Emit `.field` postfix tokens after `)` or `]` for struct field access.
+
+    Each `.IDENT` becomes a DOT token followed by an IDENTIFIER token so the
+    parser can attach the access to the preceding expression. Multiple dots
+    chain (`).a.b.c`) for nested struct fields.
+    """
+    while s.peek() == "." and s.peek(1) is not None and s.peek(1) in IDENTIFIER_START_CHARS:
+        s.next()
+        s.emit(TokenType.DOT)
+        s.accept_run(IDENTIFIER_CHARS)
+        s.emit(TokenType.IDENTIFIER)
+
+
 def lex_expression(s: "Scanner") -> None:
     while s.pos < len(s.input):
         s.ignore_run(" ")
@@ -126,6 +140,7 @@ def lex_expression(s: "Scanner") -> None:
             s.emit(TokenType.LPAREN)
         elif s.accept(")"):
             s.emit(TokenType.RPAREN)
+            _lex_postfix_dot_chain(s)
         else:
             break
 
@@ -157,9 +172,11 @@ def lex_operand(s: "Scanner") -> None:
     if p == ")":
         s.next()
         s.emit(TokenType.RPAREN)
+        _lex_postfix_dot_chain(s)
     elif p == "]":
         s.next()
         s.emit(TokenType.RBRAKET)
+        _lex_postfix_dot_chain(s)
 
     s.ignore_run(" ")
     if s.accept(","):

--- a/a816/parse/tokens.py
+++ b/a816/parse/tokens.py
@@ -76,6 +76,8 @@ class TokenType(Enum):
 
     FROM = auto()
 
+    DOT = auto()
+
 
 class Token:
     def __init__(self, type_: TokenType, value: str, position: Position | None = None) -> None:

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -252,6 +252,16 @@ class Resolver:
         # symbol export so two `.o` files declaring the same pool don't
         # collide on `<pool>.capacity` etc. at link time.
         self.pool_stat_symbol_names: set[str] = set()
+        # Struct layout registry: type name → flat (field_path, offset) pairs.
+        # Populated by `generate_struct`; consumed by typed-bind eager
+        # expansion and by `(expr as T).field` field-access codegen so we
+        # don't have to walk scopes to enumerate a struct's fields.
+        self.struct_layouts: dict[str, list[tuple[str, int]]] = {}
+        # Total size per registered struct type, exposed as `Type.__size`.
+        self.struct_sizes: dict[str, int] = {}
+        # Typed-bind registry: instance name → struct type name. Lets the
+        # linter spot redundant casts and field access on non-typed bindings.
+        self.typed_instances: dict[str, str] = {}
         self.set_position(pc)
 
     def allocate_pools(self) -> None:

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -105,8 +105,11 @@ references. Sub-symbols (`name.sub`) need their own `.extern`. See
 ### `.struct Name { ... }`
 
 Layout-only declaration; emits no bytes. Field names export as
-`Name.field` byte offsets plus `Name.__size`. Field types: `byte`,
-`word`, `long` (24-bit), `dword` (32-bit).
+`Name.field` byte offsets plus `Name.__size`. Primitive field types:
+`byte`, `word`, `long` (24-bit), `dword` (32-bit). A field type can
+also be the name of another previously declared struct, in which
+case the nested layout flattens into dotted offsets
+(`Outer.pos.x`, `Outer.pos.y`).
 
 ```ca65
 .struct OAM {
@@ -115,7 +118,49 @@ Layout-only declaration; emits no bytes. Field names export as
     byte tile
     byte attr
 }
+
+.struct Inner {
+    word x
+    word y
+}
+.struct Outer {
+    byte tag
+    Inner pos
+    byte flags
+}
+; → Outer.tag = 0, Outer.pos = 1, Outer.pos.x = 1, Outer.pos.y = 3,
+;   Outer.flags = 5, Outer.__size = 6
 ```
+
+#### Typed access: `as` casts and `:=` binds
+
+A `(expr as T)` cast tags an address with a struct type so a postfix
+`.field` resolves through the struct's layout. The two forms share one
+mechanism:
+
+```ca65
+; Inline cast, single use.
+    lda.w (0x2100 as PPU).OAMADDR    ; → lda.w $2102
+
+; Typed bind, reusable across many accesses.
+p := (0x7e0000 as OAM)
+    lda.l p.x                         ; → lda.l $7e0000
+    lda.l p.y                         ; → lda.l $7e0002
+
+; Bare form (no parens) also works for `:=`.
+q := 0x010000 as Pt
+```
+
+`p := (...)` eager-expands one constant per (possibly nested) field
+of `T`, so `p.field` is just a flat symbol after the bind. Nested
+struct fields chain cleanly: `(o as Outer).pos.y` and
+`o.pos.y` both resolve to `base + Outer.pos + Inner.y`.
+
+Lint hooks:
+
+- `S001` — cast targets a struct type the file never declared.
+- `S003` — `(p as T).field` when `p` is already bound as `T`.
+- `S004` — same `(expr as T)` repeated more than once; promote to `:=`.
 
 ## Code
 

--- a/docs/docs/fluff.md
+++ b/docs/docs/fluff.md
@@ -49,6 +49,9 @@ placement, `E***` for physical layout, `N***` for naming.
 | `E501` | Source line longer than 120 characters. |
 | `N801` | Label name is not snake_case. |
 | `N802` | Constant name is not snake_case or SCREAMING_SNAKE_CASE. |
+| `S001` | `(expr as T).field` / `p := (expr as T)` references a struct type that isn't declared in the current translation unit. |
+| `S003` | Redundant cast: `(p as T).field` when `p` is already typed-bound to `T`. |
+| `S004` | The same `(expr as T)` cast appears more than once in the file — promote it to a `:=` typed bind. |
 
 Names with a single leading underscore (`_loop`, `_private_macro`) are
 treated as private and skipped by `DOC002` / `DOC003` / naming rules.

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import pytest
+
+from a816.parse.nodes import NodeError
 from a816.program import Program
 
 
@@ -95,15 +98,15 @@ def test_struct_duplicate_field_raises() -> None:
 
 
 def test_struct_unknown_type_raises() -> None:
+    """Unknown type is now validated at codegen so nested struct types compose."""
     program = Program()
     src = """
         .struct Bad {
             qword x
         }
     """
-    error, _ = program.parser.parse(src, "memory.s")
-    assert error is not None
-    assert "Unknown struct field type" in str(error)
+    with pytest.raises(NodeError, match="Unknown struct field type"):
+        program.assemble_string_with_emitter(src, "memory.s", _NoopEmitter())
 
 
 def test_struct_supports_dword() -> None:
@@ -124,3 +127,250 @@ def test_struct_supports_dword() -> None:
     assert symbols["Big.tag"] == 0
     assert symbols["Big.payload"] == 1
     assert symbols["Big.__size"] == 5
+
+
+def _collect_symbols(program: Program) -> dict[str, int]:
+    return {
+        name: value
+        for scope in program.resolver.scopes
+        for name, value in scope.symbols.items()
+        if isinstance(value, int)
+    }
+
+
+def _assemble_ips(src: str) -> bytes:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        asm = root / "main.s"
+        asm.write_text(src, encoding="utf-8")
+        ips = root / "out.ips"
+        program = Program()
+        assert program.assemble_as_patch(str(asm), ips) == 0
+        return ips.read_bytes()
+
+
+_OAM_DEF = """
+.struct OAM {
+    word x
+    word y
+    byte tile
+    byte attr
+}
+"""
+
+_PT_DEF = """
+.struct Pt {
+    word x
+    word y
+}
+"""
+
+_NESTED_DEFS = """
+.struct Inner {
+    word x
+    word y
+}
+.struct Outer {
+    byte tag
+    Inner pos
+    byte flags
+}
+"""
+
+
+def test_inline_cast_field_access() -> None:
+    """`lda.w (0x2100 as PPU).OAMADDR` assembles to LDA $2102."""
+    src = """
+        .struct PPU {
+            byte INIDISP
+            byte OBSEL
+            word OAMADDR
+        }
+        *=0x008000
+            lda.w (0x2100 as PPU).OAMADDR
+    """
+    data = _assemble_ips(src)
+    assert b"\xad\x02\x21" in data
+
+
+def test_typed_bind_paren_form_registers_field_symbols() -> None:
+    program = _resolve(_OAM_DEF + "p := (0x7e0000 as OAM)\n")
+    symbols = _collect_symbols(program)
+    assert symbols["p"] == 0x7E0000
+    assert symbols["p.x"] == 0x7E0000
+    assert symbols["p.y"] == 0x7E0002
+    assert symbols["p.tile"] == 0x7E0004
+    assert symbols["p.attr"] == 0x7E0005
+    assert program.resolver.typed_instances["p"] == "OAM"
+
+
+def test_typed_bind_bare_form() -> None:
+    program = _resolve(_PT_DEF + "q := 0x010000 as Pt\n")
+    symbols = _collect_symbols(program)
+    assert symbols["q"] == 0x010000
+    assert symbols["q.x"] == 0x010000
+    assert symbols["q.y"] == 0x010002
+
+
+def test_typed_bind_dot_access_in_opcode() -> None:
+    src = (
+        _OAM_DEF
+        + """
+        *=0x008000
+        p := (0x7e0000 as OAM)
+            lda.l p.y
+    """
+    )
+    data = _assemble_ips(src)
+    # LDA.l $7E0002 = AF 02 00 7E
+    assert b"\xaf\x02\x00\x7e" in data
+
+
+def test_nested_struct_fields_register_dotted_subfields() -> None:
+    program = _resolve(_NESTED_DEFS)
+    symbols = _collect_symbols(program)
+    assert symbols["Outer.tag"] == 0
+    assert symbols["Outer.pos"] == 1
+    assert symbols["Outer.pos.x"] == 1
+    assert symbols["Outer.pos.y"] == 3
+    assert symbols["Outer.flags"] == 5
+    assert symbols["Outer.__size"] == 6
+
+
+def test_nested_typed_bind_registers_deep_field_symbols() -> None:
+    program = _resolve(_NESTED_DEFS + "o := (0x7e0010 as Outer)\n")
+    symbols = _collect_symbols(program)
+    assert symbols["o"] == 0x7E0010
+    assert symbols["o.tag"] == 0x7E0010
+    assert symbols["o.pos"] == 0x7E0011
+    assert symbols["o.pos.x"] == 0x7E0011
+    assert symbols["o.pos.y"] == 0x7E0013
+    assert symbols["o.flags"] == 0x7E0015
+
+
+def test_forward_ref_nested_type_raises() -> None:
+    program = Program()
+    src = """
+        .struct Outer {
+            Inner i
+        }
+        .struct Inner {
+            word x
+        }
+    """
+    with pytest.raises(NodeError, match="Unknown struct field type 'Inner'"):
+        program.assemble_string_with_emitter(src, "memory.s", _NoopEmitter())
+
+
+def test_self_reference_nested_type_raises() -> None:
+    program = Program()
+    src = """
+        .struct Node {
+            Node next
+        }
+    """
+    with pytest.raises(NodeError, match="cannot reference its own type"):
+        program.assemble_string_with_emitter(src, "memory.s", _NoopEmitter())
+
+
+def test_cast_preserves_inner_expression() -> None:
+    src = (
+        _PT_DEF
+        + """
+        *=0x008000
+            lda.w ((0x2100 + 4) as Pt).y
+    """
+    )
+    data = _assemble_ips(src)
+    # base = 0x2104, Pt.y = 2, operand = 0x2106 → AD 06 21
+    assert b"\xad\x06\x21" in data
+
+
+def test_cast_chained_field_access() -> None:
+    src = (
+        _NESTED_DEFS
+        + """
+        *=0x008000
+            lda.l (0x7e0000 as Outer).pos.y
+    """
+    )
+    data = _assemble_ips(src)
+    # Outer.pos.y = 1 (pos offset) + 2 (Inner.y) = 3, base = 0x7E0000
+    # LDA.l $7E0003 = AF 03 00 7E
+    assert b"\xaf\x03\x00\x7e" in data
+
+
+def test_typed_bind_with_equal_rejected() -> None:
+    program = Program()
+    src = _PT_DEF + "p = 0x100 as Pt\n"
+    error, _ = program.parser.parse(src, "memory.s")
+    assert error is not None
+    assert "requires `:=`" in str(error)
+
+
+def test_typed_bind_chain_through_intermediate_constant() -> None:
+    """A typed bind can resolve `_p` defined by a prior `:=` constant."""
+    program = _resolve(
+        _PT_DEF
+        + """
+        _STRUCT_BASE_ADDR := 0x7e8000
+        _p := _STRUCT_BASE_ADDR + 3 * Pt.__size
+        p := (_p as Pt)
+        """
+    )
+    symbols = _collect_symbols(program)
+    assert symbols["_STRUCT_BASE_ADDR"] == 0x7E8000
+    assert symbols["_p"] == 0x7E800C
+    assert symbols["p"] == 0x7E800C
+    assert symbols["p.x"] == 0x7E800C
+    assert symbols["p.y"] == 0x7E800E
+
+
+def test_typed_bind_with_inline_expression_inside_cast() -> None:
+    """Inner cast expression can be any compile-time expression."""
+    program = _resolve(
+        _PT_DEF
+        + """
+        _STRUCT_BASE_ADDR := 0x7e8000
+        p := ((_STRUCT_BASE_ADDR + 3 * Pt.__size) as Pt)
+        """
+    )
+    symbols = _collect_symbols(program)
+    assert symbols["p"] == 0x7E800C
+    assert symbols["p.x"] == 0x7E800C
+    assert symbols["p.y"] == 0x7E800E
+
+
+def test_formatter_round_trip_for_cast_and_typed_bind() -> None:
+    """Cast, typed bind, and dot-access survive a format-parse round trip."""
+    from a816.formatter import A816Formatter
+
+    src = (
+        ".struct Pt {\n"
+        "    word x\n"
+        "    word y\n"
+        "}\n"
+        "\n"
+        "*=0x008000\n"
+        "p := (0x7e0000 as Pt)\n"
+        "    lda.l p.y\n"
+        "    lda.w (0x2100 as Pt).y\n"
+    )
+    fmt = A816Formatter()
+    first = fmt.format_text(src)
+    second = fmt.format_text(first + "\n")
+    assert first == second
+    assert "p := (0x7e0000 as Pt)" in first
+    assert "(0x2100 as Pt).y" in first
+    assert "p.y" in first
+
+
+def test_field_access_without_cast_rejected() -> None:
+    program = Program()
+    src = """
+        *=0x008000
+            lda.w (0x2100).hp
+    """
+    error, _ = program.parser.parse(src, "memory.s")
+    assert error is not None
+    assert "Field access requires a typed cast" in str(error)


### PR DESCRIPTION
## Summary

Adds typed struct field access to a816 so the user no longer has to write `lda PTR + Struct.field` for every access.

Two forms, one mechanism:

- Inline cast: `lda.w (0x2100 as PPU).OAMADDR`
- Typed bind: `p := (0x7e0000 as OAM)` then `lda.l p.x`

Struct fields can now be other structs — `.struct Outer { Inner pos }` flattens to `Outer.pos.x`, `Outer.pos.y`, etc. Typed binds expand nested layouts too: `o := (addr as Outer)` registers `o.pos.x`, `o.pos.y`, ...

## Influences

- `as` keyword cast — Rust (`addr as *Player`), TypeScript, Kotlin, Swift.
- `:=` short declaration / typed bind — Go and Odin (a816 already had `:=` as an alternate assign; this leans on the same shape).
- `.field` access on typed value — asar (`struct player $7E0000 ... lda player.x`), wla-dx (`p1 INSTANCEOF player ... lda p1.x`), MASM `assume`.
- Eager-expand model (typed bind registers one flat symbol per field) — closest to wla-dx `INSTANCEOF`.

Survey of ca65, asar, wla-dx, NASM/MASM also informed what to skip for this PR: array indexing (`enemies[i].hp`) and `with`-block scoping stay as follow-ups.

## Highlights

- Scanner: postfix `.field` chain after `)` / `]`; multi-level dotted identifiers so `p.field.sub` lexes as one IDENTIFIER.
- Parser: `_parse_lparen_expression` handles `(inner [as T])[.field…]`; `:=` RHS also accepts bare `expr as T`.
- Codegen: nested struct layouts flatten into dotted offset symbols; typed binds eager-expand per-field instance symbols and record the type tag on the resolver.
- Cast inner can be any compile-time expression, including references to prior `:=` constants (`p := ((BASE + 3 * Pt.__size) as Pt)`).
- Fluff: three new lint rules — `S001` (unknown struct type in cast), `S003` (redundant cast on typed binding), `S004` (repeat the same cast — promote to `:=`).
- Docs: new section in `directives.md` covering both forms, nested fields, and the lint hooks.

## Test plan

- [ ] `hatch run tests:all` — pytest + ruff + mypy clean (922 passing)
- [ ] Round-trip a sample file through `a816-fluff format`
- [ ] Manual smoke: assemble a struct-heavy module and disassemble with `xdds` to verify operand bytes