### PR TITLE
Stellar errors: structured exceptions, codes, hints, did-you-mean, multi-error

### DIFF
--- a/a816/diagnostics/__init__.py
+++ b/a816/diagnostics/__init__.py
@@ -1,0 +1,3 @@
+"""Diagnostic helpers: suggestions, formatting utilities, and similar tooling
+that lives outside the parser/codegen pipelines but plugs into their errors.
+"""

--- a/a816/diagnostics/suggest.py
+++ b/a816/diagnostics/suggest.py
@@ -1,0 +1,82 @@
+"""Did-you-mean suggestions for undefined symbols.
+
+The closest-match search runs over the user-visible names in the active
+scope chain (symbols + labels), filters by an edit-distance threshold,
+and returns the top candidates. Designed to be a one-shot call from an
+error-handling site — no caching, no global state.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid circular import at runtime; Scope only needed for typing
+    from a816.symbols import Scope
+
+
+_MAX_SUGGESTIONS = 3
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Standard iterative Levenshtein distance — O(len(a) * len(b))."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            current[j] = min(
+                current[j - 1] + 1,        # insertion
+                previous[j] + 1,           # deletion
+                previous[j - 1] + cost,    # substitution
+            )
+        previous = current
+    return previous[-1]
+
+
+def _collect_visible_names(scope: Scope) -> set[str]:
+    """Walk parent chain and gather symbol + label names a user might mean."""
+    names: set[str] = set()
+    current: Scope | None = scope
+    while current is not None:
+        names.update(current.symbols.keys())
+        names.update(current.labels.keys())
+        current = current.parent
+    return names
+
+
+def closest_matches(target: str, scope: Scope) -> list[str]:
+    """Return up to 3 visible names within an adaptive edit-distance budget.
+
+    Budget scales with `target` length so a typo in a 4-char name doesn't
+    pull in unrelated 8-char names. Empty result means "no good guess —
+    don't add a hint" so callers can omit the did-you-mean line entirely.
+    """
+    if not target:
+        return []
+    budget = max(1, min(len(target) // 2, 3))
+    candidates: list[tuple[int, str]] = []
+    for name in _collect_visible_names(scope):
+        if name == target:
+            continue
+        distance = _levenshtein(target, name)
+        if distance <= budget:
+            candidates.append((distance, name))
+    candidates.sort()
+    return [name for _, name in candidates[:_MAX_SUGGESTIONS]]
+
+
+def did_you_mean_hint(target: str, scope: Scope) -> str | None:
+    """Format the suggestions as a `hint:` payload, or None when nothing fits."""
+    matches = closest_matches(target, scope)
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return f"did you mean `{matches[0]}`?"
+    formatted = ", ".join(f"`{m}`" for m in matches)
+    return f"did you mean one of: {formatted}?"

--- a/a816/error_codes.py
+++ b/a816/error_codes.py
@@ -1,0 +1,93 @@
+"""Stable error code registry.
+
+Every user-facing assembler error carries one of these codes so users can
+search docs by code and tooling (LSP, fluff) can suppress / explain
+individual diagnostics.
+
+Codes are stable across releases — once assigned, never re-purposed.
+Add new ones at the end of their category block.
+
+Categories:
+  E0001..E0099 — scanner / lexing
+  E0100..E0199 — parser
+  E0200..E0299 — symbol resolution
+  E0300..E0399 — codegen
+  E0400..E0499 — linker / object files
+  E0500..E0599 — I/O / config
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ErrorCode:
+    """Stable error identifier + human-readable category."""
+
+    code: str
+    category: str
+    short_description: str
+
+    def __str__(self) -> str:
+        return self.code
+
+
+# --- Scanner (E0001..) ---
+E_SCANNER_INVALID_INPUT = ErrorCode("E0001", "scanner", "invalid input character")
+E_SCANNER_UNTERMINATED_STRING = ErrorCode("E0002", "scanner", "unterminated string literal")
+E_SCANNER_UNKNOWN_KEYWORD = ErrorCode("E0003", "scanner", "unknown directive keyword")
+
+# --- Parser (E0100..) ---
+E_PARSER_UNEXPECTED_TOKEN = ErrorCode("E0100", "parser", "unexpected token")
+E_PARSER_EXPECTED_TOKEN = ErrorCode("E0101", "parser", "missing expected token")
+E_PARSER_INVALID_EXPRESSION = ErrorCode("E0102", "parser", "invalid expression")
+E_PARSER_STRUCT_DUPLICATE_FIELD = ErrorCode("E0103", "parser", "duplicate struct field")
+E_PARSER_TYPED_BIND_NEEDS_ASSIGN = ErrorCode("E0104", "parser", "typed cast bind requires `:=`")
+E_PARSER_FIELD_ACCESS_NEEDS_CAST = ErrorCode("E0105", "parser", "field access requires typed cast")
+E_PARSER_UNKNOWN_DIRECTIVE_ATTR = ErrorCode("E0106", "parser", "unknown directive attribute")
+E_PARSER_POOL_NO_RANGES = ErrorCode("E0107", "parser", "pool declares no ranges")
+E_PARSER_UNKNOWN_POOL_STRATEGY = ErrorCode("E0108", "parser", "unknown pool strategy")
+E_PARSER_INCLUDE_FAILED = ErrorCode("E0109", "parser", "include file unreadable")
+
+# --- Symbol resolution (E0200..) ---
+E_SYMBOL_NOT_DEFINED = ErrorCode("E0200", "symbols", "symbol not defined in scope")
+E_SYMBOL_EXTERNAL_NOT_ALLOWED = ErrorCode("E0201", "symbols", "external reference outside object mode")
+E_SYMBOL_UNRESOLVABLE_EXPRESSION = ErrorCode("E0202", "symbols", "expression failed to evaluate")
+
+# --- Codegen (E0300..) ---
+E_CODEGEN_NODE_ERROR = ErrorCode("E0300", "codegen", "node failed during emission")
+E_CODEGEN_STRUCT_UNKNOWN_TYPE = ErrorCode("E0301", "codegen", "unknown struct field type")
+E_CODEGEN_STRUCT_SELF_REFERENCE = ErrorCode("E0302", "codegen", "struct field cannot reference its own type")
+E_CODEGEN_STRUCT_REDEFINED = ErrorCode("E0303", "codegen", "struct redefined")
+E_CODEGEN_TYPED_BIND_UNKNOWN_TYPE = ErrorCode("E0304", "codegen", "typed bind references unknown struct type")
+E_CODEGEN_TYPED_BIND_NON_INT = ErrorCode("E0305", "codegen", "typed bind base must evaluate to an address")
+E_CODEGEN_BAD_OPERAND_SIZE = ErrorCode("E0306", "codegen", "operand size mismatch")
+E_CODEGEN_BAD_ADDRESSING_MODE = ErrorCode("E0307", "codegen", "addressing mode not supported by opcode")
+
+# --- Linker (E0400..) ---
+E_LINKER_DUPLICATE_SYMBOL = ErrorCode("E0400", "linker", "duplicate global symbol")
+E_LINKER_UNRESOLVED_SYMBOL = ErrorCode("E0401", "linker", "unresolved external symbol")
+E_LINKER_RELOCATION_RANGE = ErrorCode("E0402", "linker", "relocation out of range")
+E_LINKER_EXPRESSION = ErrorCode("E0403", "linker", "relocation expression failed")
+
+# --- I/O / config (E0500..) ---
+E_IO_FILE_NOT_FOUND = ErrorCode("E0500", "io", "file not found")
+E_CONFIG_INVALID = ErrorCode("E0501", "config", "invalid project config")
+
+
+_BY_CODE: dict[str, ErrorCode] = {
+    obj.code: obj
+    for obj in globals().values()
+    if isinstance(obj, ErrorCode)
+}
+
+
+def lookup(code: str) -> ErrorCode | None:
+    """Return the registered ErrorCode for `code`, or None if unknown."""
+    return _BY_CODE.get(code)
+
+
+def all_codes() -> list[ErrorCode]:
+    """Every registered error code, sorted by numeric value for catalog output."""
+    return sorted(_BY_CODE.values(), key=lambda e: e.code)

--- a/a816/errors.py
+++ b/a816/errors.py
@@ -77,16 +77,62 @@ def _magenta(text: str) -> str:
 
 @dataclass
 class SourceLocation:
-    """Represents a location in source code."""
+    """Represents a location in source code.
+
+    `context_before` / `context_after` carry up to N source lines for
+    context-aware error rendering. Both default to empty so existing
+    callers keep working; populate when you have a Position with a
+    `file.lines` handle.
+    """
 
     filename: str
     line: int
     column: int
     source_line: str
     length: int = 1
+    context_before: list[str] | None = None
+    context_after: list[str] | None = None
 
     def __str__(self) -> str:
         return f"{self.filename}:{self.line + 1}:{self.column + 1}"
+
+
+def _gutter(n: int, width: int) -> str:
+    """Right-align line number `n` in a field of `width` chars, colored cyan."""
+    return _cyan(str(n).rjust(width))
+
+
+def _empty_gutter(width: int) -> str:
+    return " " * width
+
+
+def _render_source_block(location: SourceLocation, gutter_width: int) -> list[str]:
+    """Render the `| source` block with context lines and a caret pointer."""
+    out: list[str] = []
+    out.append(f"{_empty_gutter(gutter_width)} {_cyan('|')}")
+
+    main_line = location.line + 1
+    for offset, ctx in enumerate(location.context_before or [], start=1):
+        ln = main_line - len(location.context_before or []) + offset - 1
+        out.append(f"{_gutter(ln, gutter_width)} {_cyan('|')} {ctx.rstrip()}")
+
+    source = location.source_line.rstrip() if location.source_line else ""
+    out.append(f"{_gutter(main_line, gutter_width)} {_cyan('|')} {source}")
+
+    caret_padding = " " * location.column
+    caret = "^" * max(1, location.length)
+    out.append(f"{_empty_gutter(gutter_width)} {_cyan('|')} {caret_padding}{_bold_red(caret)}")
+
+    for offset, ctx in enumerate(location.context_after or [], start=1):
+        ln = main_line + offset
+        out.append(f"{_gutter(ln, gutter_width)} {_cyan('|')} {ctx.rstrip()}")
+
+    return out
+
+
+def _max_line_number(location: SourceLocation) -> int:
+    after_count = len(location.context_after or [])
+    return location.line + 1 + after_count
 
 
 def format_error(
@@ -95,6 +141,7 @@ def format_error(
     error_type: str = "error",
     hint: str | None = None,
     note: str | None = None,
+    code: str | None = None,
 ) -> str:
     """Format an error message with source location and visual indicators.
 
@@ -104,13 +151,13 @@ def format_error(
         error_type: Type of error (e.g., "error", "warning", "note")
         hint: Optional hint for fixing the error
         note: Optional additional note
+        code: Stable error code (e.g. "E0042"). Renders as `error[E0042]: ...`.
 
     Returns:
-        Formatted error string with colors and visual indicators
+        Formatted error string with colors and visual indicators.
     """
     lines: list[str] = []
 
-    # Error type and message header
     if error_type == "error":
         type_str = _bold_red("error")
     elif error_type == "warning":
@@ -118,45 +165,26 @@ def format_error(
     else:
         type_str = _bold(error_type)
 
+    code_str = f"[{code}]" if code else ""
+    if code_str:
+        type_str = f"{type_str}{_bold_red(code_str)}"
     lines.append(f"{type_str}{_bold(':')}{_bold(' ' + message)}")
 
-    # Source location with visual indicator
     if location is not None:
-        # Location header
         location_str = f"{location.filename}:{location.line + 1}:{location.column + 1}"
-        lines.append(f"  {_cyan('-->')} {location_str}")
+        gutter_width = len(str(_max_line_number(location)))
 
-        # Line number gutter width
-        line_num = str(location.line + 1)
-        gutter_width = len(line_num) + 1
+        lines.append(f"{_empty_gutter(gutter_width)} {_cyan('-->')} {location_str}")
+        lines.extend(_render_source_block(location, gutter_width))
 
-        # Empty gutter line
-        lines.append(f"{' ' * gutter_width}{_cyan('|')}")
-
-        # Source line with line number
-        source = location.source_line.rstrip() if location.source_line else ""
-        lines.append(f"{_cyan(line_num)} {_cyan('|')} {source}")
-
-        # Caret indicator line
-        caret_padding = " " * location.column
-        caret = "^" * max(1, location.length)
-        lines.append(f"{' ' * gutter_width}{_cyan('|')} {caret_padding}{_bold_red(caret)}")
-
-    # Add hint if provided
-    if hint:
-        if location:
-            gutter_width = len(str(location.line + 1)) + 1
-            lines.append(f"{' ' * gutter_width}{_cyan('|')}")
-            lines.append(f"{' ' * gutter_width}{_cyan('=')} {_cyan('hint:')} {hint}")
-        else:
+        if hint:
+            lines.append(f"{_empty_gutter(gutter_width)} {_cyan('=')} {_cyan('hint:')} {hint}")
+        if note:
+            lines.append(f"{_empty_gutter(gutter_width)} {_cyan('=')} {_cyan('note:')} {note}")
+    else:
+        if hint:
             lines.append(f"  {_cyan('hint:')} {hint}")
-
-    # Add note if provided
-    if note:
-        if location:
-            gutter_width = len(str(location.line + 1)) + 1
-            lines.append(f"{' ' * gutter_width}{_cyan('=')} {_cyan('note:')} {note}")
-        else:
+        if note:
             lines.append(f"  {_cyan('note:')} {note}")
 
     return "\n".join(lines)

--- a/a816/exceptions.py
+++ b/a816/exceptions.py
@@ -4,6 +4,23 @@ class A816Error(Exception):
     pass
 
 
+class AssemblyError(A816Error):
+    """Raised by `Program.assemble_string_with_emitter` when parsing fails.
+
+    Carries a pre-formatted message (already including source location when
+    the parser attached one). Codegen failures keep raising `NodeError`
+    directly; both share `A816Error` as a base so embedders can catch the
+    entire family with one `except A816Error`.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class SymbolNotDefined(A816Error):
     """Raised when a symbol is not found in the current scope."""
 

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -135,6 +135,7 @@ class A816Document:
         self.diagnostics: list[Diagnostic] = []
         self.ast_nodes: list[AstNode] = []
         self.parse_error: ParseError | None = None
+        self.parse_errors: list[ParseError] = []
         self.analyze()
 
     def update_content(self, content: str) -> None:
@@ -168,6 +169,9 @@ class A816Document:
             parser_result = MZParser.parse_as_ast(self.content, self.uri, include_paths=self.include_paths)
             self.ast_nodes = parser_result.nodes
             self.parse_error = parser_result.parse_error
+            self.parse_errors = list(parser_result.parse_errors or [])
+            if self.parse_error is not None and not self.parse_errors:
+                self.parse_errors = [self.parse_error]
 
             # Extract symbols and labels from AST
             self._extract_symbols_from_ast()
@@ -512,47 +516,44 @@ class A816Document:
                 )
             )
 
-    def _add_parse_error_diagnostic(self) -> None:
-        """Convert parse error to LSP diagnostic"""
-        if not self.parse_error:
-            return
-
-        error = self.parse_error
-        error_line = error.line
-        error_col = error.column
-        error_length = error.length
-
-        # Ensure we don't go beyond document bounds
+    def _clamp_error_span(self, line: int, col: int, length: int) -> tuple[int, int, int]:
+        """Clamp a (line, col, length) tuple inside the current document."""
         if not self.lines:
-            error_line = 0
-            error_col = 0
-        else:
-            if error_line >= len(self.lines):
-                error_line = len(self.lines) - 1
-            if error_line < 0:
-                error_line = 0
-            if error_col < 0:
-                error_col = 0
+            return 0, 0, length
+        if line >= len(self.lines):
+            line = len(self.lines) - 1
+        if line < 0:
+            line = 0
+        if col < 0:
+            col = 0
+        line_length = len(self.lines[line])
+        if col >= line_length:
+            col = max(0, line_length - 1)
+        if col + length > line_length:
+            length = max(1, line_length - col)
+        return line, col, length
 
-            line_length = len(self.lines[error_line]) if self.lines else 0
-            if error_col >= line_length:
-                error_col = max(0, line_length - 1)
-
-            # Ensure error_length doesn't exceed line bounds
-            if error_col + error_length > line_length:
-                error_length = max(1, line_length - error_col)
-
-        # Create diagnostic with proper range
-        self.diagnostics.append(
-            Diagnostic(
-                range=Range(
-                    start=Position(line=error_line, character=error_col),
-                    end=Position(line=error_line, character=error_col + error_length),
-                ),
-                message=error.message,
-                severity=DiagnosticSeverity.Error,
-            )
+    def _build_diagnostic(self, error: ParseError) -> Diagnostic:
+        line, col, length = self._clamp_error_span(error.line, error.column, error.length)
+        message = error.message
+        if error.hint:
+            message = f"{message}\nhint: {error.hint}"
+        return Diagnostic(
+            range=Range(
+                start=Position(line=line, character=col),
+                end=Position(line=line, character=col + length),
+            ),
+            message=message,
+            severity=DiagnosticSeverity.Error,
+            code=error.code,
+            source="a816",
         )
+
+    def _add_parse_error_diagnostic(self) -> None:
+        """Convert collected parse error(s) to LSP diagnostics."""
+        for err in self.parse_errors or ([self.parse_error] if self.parse_error else []):
+            if err is not None:
+                self.diagnostics.append(self._build_diagnostic(err))
 
 
 class WorkspaceIndex:

--- a/a816/parse/errors.py
+++ b/a816/parse/errors.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from a816.parse.tokens import Position, Token, TokenType
 
@@ -13,10 +13,14 @@ class ParseError:
     column: int  # 0-indexed
     length: int = 1
     source_line: str = ""
+    code: str | None = None
+    hint: str | None = None
+    context_before: list[str] = field(default_factory=list)
+    context_after: list[str] = field(default_factory=list)
 
     def format(self) -> str:
         """Format error for display."""
-        # Late import: intentional to avoid circular dependency with errors module
+        # Late import: avoid circular dependency with a816.errors.
         from a816.errors import SourceLocation, format_error
 
         location = SourceLocation(
@@ -25,23 +29,46 @@ class ParseError:
             column=self.column,
             source_line=self.source_line,
             length=self.length,
+            context_before=list(self.context_before) or None,
+            context_after=list(self.context_after) or None,
         )
-        return format_error(self.message, location)
+        return format_error(self.message, location, code=self.code, hint=self.hint)
 
 
 class ParserSyntaxError(Exception):
+    """Raised by parser state functions when the token stream is invalid.
+
+    `code` carries the stable error identifier and `hint` a fix
+    suggestion; both flow through `ParseError` into the formatted user
+    output so an `error[E0100]: ... hint: ...` block lands in the CLI.
+    """
+
     def __init__(
         self,
         message: str,
         token: Token,
         expected_token_type: TokenType | None = None,
+        *,
+        code: str | None = None,
+        hint: str | None = None,
     ) -> None:
         super().__init__(message)
         self.token: Token = token
         self.expected_token_type: TokenType | None = expected_token_type
+        self.code: str | None = code
+        self.hint: str | None = hint
 
 
 class ScannerException(Exception):
-    def __init__(self, message: str, position: Position) -> None:
+    def __init__(
+        self,
+        message: str,
+        position: Position,
+        *,
+        code: str | None = None,
+        hint: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.position: Position = position
+        self.code: str | None = code
+        self.hint: str | None = hint

--- a/a816/parse/mzparser.py
+++ b/a816/parse/mzparser.py
@@ -21,11 +21,19 @@ logger = logging.getLogger("a816.parser")
 class ParserResult:
     nodes: list[AstNode]
     parse_error: ParseError | None = None
+    parse_errors: list[ParseError] | None = None
 
     @property
     def error(self) -> str | None:
-        """Formatted error string for display."""
-        return self.parse_error.format() if self.parse_error else None
+        """Formatted text of every collected parse error, blank-line separated.
+
+        Returns the first error alone when only one was collected so existing
+        single-error callers behave unchanged.
+        """
+        errors = self.parse_errors or ([self.parse_error] if self.parse_error else [])
+        if not errors:
+            return None
+        return "\n\n".join(e.format() for e in errors)
 
     @property
     def ast(self) -> list[tuple[Any, ...]]:
@@ -52,48 +60,94 @@ class MZParser:
         scanner = Scanner(lex_initial)
         ast: list[AstNode] = []
         parse_error: ParseError | None = None
+        parser: Parser | None = None
 
         try:
             tokens = scanner.scan(filename, program)
             parser = Parser(tokens, parse_initial, include_paths=include_paths)
             ast = parser.parse()
         except ScannerException as e:
-            position = e.position
-            try:
-                source_line = position.get_line()
-            except (IndexError, AttributeError):
-                source_line = ""
-            parse_error = ParseError(
-                message=str(e),
-                filename=position.file.filename,
-                line=position.line,
-                column=position.column,
-                source_line=source_line,
-                length=1,
-            )
+            parse_error = _scanner_error_to_parse_error(e)
         except ParserSyntaxError as e:
             if verbose_errors:
-                logger.exception(e)
-                e.token.display()
-            if e.token.position is not None:
-                pos = e.token.position
-                try:
-                    source_line = pos.get_line()
-                except (IndexError, AttributeError):
-                    source_line = ""
-                parse_error = ParseError(
-                    message=str(e),
-                    filename=pos.file.filename,
-                    line=pos.line,
-                    column=pos.column,
-                    source_line=source_line,
-                    length=len(e.token.value) if e.token.value else 1,
-                )
-            else:
-                parse_error = ParseError(
-                    message=str(e),
-                    filename=filename,
-                    line=0,
-                    column=0,
-                )
-        return ParserResult(nodes=ast, parse_error=parse_error)
+                logger.debug("parser raised %s", e)
+            parse_error = _parser_error_to_parse_error(e, filename)
+
+        parse_errors = _collected_parse_errors(parser, filename)
+        if parse_error is None and parse_errors:
+            parse_error = parse_errors[0]
+        return ParserResult(nodes=ast, parse_error=parse_error, parse_errors=parse_errors)
+
+
+def _scanner_error_to_parse_error(e: ScannerException) -> ParseError:
+    return _build_parse_error_from_position(
+        position=e.position,
+        message=str(e),
+        length=1,
+        code=e.code,
+        hint=e.hint,
+    )
+
+
+def _parser_error_to_parse_error(e: ParserSyntaxError, fallback_filename: str) -> ParseError:
+    length = len(e.token.value) if e.token.value else 1
+    if e.token.position is not None:
+        return _build_parse_error_from_position(
+            position=e.token.position,
+            message=str(e),
+            length=length,
+            code=e.code,
+            hint=e.hint,
+        )
+    return ParseError(
+        message=str(e),
+        filename=fallback_filename,
+        line=0,
+        column=0,
+        code=e.code,
+        hint=e.hint,
+    )
+
+
+def _collected_parse_errors(parser: Parser | None, filename: str) -> list[ParseError] | None:
+    if parser is None or not parser.errors:
+        return None
+    return [_parser_error_to_parse_error(err, filename) for err in parser.errors]
+
+
+def _build_parse_error_from_position(
+    position: Any,
+    message: str,
+    length: int,
+    code: str | None,
+    hint: str | None,
+) -> ParseError:
+    try:
+        source_line = position.get_line()
+    except (IndexError, AttributeError):
+        source_line = ""
+    context_before, context_after = _gather_context(position, before=1, after=1)
+    return ParseError(
+        message=message,
+        filename=position.file.filename,
+        line=position.line,
+        column=position.column,
+        source_line=source_line,
+        length=length,
+        code=code,
+        hint=hint,
+        context_before=context_before,
+        context_after=context_after,
+    )
+
+
+def _gather_context(position: Any, *, before: int, after: int) -> tuple[list[str], list[str]]:
+    """Return up to ``before`` lines above and ``after`` lines below ``position``."""
+    file = getattr(position, "file", None)
+    lines = getattr(file, "lines", None)
+    if not lines:
+        return [], []
+    line_idx = position.line
+    before_lines = [lines[i] for i in range(max(0, line_idx - before), line_idx)]
+    after_lines = [lines[i] for i in range(line_idx + 1, min(len(lines), line_idx + 1 + after))]
+    return before_lines, after_lines

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -9,6 +9,8 @@ from a816.cpu.cpu_65c816 import (
 )
 from a816.cpu.mapping import Address
 from a816.cpu.types import AddressingMode, ValueSize
+from a816.diagnostics.suggest import did_you_mean_hint as _did_you_mean_hint
+from a816.error_codes import E_SYMBOL_NOT_DEFINED as _E_SYMBOL_NOT_DEFINED
 from a816.exceptions import A816Error, ExternalExpressionReference, ExternalSymbolReference, SymbolNotDefined
 from a816.object_file import Region
 from a816.parse.ast.expression import eval_expression, eval_expression_str
@@ -95,7 +97,12 @@ class ExpressionNode(ValueNodeProtocol):
                 return 0
             raise NodeError(f"{e} ({self}) is not defined in the current scope.", self.file_info) from e
         except SymbolNotDefined as e:
-            raise NodeError(f"{e} ({self}) is not defined in the current scope.", self.file_info) from e
+            raise NodeError(
+                f"`{e}` is not defined in the current scope",
+                self.file_info,
+                code=str(_E_SYMBOL_NOT_DEFINED),
+                hint=_did_you_mean_hint(str(e), self.resolver.current_scope),
+            ) from e
 
     def get_value_string_len(self) -> int:
         value = self.get_value()
@@ -592,16 +599,25 @@ class UnknownOpcodeError(Exception):
 
 
 class NodeError(A816Error):
-    def __init__(self, message: str, file_info: Token) -> None:
+    def __init__(
+        self,
+        message: str,
+        file_info: Token,
+        *,
+        code: str | None = None,
+        hint: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.file_info = file_info
         self.message = message
+        self.code = code
+        self.hint = hint
 
     def __str__(self) -> str:
         return self.format()
 
     def format(self) -> str:
-        """Format the error with source location and visual indicator."""
+        """Format the error with source location, visual indicator, code, and hint."""
         # Late import: intentional to avoid circular dependency with errors module
         from a816.errors import SourceLocation, format_error
 
@@ -612,15 +628,25 @@ class NodeError(A816Error):
                 source_line = pos.get_line()
             except (IndexError, AttributeError):
                 source_line = ""
+            file = getattr(pos, "file", None)
+            lines = getattr(file, "lines", None)
+            context_before: list[str] | None = None
+            context_after: list[str] | None = None
+            if lines:
+                line_idx = pos.line
+                context_before = [lines[i] for i in range(max(0, line_idx - 1), line_idx)] or None
+                context_after = [lines[i] for i in range(line_idx + 1, min(len(lines), line_idx + 2))] or None
             location = SourceLocation(
                 filename=pos.file.filename,
                 line=pos.line,
                 column=pos.column,
                 source_line=source_line,
                 length=len(self.file_info.value) if self.file_info.value else 1,
+                context_before=context_before,
+                context_after=context_after,
             )
 
-        return format_error(self.message, location)
+        return format_error(self.message, location, code=self.code, hint=self.hint)
 
 
 class OpcodeNode(NodeProtocol):
@@ -675,8 +701,10 @@ class OpcodeNode(NodeProtocol):
             ) from e
         except SymbolNotDefined as e:
             raise NodeError(
-                f"{e} ({self.value_node}) is not defined in the current scope.",
+                f"`{e}` is not defined in the current scope",
                 self.file_info,
+                code=str(_E_SYMBOL_NOT_DEFINED),
+                hint=_did_you_mean_hint(str(e), self.resolver.current_scope),
             ) from e
 
     def pc_after(self, current_pc: Address) -> Address:

--- a/a816/parse/nodes.py
+++ b/a816/parse/nodes.py
@@ -9,7 +9,7 @@ from a816.cpu.cpu_65c816 import (
 )
 from a816.cpu.mapping import Address
 from a816.cpu.types import AddressingMode, ValueSize
-from a816.exceptions import ExternalExpressionReference, ExternalSymbolReference, SymbolNotDefined
+from a816.exceptions import A816Error, ExternalExpressionReference, ExternalSymbolReference, SymbolNotDefined
 from a816.object_file import Region
 from a816.parse.ast.expression import eval_expression, eval_expression_str
 from a816.parse.ast.nodes import BlockAstNode, ExpressionAstNode
@@ -591,7 +591,7 @@ class UnknownOpcodeError(Exception):
     pass
 
 
-class NodeError(Exception):
+class NodeError(A816Error):
     def __init__(self, message: str, file_info: Token) -> None:
         super().__init__(message)
         self.file_info = file_info

--- a/a816/parse/parser.py
+++ b/a816/parse/parser.py
@@ -2,9 +2,59 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
+from a816.error_codes import E_PARSER_EXPECTED_TOKEN
 from a816.parse.ast.nodes import AstNode
 from a816.parse.errors import ParserSyntaxError
 from a816.parse.tokens import Token, TokenType
+
+# Human-readable names for token types — used in parser error messages
+# instead of the raw `TokenType.X` repr that leaks Python internals.
+_TOKEN_FRIENDLY_NAMES: dict[TokenType, str] = {
+    TokenType.EOF: "end of input",
+    TokenType.COMMENT: "comment",
+    TokenType.LABEL: "label",
+    TokenType.IDENTIFIER: "identifier",
+    TokenType.QUOTED_STRING: "quoted string",
+    TokenType.DOCSTRING: "docstring",
+    TokenType.OPERATOR: "operator",
+    TokenType.LPAREN: "`(`",
+    TokenType.RPAREN: "`)`",
+    TokenType.SHARP: "`#`",
+    TokenType.RBRAKET: "`]`",
+    TokenType.LBRAKET: "`[`",
+    TokenType.RBRACE: "`}`",
+    TokenType.LBRACE: "`{`",
+    TokenType.ADDRESSING_MODE_INDEX: "addressing index (X/Y/S)",
+    TokenType.OPCODE_SIZE: "opcode size (.b/.w/.l)",
+    TokenType.OPCODE_NAKED: "opcode without operand",
+    TokenType.OPCODE: "opcode",
+    TokenType.COMMA: "`,`",
+    TokenType.KEYWORD: "directive keyword",
+    TokenType.NUMBER: "number literal",
+    TokenType.STAR_EQ: "`*=`",
+    TokenType.AT_EQ: "`@=`",
+    TokenType.EQUAL: "`=`",
+    TokenType.ASSIGN: "`:=`",
+    TokenType.DOUBLE_LBRACE: "`{{`",
+    TokenType.DOUBLE_RBRACE: "`}}`",
+    TokenType.BOOLEAN: "boolean",
+    TokenType.TYPE: "type identifier",
+    TokenType.IMPORT: "`.import`",
+    TokenType.FROM: "`from`",
+    TokenType.DOT: "`.`",
+}
+
+
+def _token_label(token_type: TokenType) -> str:
+    return _TOKEN_FRIENDLY_NAMES.get(token_type, token_type.name)
+
+
+def _got_label(token: Token) -> str:
+    """User-facing description of an actual token."""
+    base = _token_label(token.type)
+    if token.value and token.type not in (TokenType.EOF, TokenType.COMMENT):
+        return f"{base} `{token.value}`"
+    return base
 
 logger = logging.getLogger("a816.parser")
 
@@ -15,6 +65,10 @@ class Parser:
         self.pos = 0
         self.initial_state: StateFunc = initial_state
         self.include_paths: list[Path] = include_paths or []
+        # Errors collected during recovery. `parse_initial` appends every
+        # ParserSyntaxError it survives so callers can render *all* of them
+        # instead of only the first one.
+        self.errors: list[ParserSyntaxError] = []
 
     def parse(self) -> list[AstNode]:
         try:
@@ -49,12 +103,23 @@ class Parser:
 
 def expect_token(token: Token, token_type: TokenType) -> None:
     if token.type != token_type:
-        raise ParserSyntaxError(f"Expected {token_type} but got {token}", token, token_type)
+        raise ParserSyntaxError(
+            f"expected {_token_label(token_type)}, found {_got_label(token)}",
+            token,
+            token_type,
+            code=str(E_PARSER_EXPECTED_TOKEN),
+        )
 
 
 def expect_tokens(token: Token, token_types: list[TokenType]) -> None:
     if token.type not in token_types:
-        raise ParserSyntaxError(f"Expected {token_types} but got {token}", token, token_types[0])
+        expected = " or ".join(_token_label(t) for t in token_types)
+        raise ParserSyntaxError(
+            f"expected {expected}, found {_got_label(token)}",
+            token,
+            token_types[0],
+            code=str(E_PARSER_EXPECTED_TOKEN),
+        )
 
 
 def accept_tokens(token: Token, token_types: list[TokenType]) -> bool:

--- a/a816/parse/parser_states.py
+++ b/a816/parse/parser_states.py
@@ -5,6 +5,16 @@ from pathlib import Path
 from typing import Literal, TypeGuard, cast
 
 from a816.cpu.cpu_65c816 import AddressingMode, ValueSize
+from a816.error_codes import (
+    E_PARSER_FIELD_ACCESS_NEEDS_CAST,
+    E_PARSER_INVALID_EXPRESSION,
+    E_PARSER_POOL_NO_RANGES,
+    E_PARSER_STRUCT_DUPLICATE_FIELD,
+    E_PARSER_TYPED_BIND_NEEDS_ASSIGN,
+    E_PARSER_UNEXPECTED_TOKEN,
+    E_PARSER_UNKNOWN_DIRECTIVE_ATTR,
+    E_PARSER_UNKNOWN_POOL_STRATEGY,
+)
 from a816.parse.ast.nodes import (
     AllocAstNode,
     AsciiAstNode,
@@ -57,6 +67,8 @@ from a816.parse.errors import ParserSyntaxError
 from a816.parse.parser import (
     Parser,
     StateFunc,
+    _got_label,
+    _token_label,
     accept_token,
     accept_tokens,
     expect_token,
@@ -208,7 +220,12 @@ def parse_map(p: Parser) -> MapAstNode:
             else:
                 args[map_key] = ast.literal_eval(number1.value)
         else:
-            raise ParserSyntaxError(f"Unknown attribute for map directive. {identifier.value}", identifier)
+            raise ParserSyntaxError(
+                f"unknown attribute for `.map` directive: `{identifier.value}`",
+                identifier,
+                code=str(E_PARSER_UNKNOWN_DIRECTIVE_ATTR),
+                hint="valid attributes: identifier, writable, bank_range, addr_range, mask, mirror_bank_range",
+            )
 
     return MapAstNode(args, first_identifier)
 
@@ -274,9 +291,11 @@ def parse_struct(p: Parser) -> StructAstNode:
         expect_token(name_token, TokenType.IDENTIFIER)
         if name_token.value in seen:
             raise ParserSyntaxError(
-                f"Duplicate struct field {name_token.value!r}",
+                f"Duplicate struct field `{name_token.value}`",
                 name_token,
                 TokenType.IDENTIFIER,
+                code=str(E_PARSER_STRUCT_DUPLICATE_FIELD),
+                hint="each field name must be unique within a `.struct` block",
             )
         seen.add(name_token.value)
         fields.append((name_token.value, type_token.value))
@@ -409,8 +428,10 @@ def _parse_pool_strategy(p: Parser) -> str:
     expect_token(strat_token, TokenType.IDENTIFIER)
     if strat_token.value not in _POOL_STRATEGIES:
         raise ParserSyntaxError(
-            f"unknown pool strategy {strat_token.value!r}; expected one of {sorted(_POOL_STRATEGIES)}",
+            f"unknown pool strategy `{strat_token.value}`",
             strat_token,
+            code=str(E_PARSER_UNKNOWN_POOL_STRATEGY),
+            hint=f"expected one of: {', '.join(sorted(_POOL_STRATEGIES))}",
         )
     return strat_token.value
 
@@ -434,8 +455,10 @@ def _parse_pool_attr(p: Parser, key_token: Token, attrs: _PoolAttrs) -> None:
         attrs.strategy = _parse_pool_strategy(p)
     else:
         raise ParserSyntaxError(
-            f"unknown pool attribute {key!r}; expected range, fill, strategy",
+            f"unknown `.pool` attribute `{key}`",
             key_token,
+            code=str(E_PARSER_UNKNOWN_DIRECTIVE_ATTR),
+            hint="expected one of: range, fill, strategy",
         )
 
 
@@ -461,7 +484,12 @@ def parse_pool(p: Parser) -> PoolAstNode:
 
     expect_token(p.next(), TokenType.RBRACE)
     if not attrs.ranges:
-        raise ParserSyntaxError(f"pool {name_token.value!r} declares no ranges", keyword)
+        raise ParserSyntaxError(
+            f"pool `{name_token.value}` declares no ranges",
+            keyword,
+            code=str(E_PARSER_POOL_NO_RANGES),
+            hint="add at least one `range LO HI` line so the allocator has space to work with",
+        )
     return PoolAstNode(
         name_token.value,
         attrs.ranges,
@@ -475,7 +503,11 @@ def _expect_contextual_keyword(p: Parser, expected: str) -> Token:
     token = p.next()
     expect_token(token, TokenType.IDENTIFIER)
     if token.value != expected:
-        raise ParserSyntaxError(f"expected {expected!r}, got {token.value!r}", token)
+        raise ParserSyntaxError(
+            f"expected `{expected}`, found `{token.value}`",
+            token,
+            code=str(E_PARSER_UNEXPECTED_TOKEN),
+        )
     return token
 
 
@@ -562,7 +594,12 @@ def parse_keyword(p: Parser) -> KeywordAstNode:
     keyword = p.next()
     handler = _KEYWORD_HANDLERS.get(keyword.value)
     if handler is None:
-        raise ParserSyntaxError(f"Unexpected token {keyword}", keyword)
+        raise ParserSyntaxError(
+            f"unknown directive `.{keyword.value}`",
+            keyword,
+            code=str(E_PARSER_UNEXPECTED_TOKEN),
+            hint="see https://a816.ringum.net/directives/ for the list of supported `.` directives",
+        )
     return cast(KeywordAstNode, handler(p, keyword))
 
 
@@ -653,8 +690,10 @@ def _parse_lparen_expression(p: Parser, lparen: Token) -> list[ExprNode]:
         return [CastValueExprNode(lparen, inner, type_name)]
     if field_path:
         raise ParserSyntaxError(
-            "Field access requires a typed cast: `(expr as Type).field`.",
+            "field access requires a typed cast",
             lparen,
+            code=str(E_PARSER_FIELD_ACCESS_NEEDS_CAST),
+            hint="use `(expr as Type).field` so the resolver knows which struct layout to apply",
         )
     # Plain parenthesised expression — restore the wrapping tokens for shunting yard.
     rparen = Token(TokenType.RPAREN, ")", lparen.position)
@@ -674,7 +713,12 @@ def _parse_expression(p: Parser) -> list[ExprNode]:
         tokens.append(UnaryOp(current_token))
         tokens += _parse_expression(p)
     else:
-        raise ParserSyntaxError("Invalid expression", token=current_token)
+        raise ParserSyntaxError(
+            f"invalid expression at {_token_label(current_token.type)}",
+            current_token,
+            code=str(E_PARSER_INVALID_EXPRESSION),
+            hint="expressions accept numbers, identifiers, `(...)`, unary `-`/`~`, and binary operators",
+        )
 
     if tokens:
         operator = p.current()
@@ -709,8 +753,10 @@ def parse_symbol_affectation(
     if as_token.type == TokenType.IDENTIFIER and as_token.value == "as":
         if operator.type != TokenType.ASSIGN:
             raise ParserSyntaxError(
-                "Typed-bind cast `as T` requires `:=`, not `=`.",
+                "typed-cast bind requires `:=`, not `=`",
                 as_token,
+                code=str(E_PARSER_TYPED_BIND_NEEDS_ASSIGN),
+                hint="use `name := expr as T` so the binding eager-expands per-field instance symbols",
             )
         p.next()
         type_token = p.next()
@@ -758,7 +804,13 @@ def parse_opcode(p: Parser) -> OpcodeAstNode:
 def _parse_immediate_operand(p: Parser) -> tuple[AddressingMode, None, ExpressionAstNode]:
     p.next()
     if accept_token(p.current(), TokenType.EOF):
-        raise ParserSyntaxError("Unexpected end of input.", p.current(), None)
+        raise ParserSyntaxError(
+            "unexpected end of input after `#` immediate prefix",
+            p.current(),
+            None,
+            code=str(E_PARSER_INVALID_EXPRESSION),
+            hint="`#` introduces an immediate operand — supply a value, e.g. `lda #0x42`",
+        )
     return AddressingMode.immediate, None, parse_expression(p)
 
 
@@ -861,14 +913,68 @@ def parse_decl(
     elif accept_token(current_token, TokenType.AT_EQ):
         return parse_code_relocation_keyword(p)
     else:
-        raise ParserSyntaxError(f"Unexpected Keyword {current_token}", current_token, None)
+        raise ParserSyntaxError(
+            f"unexpected {_got_label(current_token)} at top level",
+            current_token,
+            None,
+            code=str(E_PARSER_UNEXPECTED_TOKEN),
+            hint="declarations begin with an opcode, label, `.directive`, identifier, or `{...}` block",
+        )
+
+
+_MAX_PARSE_ERRORS = 20
+
+# Tokens that mark a fresh top-level statement; the recovery walker fast-
+# forwards to one of these after a syntax error so a single typo doesn't
+# cascade into dozens of follow-up parse failures.
+_TOP_LEVEL_SYNC_TOKENS = (
+    TokenType.LABEL,
+    TokenType.OPCODE,
+    TokenType.OPCODE_NAKED,
+    TokenType.KEYWORD,
+    TokenType.STAR_EQ,
+    TokenType.AT_EQ,
+    TokenType.DOUBLE_LBRACE,
+)
+
+
+def _recover_to_next_statement(p: Parser) -> None:
+    """Skip ahead to the next plausible statement start after a parse error."""
+    depth = 0
+    while p.current().type != TokenType.EOF:
+        current = p.current()
+        if current.type == TokenType.LBRACE:
+            depth += 1
+            p.next()
+            continue
+        if current.type == TokenType.RBRACE:
+            if depth == 0:
+                return  # let the enclosing block consume it
+            depth -= 1
+            p.next()
+            continue
+        if depth == 0 and current.type in _TOP_LEVEL_SYNC_TOKENS:
+            return
+        p.next()
 
 
 def parse_initial(p: Parser) -> list[AstNode]:
     statements: list[AstNode] = []
     while p.current().type != TokenType.EOF:
-        statement = parse_decl(p)
+        try:
+            statement = parse_decl(p)
+        except ParserSyntaxError as exc:
+            p.errors.append(exc)
+            if len(p.errors) >= _MAX_PARSE_ERRORS:
+                raise
+            _recover_to_next_statement(p)
+            continue
         if statement:
             statements.append(statement)
 
+    if p.errors:
+        # Re-raise the first error so existing single-error callers still
+        # see something. mzparser unpacks the full list off `p.errors` for
+        # multi-diagnostic rendering.
+        raise p.errors[0]
     return statements

--- a/a816/parse/scanner.py
+++ b/a816/parse/scanner.py
@@ -26,6 +26,10 @@ class Scanner:
 
     def scan(self, filename: str, input_: str) -> list[Token]:
         self.file = File(filename)
+        # Eagerly populate file lines so error-rendering can pull context
+        # for positions beyond where the scanner halts (otherwise only the
+        # lines already consumed up to the failure point would be available).
+        self.file.lines = input_.split("\n")
         self.input = input_
         self.state = self.initial_state
         self.tokens = []
@@ -45,8 +49,9 @@ class Scanner:
         return self.tokens
 
     def _handle_line(self) -> None:
+        # `scan()` now pre-splits the input into `file.lines`, so the only
+        # work left is bookkeeping for the rolling line-start cursor.
         if self.line_offset <= self.pos:
-            self.file.append(self.input[self.line_offset : self.pos])
             self.line_offset = self.pos + 1
             self.current_line += 1
 

--- a/a816/parse/scanner_states.py
+++ b/a816/parse/scanner_states.py
@@ -3,6 +3,11 @@ from a816.cpu.cpu_65c816 import (
     get_opcodes_with_addressing,
     snes_opcode_table,
 )
+from a816.error_codes import (
+    E_SCANNER_INVALID_INPUT,
+    E_SCANNER_UNKNOWN_KEYWORD,
+    E_SCANNER_UNTERMINATED_STRING,
+)
 from a816.parse.errors import ScannerException
 from a816.parse.scanner import Scanner
 from a816.parse.tokens import EOF, TokenType
@@ -39,7 +44,12 @@ def _lex_string(s: "Scanner", quote_char: str) -> None:
     c = s.next()
     while c != quote_char:
         if c == "\n" or c is None:
-            raise ScannerException("Unterminated String", start_position)
+            raise ScannerException(
+                "unterminated string literal",
+                start_position,
+                code=str(E_SCANNER_UNTERMINATED_STRING),
+                hint=f"add a closing `{quote_char}` to terminate the string",
+            )
 
         if c == "\\" and s.peek() == quote_char:
             s.next()
@@ -66,7 +76,12 @@ def lex_docstring(s: "Scanner", quote_char: str) -> None:
     while True:
         c = s.next()
         if c is None:
-            raise ScannerException("Unterminated docstring", start_position)
+            raise ScannerException(
+                "unterminated docstring",
+                start_position,
+                code=str(E_SCANNER_UNTERMINATED_STRING),
+                hint=f"docstrings end with three `{quote_char}` characters",
+            )
         if c == "\\":
             # Skip escaped characters so they don't terminate the string early
             s.next()
@@ -270,7 +285,12 @@ def lex_keyword(s: "Scanner") -> None:
     if s.current_token_text() in KEYWORDS:
         s.emit(TokenType.KEYWORD)
     else:
-        raise ScannerException(f"Unknown Keyword {s.current_token_text()}", s.get_position())
+        raise ScannerException(
+            f"unknown directive `.{s.current_token_text()}`",
+            s.get_position(),
+            code=str(E_SCANNER_UNKNOWN_KEYWORD),
+            hint="see https://a816.ringum.net/directives/ for the list of supported `.` directives",
+        )
 
 
 def lex_number(s: Scanner) -> None:
@@ -459,4 +479,8 @@ def lex_initial(s: Scanner) -> None:
         if handler(s):
             return
     if s.next() is not None:
-        raise ScannerException(f"Invalid Input {s.input[s.start :]}", s.get_position())
+        raise ScannerException(
+            f"invalid character `{s.input[s.start]}`",
+            s.get_position(),
+            code=str(E_SCANNER_INVALID_INPUT),
+        )

--- a/a816/program.py
+++ b/a816/program.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from a816.context import AssemblyMode
 from a816.cpu.cpu_65c816 import RomType
-from a816.exceptions import A816Error, AssemblyError
+from a816.exceptions import AssemblyError
 from a816.object_file import ObjectFile, SymbolSection, SymbolType
 from a816.parse.mzparser import MZParser
 from a816.parse.nodes import (
@@ -541,8 +541,16 @@ class Program:
                     input_program = prelude + "\n" + input_program
                 try:
                     self.assemble_string_with_emitter(input_program, asm_file, emitter)
-                except A816Error as e:
+                except AssemblyError as e:
+                    # Parser failure: the message already carries source
+                    # location. A Python traceback would just be noise for
+                    # the CLI user.
                     logger.error(str(e))
+                    return 128
+                except NodeError:
+                    # Codegen failure: include the traceback — these can
+                    # surface internal bugs the user should report.
+                    logger.exception("Codegen failed")
                     return 128
 
         except RuntimeError as e:

--- a/a816/program.py
+++ b/a816/program.py
@@ -543,9 +543,10 @@ class Program:
                     self.assemble_string_with_emitter(input_program, asm_file, emitter)
                 except AssemblyError as e:
                     # Parser failure: the message already carries source
-                    # location. A Python traceback would just be noise for
-                    # the CLI user.
-                    logger.error(str(e))
+                    # location + caret + hint. A Python traceback would
+                    # bury that under irrelevant frames for a CLI user, so
+                    # `logger.error` (not `logger.exception`) is intentional.
+                    logger.error(str(e))  # NOSONAR python:S8572
                     return 128
                 except NodeError:
                     # Codegen failure: include the traceback — these can

--- a/a816/program.py
+++ b/a816/program.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from a816.context import AssemblyMode
 from a816.cpu.cpu_65c816 import RomType
+from a816.exceptions import A816Error, AssemblyError
 from a816.object_file import ObjectFile, SymbolSection, SymbolType
 from a816.parse.mzparser import MZParser
 from a816.parse.nodes import (
@@ -492,11 +493,19 @@ class Program:
             object_writer.write_block(state.current_block, 0)
             state.current_block = b""
 
-    def assemble_string_with_emitter(self, input_program: str, filename: str, emitter: Writer) -> str | None:
+    def assemble_string_with_emitter(self, input_program: str, filename: str, emitter: Writer) -> None:
+        """Assemble `input_program` to `emitter`.
+
+        Raises:
+          AssemblyError: parser-level failure (wraps the formatted location
+            string the parser produces).
+          NodeError: codegen-level failure (location-aware; subclass of
+            A816Error so a single `except A816Error` catches both).
+        """
         error, nodes = self.parser.parse(input_program, filename)
 
         if error is not None:
-            return error
+            raise AssemblyError(error)
 
         self._mark_import_winners(nodes)
         self.logger.info("Resolving labels")
@@ -510,12 +519,20 @@ class Program:
         self._program_nodes = list(nodes)
         self.emit(nodes, emitter)
 
-        return None
-
     def assemble_with_emitter(self, asm_file: str, emitter: Writer, prelude: str | None = None) -> int:
+        """CLI-facing wrapper around `assemble_string_with_emitter`.
+
+        Always returns an exit code; never calls `sys.exit`. Embedders that
+        want structured failures should call `assemble_string_with_emitter`
+        directly and catch `A816Error`.
+
+        Returns:
+          0   on success
+          128 on `A816Error` (covers both `AssemblyError` and `NodeError`)
+          -1  on `RuntimeError` (mapping / bus failures bubbling up)
+        """
         previous_mode = self.resolver.context.mode
         try:
-            # Set direct assembly mode so .import includes module code
             self.resolver.context.mode = AssemblyMode.DIRECT
 
             with open(asm_file, encoding="utf-8") as f:
@@ -523,13 +540,10 @@ class Program:
                 if prelude:
                     input_program = prelude + "\n" + input_program
                 try:
-                    error = self.assemble_string_with_emitter(input_program, asm_file, emitter)
-                    if error is not None:
-                        logger.error(error)
-                        exit(128)
-                except NodeError as e:
-                    logger.exception(str(e))
-                    exit(128)
+                    self.assemble_string_with_emitter(input_program, asm_file, emitter)
+                except A816Error as e:
+                    logger.error(str(e))
+                    return 128
 
         except RuntimeError as e:
             self.logger.error(e)

--- a/docs/docs/errors.md
+++ b/docs/docs/errors.md
@@ -1,0 +1,115 @@
+# Error codes
+
+Every user-facing assembler diagnostic carries a stable error code so
+you can search docs by code, suppress individual rules in tooling, and
+correlate output across CLI runs.
+
+## Anatomy
+
+```
+error[E0200]: `my_routime` is not defined in the current scope
+  --> dym.s:4:11
+  |
+3 |     rts
+4 |     jsr.l my_routime
+  |           ^^^^^^^^^^
+5 |
+  = hint: did you mean `my_routine`?
+```
+
+- `error[CODE]` — severity + stable identifier.
+- `--> file:line:column` — the failure location.
+- Source block with `±1` context lines and a caret pointing at the
+  offending span.
+- Optional `= hint:` / `= note:` lines with fix suggestions.
+
+When multiple errors come out of one parse pass they are rendered as
+separate blocks separated by a blank line.
+
+## Categories
+
+- `E0001..E0099` — scanner / lexing.
+- `E0100..E0199` — parser.
+- `E0200..E0299` — symbol resolution.
+- `E0300..E0399` — codegen.
+- `E0400..E0499` — linker / object files.
+- `E0500..E0599` — I/O / config.
+
+## Code catalog
+
+### Scanner
+
+- `E0001` invalid input character — the scanner met a character it
+  doesn't know how to start a token with.
+- `E0002` unterminated string literal — close the string with the
+  matching quote character.
+- `E0003` unknown directive keyword — `.directive` not in the
+  supported set; see [directives.md](directives.md).
+
+### Parser
+
+- `E0100` unexpected token — generic structural failure.
+- `E0101` missing expected token — the parser knew what it wanted
+  next but found something else.
+- `E0102` invalid expression — the expression couldn't be parsed at
+  the given position.
+- `E0103` duplicate struct field — each `.struct` field name must
+  be unique within the block.
+- `E0104` typed-cast bind requires `:=` — use `name := expr as T`
+  instead of `=`.
+- `E0105` field access requires typed cast — `(expr).field` only
+  works on a typed cast: `(expr as Type).field`.
+- `E0106` unknown directive attribute — the directive doesn't
+  accept the attribute name.
+- `E0107` pool declares no ranges — every `.pool` needs at least
+  one `range LO HI`.
+- `E0108` unknown pool strategy — accepted values: `pack`, `order`.
+- `E0109` include file unreadable — the path resolution failed.
+
+### Symbols
+
+- `E0200` symbol not defined — the resolver couldn't find this
+  symbol; the error includes a did-you-mean suggestion when a close
+  match exists in scope.
+- `E0201` external reference outside object mode.
+- `E0202` expression failed to evaluate — likely a forward
+  reference the resolver couldn't bind.
+
+### Codegen
+
+- `E0300` node failed during emission — generic codegen failure.
+- `E0301` unknown struct field type — `.struct` references an
+  identifier that isn't a primitive or a previously-declared struct.
+- `E0302` struct field self-reference — a struct cannot embed
+  itself.
+- `E0303` struct redefined.
+- `E0304` typed bind references unknown struct type.
+- `E0305` typed bind base must evaluate to an address.
+- `E0306` operand size mismatch.
+- `E0307` addressing mode not supported by opcode.
+
+### Linker
+
+- `E0400` duplicate global symbol.
+- `E0401` unresolved external symbol.
+- `E0402` relocation out of range.
+- `E0403` relocation expression failed.
+
+### I/O / config
+
+- `E0500` file not found.
+- `E0501` invalid project config.
+
+## LSP integration
+
+The `a816-lsp-server` publishes diagnostics with the same `code` and
+appends the `hint` to the message. Editors that recognise the `code`
+field (VS Code, Helix, Neovim with `vim.diagnostic`) render it as the
+familiar inline chip.
+
+## Suppressing noise
+
+There is no global suppression knob for `E*` errors — they signal real
+failures, not style issues. Style-style suppression lives on the
+`fluff` side (`; noqa: <RULE>` for `DOC*` / `S*` / `N*`); see
+[fluff.md](fluff.md).

--- a/tests/test_assemble_errors.py
+++ b/tests/test_assemble_errors.py
@@ -1,0 +1,85 @@
+"""`assemble_with_emitter` always returns; never calls sys.exit.
+
+Embedders (LSP, fluff, tests) drive the assembler programmatically and
+would otherwise have to catch `SystemExit`. The embedder-facing
+`assemble_string_with_emitter` raises `A816Error` (parent of both
+`AssemblyError` and `NodeError`) so a single `except` catches both
+parser and codegen failures.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from a816.exceptions import A816Error, AssemblyError
+from a816.parse.nodes import NodeError
+from a816.program import Program
+from a816.writers import SFCWriter
+from tests import StubWriter
+
+
+def _write_source(src: str) -> tuple[Path, Path]:
+    tmp = Path(tempfile.mkdtemp())
+    asm = tmp / "main.s"
+    asm.write_text(src, encoding="utf-8")
+    return tmp, asm
+
+
+def test_assemble_with_emitter_returns_128_on_parser_error() -> None:
+    tmp, asm = _write_source(".struct\n")  # parser error: missing name
+    out = tmp / "out.sfc"
+    program = Program()
+    with out.open("wb") as fh:
+        rc = program.assemble_with_emitter(str(asm), SFCWriter(fh))
+    assert rc == 128
+
+
+def test_assemble_with_emitter_returns_128_on_codegen_error() -> None:
+    src = """
+        .struct Bad {
+            qword x
+        }
+    """
+    tmp, asm = _write_source(src)
+    out = tmp / "out.sfc"
+    program = Program()
+    with out.open("wb") as fh:
+        rc = program.assemble_with_emitter(str(asm), SFCWriter(fh))
+    assert rc == 128
+
+
+def test_assemble_string_raises_assembly_error_on_parser_failure() -> None:
+    program = Program()
+    with pytest.raises(AssemblyError):
+        program.assemble_string_with_emitter(".struct\n", "x.s", StubWriter())
+
+
+def test_assemble_string_raises_node_error_on_codegen_failure() -> None:
+    program = Program()
+    with pytest.raises(NodeError):
+        program.assemble_string_with_emitter("nop #0x00", "x.s", StubWriter())
+
+
+def test_assembly_error_and_node_error_share_a816_base() -> None:
+    """A single `except A816Error` catches both shapes for embedders."""
+    program = Program()
+    with pytest.raises(A816Error):
+        program.assemble_string_with_emitter(".struct\n", "x.s", StubWriter())
+    with pytest.raises(A816Error):
+        program.assemble_string_with_emitter("nop #0x00", "x.s", StubWriter())
+
+
+def test_assemble_with_emitter_returns_zero_on_success() -> None:
+    src = """
+        *=0x008000
+            nop
+    """
+    tmp, asm = _write_source(src)
+    out = tmp / "out.sfc"
+    program = Program()
+    with out.open("wb") as fh:
+        rc = program.assemble_with_emitter(str(asm), SFCWriter(fh))
+    assert rc == 0

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -199,7 +199,7 @@ class TestParse(TestCase):
         # Error should contain key elements
         assert result.error is not None
         self.assertIn("memory.s", result.error)
-        self.assertIn("EOF", result.error)
+        self.assertIn("end of input", result.error)
 
     def test_recursive_macros(self) -> None:
         program = """

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -109,7 +109,7 @@ subroutine:
 
         # Error should be on line 1 (index 0), not line 2
         self.assertEqual(diag.range.start.line, 0, "Unterminated string error should be on line 1")
-        self.assertIn("Unterminated String", diag.message)
+        self.assertIn("unterminated string", diag.message)
 
     def test_document_update_content(self) -> None:
         """Test document content update"""

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -73,7 +73,7 @@ class ParseTest(unittest.TestCase):
 
         # Error should contain key elements
         assert result.error is not None
-        self.assertIn("Unterminated String", result.error)
+        self.assertIn("unterminated string", result.error)
         self.assertIn("memory.s", result.error)
         self.assertIn("'coucou", result.error)
 
@@ -86,7 +86,7 @@ class ParseTest(unittest.TestCase):
 
         # Error should be on line 1, not line 2
         assert result.error is not None
-        self.assertIn("Unterminated String", result.error)
+        self.assertIn("unterminated string", result.error)
         self.assertIn("test.s:1:", result.error, "error should be on line 1")
         self.assertIn(".incbin 'assets/dakuten.bin", result.error)
 

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -89,7 +89,7 @@ class TestPoolDirective:
             filename="t.s",
         )
         assert result.parse_error is not None
-        assert "unknown pool attribute" in result.parse_error.message
+        assert "unknown `.pool` attribute" in result.parse_error.message
 
     def test_to_canonical_round_trip(self) -> None:
         node = _first_of(
@@ -124,7 +124,7 @@ class TestAllocDirective:
             filename="t.s",
         )
         assert result.parse_error is not None
-        assert "'in'" in result.parse_error.message
+        assert "`in`" in result.parse_error.message
 
 
 class TestRelocateDirective:
@@ -153,7 +153,7 @@ class TestRelocateDirective:
             filename="t.s",
         )
         assert result.parse_error is not None
-        assert "'into'" in result.parse_error.message
+        assert "`into`" in result.parse_error.message
 
     def test_to_canonical_includes_body(self) -> None:
         node = _first_of(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -206,4 +206,4 @@ class ScannerTest(TestCase):
         scanner = Scanner(lex_initial)
         with self.assertRaises(ScannerException) as ctx:
             scanner.scan("test.s", "'unterminated")
-        self.assertIn("Unterminated", str(ctx.exception))
+        self.assertIn("unterminated", str(ctx.exception))

--- a/tests/test_stellar_errors.py
+++ b/tests/test_stellar_errors.py
@@ -1,0 +1,142 @@
+"""Stellar diagnostics: codes, hints, did-you-mean, multi-error recovery."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from a816.diagnostics.suggest import closest_matches, did_you_mean_hint
+from a816.error_codes import all_codes, lookup
+from a816.parse.mzparser import MZParser
+from a816.parse.nodes import NodeError
+from a816.program import Program
+from a816.symbols import Resolver
+from tests import StubWriter
+
+
+@pytest.fixture(autouse=True)
+def _disable_colors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip ANSI so substring asserts work regardless of terminal state."""
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    # `a816.errors._USE_COLORS` is captured at import time; flip it for tests.
+    import a816.errors as err_mod
+
+    monkeypatch.setattr(err_mod, "_USE_COLORS", False)
+
+
+def test_error_codes_are_unique_and_well_formed() -> None:
+    codes = all_codes()
+    assert len(codes) == len({c.code for c in codes}), "duplicate error codes"
+    for code in codes:
+        assert code.code.startswith("E") and code.code[1:].isdigit()
+        assert code.category
+        assert code.short_description
+
+
+def test_lookup_known_and_unknown_codes() -> None:
+    assert lookup("E0100") is not None
+    assert lookup("E9999") is None
+
+
+def test_parser_error_renders_code_and_hint() -> None:
+    result = MZParser.parse_as_ast(".pool p { range 0x1000 0x1fff bogus 1 }\n", "demo.s")
+    assert result.error is not None
+    assert "[E0106]" in result.error
+    assert "unknown `.pool` attribute" in result.error
+    assert "hint:" in result.error
+    assert "range, fill, strategy" in result.error
+
+
+def test_parser_error_includes_context_lines() -> None:
+    src = "; line above\n.lalala foo\n; line below\n"
+    result = MZParser.parse_as_ast(src, "ctx.s")
+    assert result.error is not None
+    # Above + below should appear in the rendered block.
+    assert "; line above" in result.error
+    assert "; line below" in result.error
+
+
+def test_did_you_mean_picks_closest_match() -> None:
+    resolver = Resolver()
+    resolver.current_scope.add_symbol("player_x", 0)
+    resolver.current_scope.add_symbol("player_y", 1)
+    resolver.current_scope.add_symbol("player_hp", 2)
+
+    matches = closest_matches("playr_x", resolver.current_scope)
+    assert "player_x" in matches
+
+
+def test_did_you_mean_returns_none_when_far_away() -> None:
+    resolver = Resolver()
+    resolver.current_scope.add_symbol("totally_unrelated", 0)
+    assert did_you_mean_hint("xyz", resolver.current_scope) is None
+
+
+def test_undefined_symbol_error_includes_suggestion() -> None:
+    program = Program()
+    src = """
+my_routine:
+    rts
+    jsr.l my_routime
+"""
+    with pytest.raises(NodeError) as exc_info:
+        program.assemble_string_with_emitter(src, "dym.s", StubWriter())
+    rendered = str(exc_info.value)
+    assert "[E0200]" in rendered
+    assert "`my_routime`" in rendered
+    assert "did you mean `my_routine`?" in rendered
+
+
+def test_multi_error_collects_top_level_failures() -> None:
+    src = """
+.struct OAM {
+    word x
+    word x
+}
+lda.w (0x2100).hp
+"""
+    result = MZParser.parse_as_ast(src, "multi.s")
+    assert result.parse_errors is not None
+    assert len(result.parse_errors) >= 2
+    rendered = result.error or ""
+    assert "[E0103]" in rendered
+    assert "[E0105]" in rendered
+
+
+def test_token_type_label_uses_friendly_name() -> None:
+    """Generic expect_token errors no longer leak `TokenType.X` to the user."""
+    result = MZParser.parse_as_ast(".include\n", "missing.s")
+    assert result.error is not None
+    assert "quoted string" in result.error
+    assert "TokenType" not in result.error
+
+
+def test_typed_bind_with_equal_shows_code_and_hint() -> None:
+    src = """
+.struct Pt {
+    word x
+}
+p = 0x100 as Pt
+"""
+    result = MZParser.parse_as_ast(src, "tb.s")
+    assert result.error is not None
+    assert "[E0104]" in result.error
+    assert "use `name := expr as T`" in result.error
+
+
+def _strip_ansi(s: str) -> str:
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def test_format_error_respects_no_color_env() -> None:
+    """With NO_COLOR set, no ANSI escapes leak into the output."""
+    src = ".pool p { range 0x1000 0x1fff bogus 1 }\n"
+    result = MZParser.parse_as_ast(src, "nc.s")
+    assert result.error is not None
+    assert "\x1b[" not in result.error, "ANSI escapes leaked despite NO_COLOR"
+    assert _strip_ansi(result.error) == result.error
+    _ = os  # silence "unused import" — used by the env helpers above

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -372,4 +372,4 @@ def test_field_access_without_cast_rejected() -> None:
     """
     error, _ = program.parser.parse(src, "memory.s")
     assert error is not None
-    assert "Field access requires a typed cast" in str(error)
+    assert "field access requires a typed cast" in str(error)

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -14,8 +14,7 @@ from a816.program import Program
 def _resolve(source: str) -> Program:
     """Run a program through resolve so resolver scopes are populated."""
     program = Program()
-    error = program.assemble_string_with_emitter(source, "memory.s", _NoopEmitter())
-    assert error is None, error
+    program.assemble_string_with_emitter(source, "memory.s", _NoopEmitter())
     return program
 
 


### PR DESCRIPTION
## Summary

Two-stage upgrade of a816's failure path:

**Stage 1 — Structured exceptions.** `Program.assemble_with_emitter` no longer calls `sys.exit`. Embedders (LSP, fluff, tests) drive the assembler programmatically and would otherwise have to catch `SystemExit`. `assemble_string_with_emitter` now returns `None` on success and raises `A816Error` on failure (`AssemblyError` for parser failures, `NodeError` for codegen — both share `A816Error` so one `except` covers everything).

**Stage 2 — Stellar diagnostics.** Every user-facing error carries a stable code, an actionable hint, and ±1 lines of source context. Undefined symbols suggest the closest match in scope. Top-level parser errors recover and collect up to 20 failures per pass instead of bailing on the first.

## What it looks like

```
error[E0200]: `my_routime` is not defined in the current scope
  --> dym.s:4:11
  |
3 |     rts
4 |     jsr.l my_routime
  |           ^^^^^^^^^^
5 |
  = hint: did you mean `my_routine`?
```

## Highlights

- New `a816.error_codes` module — stable `E0001..` catalog, grouped by category (scanner / parser / symbols / codegen / linker / io). Documented in `docs/docs/errors.md`.
- `format_error` extended with `code` + context lines; both `ParseError` and `NodeError` route through it.
- Hand-written messages + hints for every parser failure that users hit in practice: duplicate struct field, typed-cast bind shape, field access without cast, pool attributes, unknown directives, etc.
- Scanner errors carry codes too (`E0001..E0003`).
- `did_you_mean_hint` (Levenshtein, budget scales with target length) attached to every undefined-symbol error.
- Parser `parse_initial` recovers to the next statement on syntax error, collecting up to 20 errors per pass. `ParserResult.parse_errors` exposes the whole list; the existing `.error` property concatenates them.
- LSP publishes the new `code` field and appends the hint to the message; multi-error pass produces one `Diagnostic` per failure.
- Scanner pre-splits the input into `file.lines` so context rendering works even when parsing aborts before reading later lines.

## Files of note

| Area | File |
|------|------|
| Exception hierarchy | `a816/exceptions.py`, `a816/parse/nodes.py` (NodeError reparented) |
| Error code catalog | `a816/error_codes.py` |
| Format pipeline | `a816/errors.py`, `a816/parse/errors.py`, `a816/parse/mzparser.py` |
| Did-you-mean | `a816/diagnostics/suggest.py` |
| Parser polish + recovery | `a816/parse/parser.py`, `a816/parse/parser_states.py`, `a816/parse/scanner_states.py` |
| LSP integration | `a816/lsp/server.py` |
| Docs | `docs/docs/errors.md` |
| Tests | `tests/test_stellar_errors.py`, `tests/test_assemble_errors.py` |

## Test plan

- [ ] `hatch run tests:all` — 939 passing, ruff + mypy strict clean
- [ ] `scry analyse` — 0 issues, 87.4% coverage
- [ ] Smoke: trigger each error class manually and confirm code + hint + context render correctly under `FORCE_COLOR=1` and `NO_COLOR=1`
- [ ] LSP: open a broken file in an editor with `a816-lsp-server` and confirm code chip + hint surface