### PR TITLE
Dedup transitive `.import` and tolerate idempotent struct redef

### DIFF
--- a/a816/diagnostics/suggest.py
+++ b/a816/diagnostics/suggest.py
@@ -31,9 +31,9 @@ def _levenshtein(a: str, b: str) -> int:
         for j, cb in enumerate(b, start=1):
             cost = 0 if ca == cb else 1
             current[j] = min(
-                current[j - 1] + 1,        # insertion
-                previous[j] + 1,           # deletion
-                previous[j - 1] + cost,    # substitution
+                current[j - 1] + 1,  # insertion
+                previous[j] + 1,  # deletion
+                previous[j - 1] + cost,  # substitution
             )
         previous = current
     return previous[-1]

--- a/a816/error_codes.py
+++ b/a816/error_codes.py
@@ -76,11 +76,7 @@ E_IO_FILE_NOT_FOUND = ErrorCode("E0500", "io", "file not found")
 E_CONFIG_INVALID = ErrorCode("E0501", "config", "invalid project config")
 
 
-_BY_CODE: dict[str, ErrorCode] = {
-    obj.code: obj
-    for obj in globals().values()
-    if isinstance(obj, ErrorCode)
-}
+_BY_CODE: dict[str, ErrorCode] = {obj.code: obj for obj in globals().values() if isinstance(obj, ErrorCode)}
 
 
 def lookup(code: str) -> ErrorCode | None:

--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -911,10 +911,7 @@ def _is_typed_bind_owner(
     """True when `cast` is the very RHS of `parent`'s typed bind — counting that
     line against the user would penalize the `:=` we want them to write.
     """
-    return (
-        isinstance(parent, AssignAstNode)
-        and instances.get(parent.symbol) == cast.type_name
-    )
+    return isinstance(parent, AssignAstNode) and instances.get(parent.symbol) == cast.type_name
 
 
 class UnknownStructTypeCast(Rule):

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -4,8 +4,6 @@ from typing import Any, Protocol, cast
 
 from a816.cpu.types import AddressingMode
 from a816.exceptions import SymbolNotDefined
-
-logger = logging.getLogger("a816.codegen")
 from a816.parse.ast.expression import eval_expression
 from a816.parse.ast.nodes import (
     AllocAstNode,
@@ -76,6 +74,8 @@ from a816.parse.tokens import Token, TokenType
 from a816.pool import Pool, PoolRange, Strategy
 from a816.protocols import NodeProtocol
 from a816.symbols import Resolver
+
+logger = logging.getLogger("a816.codegen")
 
 MacroDefinitions = dict[str, Any]
 GenNodes = list[NodeProtocol]

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -1,8 +1,11 @@
+import logging
 from pathlib import Path
 from typing import Any, Protocol, cast
 
 from a816.cpu.types import AddressingMode
 from a816.exceptions import SymbolNotDefined
+
+logger = logging.getLogger("a816.codegen")
 from a816.parse.ast.expression import eval_expression
 from a816.parse.ast.nodes import (
     AllocAstNode,
@@ -188,10 +191,21 @@ def generate_struct(
 ) -> GenNodes:
     """Push a NamedScope, register one offset symbol per (possibly nested)
     field, register the layout for later typed-bind expansion, then export.
+
+    Idempotent: a second `.struct` with the same name + identical field list
+    is treated as a no-op so a header `.include`d twice (or imported via
+    different cascades) doesn't fail. A mismatched redef still raises so
+    real layout bugs surface.
     """
-    if node.name in resolver.struct_layouts:
-        raise NodeError(f"Struct {node.name!r} redefined.", file_info)
     entries, total_size = _layout_struct_fields(node, resolver, file_info)
+    existing = resolver.struct_layouts.get(node.name)
+    if existing is not None:
+        if existing == entries and resolver.struct_sizes.get(node.name) == total_size:
+            return []
+        raise NodeError(
+            f"Struct {node.name!r} redefined with a different field layout.",
+            file_info,
+        )
     resolver.struct_layouts[node.name] = entries
     resolver.struct_sizes[node.name] = total_size
 
@@ -493,13 +507,27 @@ def _import_from_source(
         return None
 
 
+def _canonical(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
 def generate_import(
     node: ImportAstNode,
     resolver: Resolver,
     macro_definitions: MacroDefinitions,
     file_info: Token,
 ) -> GenNodes:
-    """Resolve an .import to ExternNode (object/parse mode) or LinkedModuleNode/inline source (direct)."""
+    """Resolve an .import to ExternNode (object/parse mode) or LinkedModuleNode/inline source (direct).
+
+    Source-inlined imports (direct mode, no `.o` available) are deduped by
+    canonical path so transitive cascades don't re-execute the same module
+    and trip idempotency checks (struct redef, etc). Object-mode imports
+    keep the existing winner/loser mechanism intact — `LinkedModuleNode`
+    already handles duplicates by marking earlier placements as losers.
+    """
     module_name = node.module_name
     direct_mode = resolver.context.is_direct_mode and not resolver.context.is_object_mode
     search_paths = _import_search_paths(resolver, file_info)
@@ -512,6 +540,12 @@ def generate_import(
 
     src_path = _resolve_module_path(module_name, ".s", search_paths)
     if src_path:
+        if direct_mode:
+            key = _canonical(src_path)
+            if key in resolver.imported_module_paths:
+                logger.info("`.import %r` deduped — already loaded from %s", module_name, key)
+                return []
+            resolver.imported_module_paths.add(key)
         nodes = _import_from_source(src_path, resolver, macro_definitions, direct_mode)
         if nodes is not None:
             return nodes

--- a/a816/parse/parser.py
+++ b/a816/parse/parser.py
@@ -56,6 +56,7 @@ def _got_label(token: Token) -> str:
         return f"{base} `{token.value}`"
     return base
 
+
 logger = logging.getLogger("a816.parser")
 
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -102,13 +102,22 @@ class Scope:
         return self.labels.items()
 
     def add_symbol(self, symbol: str, value: int | BlockAstNode | str) -> None:
+        """Bind `symbol` to `value`. Silent on idempotent re-bind.
+
+        Multi-pass resolution re-runs `add_symbol` for the same `(name,
+        value)` pair on every pass; warning every time produces thousands
+        of lines of noise on real projects. Only re-binds that actually
+        change the value indicate a real collision worth surfacing.
+        """
         if isinstance(value, BlockAstNode):
-            if symbol in self.code_symbols:
+            existing_code = self.code_symbols.get(symbol)
+            if existing_code is not None and existing_code is not value:
                 logger.warning(f"Symbol already defined ({symbol})")
             self.code_symbols[symbol] = value
         else:
-            if symbol in self.symbols:
-                logger.warning(f"Symbol already defined ({symbol})")
+            existing = self.symbols.get(symbol)
+            if existing is not None and existing != value:
+                logger.warning(f"Symbol already defined ({symbol}): {existing!r} -> {value!r}")
             self.symbols[symbol] = value
 
     def add_external_symbol(self, symbol: str) -> None:
@@ -262,6 +271,11 @@ class Resolver:
         # Typed-bind registry: instance name → struct type name. Lets the
         # linter spot redundant casts and field access on non-typed bindings.
         self.typed_instances: dict[str, str] = {}
+        # Canonical paths of modules already loaded by `.import`. Used to
+        # short-circuit transitive re-imports (file A and file B both import
+        # "inc"; without dedup the third party that imports both re-parses
+        # "inc" twice and trips struct-redef and similar idempotency checks).
+        self.imported_module_paths: set[str] = set()
         self.set_position(pc)
 
     def allocate_pools(self) -> None:

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -16,6 +16,7 @@ nav = [
     { "Modules" = "modules.md" },
     { "Freespace pools" = "freespace-pools.md" },
     { "Fluff (lint + format)" = "fluff.md" },
+    { "Error codes" = "errors.md" },
     { "LSP" = "lsp.md" },
     { "Editor setup" = "editor-setup.md" },
     { "Object file format (.o)" = "object-file-format.md" },

--- a/tests/test_import_dedup.py
+++ b/tests/test_import_dedup.py
@@ -1,0 +1,137 @@
+"""`.import` cascade dedup + struct idempotent redefinition.
+
+Two regressions from the typed-struct PR (#60):
+
+1. Transitive `.import` cascades re-parse the same `.s` source through
+   different paths, blowing up on the struct-redef check.
+2. `Symbol already defined` warnings fire on every multi-pass re-bind
+   even when the value is unchanged — kilometres of log noise on real
+   projects.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from a816.parse.nodes import NodeError
+from a816.program import Program
+
+
+def _write(root: Path, name: str, body: str) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_transitive_import_does_not_redefine_struct() -> None:
+    """A common `inc` imported through two paths must load exactly once."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "inc.s",
+            """
+.struct Point {
+    word x
+    word y
+}
+""",
+        )
+        _write(root, "a.s", '.import "inc"\n')
+        _write(root, "b.s", '.import "inc"\n')
+        main = _write(
+            root,
+            "main.s",
+            """
+.import "a"
+.import "b"
+*=0x008000
+    nop
+""",
+        )
+
+        program = Program()
+        program.add_module_path(root)
+        program.add_include_path(root)
+        out = root / "out.ips"
+        assert program.assemble_as_patch(str(main), out) == 0
+
+
+def test_struct_identical_redef_is_silent() -> None:
+    """Two identical `.struct` declarations (via include) are a no-op."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(
+            root,
+            "main.s",
+            """
+.struct Point {
+    word x
+    word y
+}
+.struct Point {
+    word x
+    word y
+}
+*=0x008000
+    nop
+""",
+        )
+        program = Program()
+        out = root / "out.ips"
+        # No NodeError raised, no failure to assemble.
+        assert program.assemble_as_patch(str(root / "main.s"), out) == 0
+
+
+def test_struct_mismatched_redef_still_raises() -> None:
+    """A redefinition that *changes* the layout is still an error."""
+    program = Program()
+    src = """
+.struct Point {
+    word x
+    word y
+}
+.struct Point {
+    word x
+    word z
+}
+"""
+    with pytest.raises(NodeError, match="different field layout"):
+        program.assemble_string_with_emitter(src, "memory.s", _NoopEmitter())
+
+
+def test_symbol_rebind_with_same_value_is_silent(caplog: pytest.LogCaptureFixture) -> None:
+    program = Program()
+    src = """
+foo = 0x42
+foo = 0x42
+"""
+    with caplog.at_level(logging.WARNING):
+        program.assemble_string_with_emitter(src, "memory.s", _NoopEmitter())
+    assert not any("already defined" in rec.message for rec in caplog.records), "no-op rebind must not log"
+
+
+def test_symbol_rebind_with_different_value_warns(caplog: pytest.LogCaptureFixture) -> None:
+    program = Program()
+    src = """
+foo = 0x42
+foo = 0x43
+"""
+    with caplog.at_level(logging.WARNING):
+        program.assemble_string_with_emitter(src, "memory.s", _NoopEmitter())
+    assert any("already defined" in rec.message for rec in caplog.records), "value-changing rebind should warn"
+
+
+class _NoopEmitter:
+    def begin(self) -> None: ...
+
+    def end(self) -> None: ...
+
+    def write_block_header(self, *_: object, **__: object) -> None: ...
+
+    def write_block(self, *_: object, **__: object) -> None: ...


### PR DESCRIPTION
## Summary

Two regressions surfaced by the typed-struct PR (#60) once a fresh `build/obj` exposed transitive `.import` cascades.

1. **`.import` cascades** — when `A` imports `inc` and `B` imports `inc`, importing both `A` and `B` re-parsed `inc.s` and tripped the new struct-redef check. Now source-inlined imports dedup by canonical resolved path: the second visit is a no-op. Object-mode imports keep the existing winner/loser mechanism intact.
2. **`Symbol already defined` warning flood** — multi-pass resolution re-binds the same `(name, value)` pair on every pass, producing thousands of identical warnings on real projects. Now silent when the value is unchanged; only value-changing rebinds warn (with the old/new values for context).

Belt-and-suspenders: `.struct` declarations are now idempotent — a second `.struct Foo { ... }` with the same field list is a no-op. Mismatched redef still raises (now with a clearer message). Catches double-include cases without needing an explicit guard directive.

## Behavior changes

| Before | After |
|---|---|
| `.import "inc"` reached via cascades re-parsed `inc.s` and re-ran codegen | Dedupes by canonical path; logged at INFO level |
| `foo = 0x42` followed by `foo = 0x42` warned every multi-pass cycle | Silent — only warns when the value differs |
| Two identical `.struct Foo {...}` blocks raised `Struct 'Foo' redefined.` | No-op; mismatched layout raises `Struct 'Foo' redefined with a different field layout.` |

## Out of scope

- A fluff lint rule that flags when a module is reached through multiple cascades — needs cross-file graph analysis and belongs in a fluff PR.
- A `.once` / `#pragma once` directive for `.include` — current `.include` semantics stay textual; users can rely on the new struct-idempotency instead.

## Test plan

- [ ] \`hatch run tests:all\` — 944 passing, ruff + mypy strict clean
- [ ] \`scry analyse\` — 0 issues, 88% coverage
- [ ] Targeted regression test (\`tests/test_import_dedup.py\`) covers the diamond import case and the silent/warning split on rebinds