### PR TITLE
Auto-size opcodes from typed-instance field accesses + width warnings

### DIFF
--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any, Protocol, cast
 
-from a816.cpu.types import AddressingMode
+from a816.cpu.types import AddressingMode, ValueSize
 from a816.exceptions import SymbolNotDefined
 from a816.parse.ast.expression import eval_expression
 from a816.parse.ast.nodes import (
@@ -147,21 +147,26 @@ def _layout_struct_fields(
     node: StructAstNode,
     resolver: Resolver,
     file_info: Token,
-) -> tuple[list[tuple[str, int]], int]:
-    """Compute flat (field_path, offset) entries + total size for a struct.
+) -> tuple[list[tuple[str, int, int]], int]:
+    """Compute flat (field_path, offset, width) entries + total size for a struct.
 
-    Primitive fields contribute one entry. Fields whose declared type is a
-    previously registered struct contribute the field's own offset plus the
-    nested struct's flattened entries with the field name prefixed
-    (`pos`, `pos.x`, `pos.y`). Forward refs and self-references raise a
-    NodeError because the layout would be unresolvable.
+    Primitive fields contribute one entry whose ``width`` is the declared
+    type's byte size (1/2/3/4). Nested struct fields contribute the parent
+    field at its own offset with width equal to the nested struct's
+    ``__size`` plus every flattened sub-entry inheriting its declared
+    primitive width. Forward refs and self-references raise a NodeError.
+
+    Width is what `lda p.field` needs to pick the right operand encoding
+    later; without it auto-sizing would have to fall back to the string
+    heuristic that already misfires for typed accesses.
     """
-    entries: list[tuple[str, int]] = []
+    entries: list[tuple[str, int, int]] = []
     offset = 0
     for field_name, field_type in node.fields:
-        if field_type in _STRUCT_FIELD_SIZES:
-            entries.append((field_name, offset))
-            offset += _STRUCT_FIELD_SIZES[field_type]
+        primitive_size = _STRUCT_FIELD_SIZES.get(field_type)
+        if primitive_size is not None:
+            entries.append((field_name, offset, primitive_size))
+            offset += primitive_size
             continue
         if field_type == node.name:
             raise NodeError(
@@ -176,9 +181,9 @@ def _layout_struct_fields(
             )
         nested_layout = resolver.struct_layouts[field_type]
         nested_size = resolver.struct_sizes[field_type]
-        entries.append((field_name, offset))
-        for sub_path, sub_offset in nested_layout:
-            entries.append((f"{field_name}.{sub_path}", offset + sub_offset))
+        entries.append((field_name, offset, nested_size))
+        for sub_path, sub_offset, sub_width in nested_layout:
+            entries.append((f"{field_name}.{sub_path}", offset + sub_offset, sub_width))
         offset += nested_size
     return entries, offset
 
@@ -212,7 +217,7 @@ def generate_struct(
     resolver.append_named_scope(node.name)
     resolver.use_next_scope()
     code: list[NodeProtocol] = [ScopeNode(resolver)]
-    for field_path, offset in entries:
+    for field_path, offset, _width in entries:
         resolver.current_scope.add_symbol(field_path, offset)
     resolver.current_scope.add_symbol("__size", total_size)
     code.append(PopScopeNode(resolver))
@@ -240,6 +245,109 @@ def generate_map(
     return []
 
 
+def _infer_typed_operand_size(
+    operand: ExpressionAstNode | None, resolver: Resolver
+) -> str | None:
+    """Pick `b`/`w`/`l` from a typed-instance field reference, else None.
+
+    Covers the `lda p.field` shorthand: when the operand is exactly one
+    dotted-identifier term and its base name is in
+    ``resolver.typed_instance_addr_width``, use that addressing width.
+    Compound expressions (`p.x + 1`, casts) fall back to the existing
+    string-heuristic so this is purely additive.
+    """
+    if operand is None or not isinstance(operand, ExpressionAstNode):
+        return None
+    if len(operand.tokens) != 1:
+        return None
+    token = operand.tokens[0]
+    if not isinstance(token, Term) or token.token.type != TokenType.IDENTIFIER:
+        return None
+    name = token.token.value
+    if "." not in name:
+        return None
+    instance = name.split(".", 1)[0]
+    return resolver.typed_instance_addr_width.get(instance)
+
+
+_A_OPCODES = {"lda", "sta", "adc", "sbc", "and", "ora", "eor", "cmp", "bit"}
+_X_Y_OPCODES = {"ldx", "stx", "ldy", "sty", "cpx", "cpy"}
+
+
+def _opcode_register_width(opcode: str, resolver: Resolver) -> int | None:
+    """Bytes-per-register for the current REP/SEP state, or None for opcodes
+    that don't touch A/X/Y."""
+    if opcode in _A_OPCODES:
+        return resolver.a_size // 8
+    if opcode in _X_Y_OPCODES:
+        return resolver.i_size // 8
+    return None
+
+
+def _typed_field_lookup(
+    operand: ExpressionAstNode | None, resolver: Resolver
+) -> tuple[str, str, int] | None:
+    """Resolve a `p.field` operand to `(instance, full_name, field_width)`."""
+    if operand is None or not isinstance(operand, ExpressionAstNode) or len(operand.tokens) != 1:
+        return None
+    token = operand.tokens[0]
+    if not isinstance(token, Term) or token.token.type != TokenType.IDENTIFIER:
+        return None
+    name = token.token.value
+    if "." not in name:
+        return None
+    instance, field_path = name.split(".", 1)
+    type_name = resolver.typed_instances.get(instance)
+    if type_name is None:
+        return None
+    layout = resolver.struct_layouts.get(type_name) or []
+    field_entry = next(((p, o, w) for (p, o, w) in layout if p == field_path), None)
+    if field_entry is None:
+        return None
+    _path, _offset, field_width = field_entry
+    return instance, name, field_width
+
+
+def _register_label(opcode: str) -> str:
+    return "A" if opcode in _A_OPCODES else "X/Y"
+
+
+def _rep_sep_payload(register_label: str, field_width: int) -> int:
+    if register_label == "A":
+        return 0x20
+    return 0x10 if field_width == 2 else 0
+
+
+def _maybe_warn_register_width_mismatch(node: OpcodeAstNode, resolver: Resolver) -> None:
+    """Warn when a typed-field access asks for a width the current
+    `a8`/`a16`/`i8`/`i16` state can't satisfy in one transfer.
+
+    Only fires for the canonical `lda p.field` / `sta p.field` /
+    `ldx p.field` shorthand; richer expressions silently skip.
+    """
+    lookup = _typed_field_lookup(node.operand, resolver)
+    if lookup is None:
+        return
+    _instance, full_name, field_width = lookup
+    register_width = _opcode_register_width(node.opcode, resolver)
+    if register_width is None or field_width == register_width:
+        return
+    register_label = _register_label(node.opcode)
+    rep_sep = "rep" if field_width > register_width else "sep"
+    logger.warning(
+        "field width (%d byte%s) does not match %s register size (%d bits) on `%s %s`; "
+        "consider `%s #$%02x` first",
+        field_width,
+        "" if field_width == 1 else "s",
+        register_label,
+        register_width * 8,
+        node.opcode,
+        full_name,
+        rep_sep,
+        _rep_sep_payload(register_label, field_width),
+    )
+
+
 def generate_opcode(
     node: OpcodeAstNode,
     resolver: Resolver,
@@ -253,6 +361,11 @@ def generate_opcode(
         raise NodeError("Opcode operand must not be code", file_info)
 
     size = node.value_size
+    if size is None:
+        inferred = _infer_typed_operand_size(node.operand, resolver)
+        if inferred in ("b", "w", "l"):
+            size = cast(ValueSize, inferred)
+    _maybe_warn_register_width_mismatch(node, resolver)
     opcode = node.opcode
     mode = node.addressing_mode
     if mode == AddressingMode.none:
@@ -722,10 +835,25 @@ def _try_typed_bind(node: AssignAstNode, resolver: Resolver, file_info: Token) -
             file_info,
         )
     resolver.current_scope.add_symbol(node.symbol, base)
-    for field_path, offset in resolver.struct_layouts[type_name]:
+    for field_path, offset, _width in resolver.struct_layouts[type_name]:
         resolver.current_scope.add_symbol(f"{node.symbol}.{field_path}", base + offset)
     resolver.typed_instances[node.symbol] = type_name
+    resolver.typed_instance_addr_width[node.symbol] = _address_width_for(base)
     return True
+
+
+def _address_width_for(value: int) -> str:
+    """Map an integer address to its natural 65c816 addressing-mode width.
+
+    - `< 0x100`     → "b" (direct page; one-byte operand)
+    - `< 0x10000`   → "w" (absolute; two-byte operand)
+    - otherwise      → "l" (long; three-byte operand)
+    """
+    if value < 0x100:
+        return "b"
+    if value < 0x10000:
+        return "w"
+    return "l"
 
 
 def generate_assign(

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -265,12 +265,21 @@ class Resolver:
         # Populated by `generate_struct`; consumed by typed-bind eager
         # expansion and by `(expr as T).field` field-access codegen so we
         # don't have to walk scopes to enumerate a struct's fields.
-        self.struct_layouts: dict[str, list[tuple[str, int]]] = {}
+        # Each entry: (dotted_field_path, byte_offset, byte_width). The
+        # width column is what enables auto-sized opcode emission on typed
+        # field accesses; nested struct sub-fields inherit their declared
+        # primitive width.
+        self.struct_layouts: dict[str, list[tuple[str, int, int]]] = {}
         # Total size per registered struct type, exposed as `Type.__size`.
         self.struct_sizes: dict[str, int] = {}
         # Typed-bind registry: instance name → struct type name. Lets the
         # linter spot redundant casts and field access on non-typed bindings.
         self.typed_instances: dict[str, str] = {}
+        # Address width per typed instance — "b" (DP), "w" (abs 16-bit),
+        # or "l" (long 24-bit). Derived from the base value's bank at
+        # bind time so opcode emission can pick `lda` / `lda.w` / `lda.l`
+        # without re-parsing the operand string.
+        self.typed_instance_addr_width: dict[str, str] = {}
         # Canonical paths of modules already loaded by `.import`. Used to
         # short-circuit transitive re-imports (file A and file B both import
         # "inc"; without dedup the third party that imports both re-parses

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -156,6 +156,28 @@ of `T`, so `p.field` is just a flat symbol after the bind. Nested
 struct fields chain cleanly: `(o as Outer).pos.y` and
 `o.pos.y` both resolve to `base + Outer.pos + Inner.y`.
 
+#### Auto-sized opcodes on typed accesses
+
+When a typed instance is referenced directly as an operand
+(`lda p.field`), the assembler picks the addressing mode (`lda` /
+`lda.w` / `lda.l`) from the binding's base bank — no operand-string
+guessing involved. The mapping is:
+
+| Base value | Addressing mode |
+|------------|-----------------|
+| `< 0x100`   | direct page (`lda`) |
+| `< 0x10000` | absolute (`lda.w`) |
+| otherwise   | long (`lda.l`)     |
+
+An explicit `.b` / `.w` / `.l` on the opcode always wins. Compound
+operands (`p.field + 1`, raw addresses, casts) keep using the
+existing operand-string heuristic.
+
+If the field's declared width disagrees with the current REP/SEP
+register width (e.g. `lda p.word_field` while `.a8` is in effect),
+the assembler emits a warning suggesting the `rep` / `sep` flip
+the user probably wants.
+
 Lint hooks:
 
 - `S001` — cast targets a struct type the file never declared.

--- a/tests/test_auto_size.py
+++ b/tests/test_auto_size.py
@@ -1,0 +1,141 @@
+"""Auto-size opcode emission from typed-instance field accesses + A/I-width warnings."""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from a816.program import Program
+
+
+def _assemble_ips(src: str) -> bytes:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        asm = root / "main.s"
+        asm.write_text(src, encoding="utf-8")
+        ips = root / "out.ips"
+        program = Program()
+        assert program.assemble_as_patch(str(asm), ips) == 0
+        return ips.read_bytes()
+
+
+_OAM_DEF = """
+.struct OAM {
+    word x
+    word y
+    byte tile
+    byte attr
+}
+"""
+
+
+def test_typed_field_in_long_bank_picks_lda_l() -> None:
+    """`p := (0x7e0000 as OAM)` → `lda p.tile` emits `lda.l` (AF op)."""
+    src = (
+        _OAM_DEF
+        + """
+        .a8
+        *=0x008000
+        p := (0x7e0000 as OAM)
+            lda p.tile
+        """
+    )
+    data = _assemble_ips(src)
+    # Tile offset = 4, base = 0x7E0000. LDA.l $7E0004 → AF 04 00 7E
+    assert b"\xaf\x04\x00\x7e" in data
+
+
+def test_typed_field_in_abs_bank_picks_lda_w() -> None:
+    """Base under 0x10000 (abs) → 16-bit absolute addressing."""
+    src = (
+        _OAM_DEF
+        + """
+        .a8
+        *=0x008000
+        p := (0x002100 as OAM)
+            lda p.tile
+        """
+    )
+    data = _assemble_ips(src)
+    # Tile offset = 4, base = 0x002100. LDA $2104 → AD 04 21
+    assert b"\xad\x04\x21" in data
+
+
+def test_typed_field_in_direct_page_picks_lda_b() -> None:
+    """Base under 0x100 (DP) → direct page addressing."""
+    src = (
+        _OAM_DEF
+        + """
+        .a8
+        *=0x008000
+        p := (0x10 as OAM)
+            lda p.tile
+        """
+    )
+    data = _assemble_ips(src)
+    # Tile offset = 4, base = 0x10. LDA $14 → A5 14
+    assert b"\xa5\x14" in data
+
+
+def test_explicit_size_still_wins() -> None:
+    """User-specified `.b/.w/.l` overrides the typed-instance inference."""
+    src = (
+        _OAM_DEF
+        + """
+        .a8
+        *=0x008000
+        p := (0x7e0000 as OAM)
+            lda.w 0x0004 + p.tile - 0x7e0000
+        """
+    )
+    # Compose so the expression hits the string heuristic, not the
+    # typed-field shortcut. `.w` forces abs.
+    data = _assemble_ips(src)
+    # Operand evaluates to 4 + 4 = 8. LDA $0008 → AD 08 00
+    assert b"\xad\x08\x00" in data
+
+
+def test_register_width_mismatch_warns_when_a8_loads_word(caplog: pytest.LogCaptureFixture) -> None:
+    src = (
+        _OAM_DEF
+        + """
+        .a8
+        *=0x008000
+        p := (0x7e0000 as OAM)
+            lda p.x
+        """
+    )
+    with caplog.at_level(logging.WARNING):
+        _assemble_ips(src)
+    assert any("field width" in r.message and "A register" in r.message for r in caplog.records), (
+        f"expected an A-width warning, got {[r.message for r in caplog.records]}"
+    )
+
+
+def test_no_warning_when_field_matches_register(caplog: pytest.LogCaptureFixture) -> None:
+    src = (
+        _OAM_DEF
+        + """
+        .a8
+        *=0x008000
+        p := (0x7e0000 as OAM)
+            lda p.tile
+        """
+    )
+    with caplog.at_level(logging.WARNING):
+        _assemble_ips(src)
+    assert not any("field width" in r.message for r in caplog.records)
+
+
+def test_non_typed_operand_keeps_string_heuristic() -> None:
+    """Bare numbers / labels are untouched by the typed-field path."""
+    src = """
+        *=0x008000
+            lda 0x12
+        """
+    data = _assemble_ips(src)
+    # `0x12` < 0x100 → DP heuristic → LDA $12 → A5 12
+    assert b"\xa5\x12" in data


### PR DESCRIPTION
## Summary

`lda p.hp` now picks the right addressing mode (`lda` / `lda.w` / `lda.l`) from the binding's base bank instead of falling back to the operand-string heuristic, which routinely guesses wrong and forces explicit `.b` / `.w` / `.l` everywhere.

The struct layout now carries per-field width; the typed-instance registry remembers each binding's addressing width; the opcode generator looks both up when the user wrote `lda p.field` without pinning a size. If the field's declared width disagrees with the current REP/SEP register width, the assembler emits a warning suggesting the `rep` / `sep` flip.

## How the pieces compose

- `_layout_struct_fields` now emits `(path, offset, width)` tuples — primitives use `byte`/`word`/`long`/`dword` sizes, nested struct sub-fields inherit their declared widths.
- `resolver.typed_instance_addr_width[name]` records `"b"` / `"w"` / `"l"` for each `:=` typed bind, derived from the base value's bank.
- `generate_opcode`: when `size is None` and the operand is a bare `p.field` term, looks up the binding's addressing width and uses it as the opcode suffix. Explicit `.b` / `.w` / `.l` on the opcode always wins. Compound expressions (`p.x + 1`, casts) keep the existing heuristic — zero regression for non-typed code.
- `_maybe_warn_register_width_mismatch`: catches the common bug of reading a word field while `.a8` is in effect (or vice versa). Suggests the right `rep` / `sep` payload.

## Example

```ca65
.struct OAM { word x; word y; byte tile; byte attr }
.a8
*=0x008000
p := (0x7e0000 as OAM)
    lda p.tile       ; emits LDA.l $7E0004 — AF 04 00 7E
    lda p.x          ; warns: field width (2 bytes) ... consider rep #$20 first
```

## Test plan

- [ ] \`hatch run tests:all\` — 951 passing, ruff + mypy strict clean
- [ ] \`scry analyse\` — 0 issues, 88% coverage
- [ ] Manual smoke: bind a struct in DP / abs / long banks and check that the emitted opcode bytes match the expected addressing-mode form