### PR TITLE
Ship `@std/snes/*` stdlib of hardware register structs

### DIFF
--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -569,6 +569,16 @@ def generate_extern(
     return [ExternNode(node.symbol, resolver)]
 
 
+_STDLIB_PREFIX = "@std/"
+
+
+def _stdlib_root() -> Path:
+    """Directory holding the bundled standard-library modules."""
+    import a816
+
+    return Path(a816.__file__).parent / "stdlib"
+
+
 def _import_search_paths(resolver: Resolver, file_info: Token) -> list[Path]:
     paths: list[Path] = []
     if file_info.position and file_info.position.file:
@@ -577,6 +587,15 @@ def _import_search_paths(resolver: Resolver, file_info: Token) -> list[Path]:
         paths.append(uri_to_path(file_info.position.file.filename).parent)
     paths.extend(resolver.context.module_paths)
     return paths
+
+
+def _resolve_stdlib_module(module_name: str, extension: str) -> Path | None:
+    """Map `@std/snes/ppu` → `<wheel>/a816/stdlib/snes/ppu.s` (or `.o`)."""
+    if not module_name.startswith(_STDLIB_PREFIX):
+        return None
+    relative = module_name[len(_STDLIB_PREFIX) :]
+    candidate = _stdlib_root() / f"{relative}{extension}"
+    return candidate if candidate.exists() else None
 
 
 def _import_from_object(
@@ -645,13 +664,13 @@ def generate_import(
     direct_mode = resolver.context.is_direct_mode and not resolver.context.is_object_mode
     search_paths = _import_search_paths(resolver, file_info)
 
-    obj_path = _resolve_module_path(module_name, ".o", search_paths)
+    obj_path = _resolve_stdlib_module(module_name, ".o") or _resolve_module_path(module_name, ".o", search_paths)
     if obj_path:
         nodes = _import_from_object(module_name, obj_path, resolver, direct_mode)
         if nodes is not None:
             return nodes
 
-    src_path = _resolve_module_path(module_name, ".s", search_paths)
+    src_path = _resolve_stdlib_module(module_name, ".s") or _resolve_module_path(module_name, ".s", search_paths)
     if src_path:
         if direct_mode:
             key = _canonical(src_path)

--- a/a816/stdlib/__init__.py
+++ b/a816/stdlib/__init__.py
@@ -1,0 +1,13 @@
+"""Bundled assembly modules importable via the `@std/...` prefix.
+
+The contents of this directory (and its sub-directories) are addressable
+from assembly source as:
+
+    .import "@std/snes/ppu"
+    .import "@std/snes/cpu"
+
+The resolver maps that prefix to this package's filesystem path (see
+`a816.parse.codegen._resolve_stdlib_module`). Anything dropped under
+`a816/stdlib/.../foo.s` becomes importable as `@std/.../foo` once it
+ships in the wheel.
+"""

--- a/a816/stdlib/snes/__init__.py
+++ b/a816/stdlib/snes/__init__.py
@@ -1,0 +1,1 @@
+"""SNES (S-PPU / S-CPU / S-SMP) hardware register stdlib modules."""

--- a/a816/stdlib/snes/apu.s
+++ b/a816/stdlib/snes/apu.s
@@ -1,0 +1,21 @@
+"""SNES APU I/O ports ($2140-$2143).
+
+The CPU↔SPC700 communication channels. Each port is full-duplex: the
+S-CPU writes a byte and the SPC700 reads it (and vice versa) on the
+same address. The struct just lays out the four ports as bytes.
+
+    .import "@std/snes/apu"
+
+    apu := (APU_BASE as APU)
+        lda apu.APUIO0          ; read SPC's port-0 reply
+        sta apu.APUIO1          ; send byte on port 1
+"""
+
+APU_BASE = 0x2140
+
+.struct APU {
+    byte APUIO0
+    byte APUIO1
+    byte APUIO2
+    byte APUIO3
+}

--- a/a816/stdlib/snes/cpu.s
+++ b/a816/stdlib/snes/cpu.s
@@ -1,0 +1,53 @@
+"""SNES CPU-side I/O registers ($4200-$421F).
+
+Covers NMI / IRQ / joypad enables, the multiplier and divider math
+pair, the joypad auto-read buffers, and the H/V counters. Bind to
+its base for typed access:
+
+    .import "@std/snes/cpu"
+
+    cpu_regs := (CPU_REGS_BASE as CPU_REGS)
+        lda cpu_regs.NMITIMEN
+        sta cpu_regs.WRMPYA
+
+`PAD1L`/`PAD1H` etc. are the auto-read joypad shadows refreshed by
+the hardware every vblank; they are stable to read between $4218
+and $421F once `NMITIMEN.auto_joypad_read` is enabled.
+"""
+
+CPU_REGS_BASE = 0x4200
+
+.struct CPU_REGS {
+    byte NMITIMEN
+    byte WRIO
+    byte WRMPYA
+    byte WRMPYB
+    byte WRDIVL
+    byte WRDIVH
+    byte WRDIVB
+    byte HTIMEL
+    byte HTIMEH
+    byte VTIMEL
+    byte VTIMEH
+    byte MDMAEN
+    byte HDMAEN
+    byte MEMSEL
+    byte UNUSED_420E
+    byte UNUSED_420F
+    byte RDNMI
+    byte TIMEUP
+    byte HVBJOY
+    byte RDIO
+    byte RDDIVL
+    byte RDDIVH
+    byte RDMPYL
+    byte RDMPYH
+    byte PAD1L
+    byte PAD1H
+    byte PAD2L
+    byte PAD2H
+    byte PAD3L
+    byte PAD3H
+    byte PAD4L
+    byte PAD4H
+}

--- a/a816/stdlib/snes/dma.s
+++ b/a816/stdlib/snes/dma.s
@@ -1,0 +1,49 @@
+"""SNES DMA channels ($4300-$437F).
+
+Each of the eight DMA channels has a 16-byte register slice; the first
+12 bytes are documented (the remaining four are reserved / unmapped).
+The `DMAChannel` struct lays out one channel; the eight channels are
+addressable by computing the base + `channel * 0x10` or by binding one
+typed instance per channel that needs configuration.
+
+    .import "@std/snes/dma"
+    .import "@std/snes/cpu"
+
+    ; Channel 0 → VRAM upload
+    ch0 := (DMA_BASE as DMAChannel)
+        lda #0x01
+        sta ch0.DMAP
+        lda #0x18                    ; VMDATAL
+        sta ch0.BBAD
+        ; ... configure source + size, then enable on MDMAEN
+
+Channel base addresses for direct constant use:
+
+    DMA_CH0 = DMA_BASE + 0 * DMAChannel.__size
+    DMA_CH1 = DMA_BASE + 1 * DMAChannel.__size
+    ...
+
+The 16-byte stride is the bus mapping width even though only 12 are
+register-mapped; the trailing four are reserved on real hardware.
+"""
+
+DMA_BASE = 0x4300
+
+.struct DMAChannel {
+    byte DMAP
+    byte BBAD
+    byte A1TL
+    byte A1TH
+    byte A1B
+    byte DASL
+    byte DASH
+    byte DASB
+    byte A2AL
+    byte A2AH
+    byte NTRL
+    byte UNUSED_B
+    byte UNUSED_C
+    byte UNUSED_D
+    byte UNUSED_E
+    byte UNUSED_F
+}

--- a/a816/stdlib/snes/joypad.s
+++ b/a816/stdlib/snes/joypad.s
@@ -1,0 +1,21 @@
+"""SNES joypad serial / manual-read registers ($4016-$4017).
+
+These are the raw serial interface; the auto-read shadow registers
+($4218-$421F) live in `@std/snes/cpu` as `PAD1L/PAD1H` etc.
+
+    .import "@std/snes/joypad"
+
+    pad := (JOYPAD_BASE as JOYPAD_SERIAL)
+        ; manual read sequence
+        lda #1
+        sta pad.JOYSER0
+        stz pad.JOYSER0
+        ; shift bits out of JOYSER0/JOYSER1
+"""
+
+JOYPAD_BASE = 0x4016
+
+.struct JOYPAD_SERIAL {
+    byte JOYSER0
+    byte JOYSER1
+}

--- a/a816/stdlib/snes/ppu.s
+++ b/a816/stdlib/snes/ppu.s
@@ -1,0 +1,84 @@
+"""SNES PPU registers ($2100-$213F).
+
+Comprehensive layout of the PPU register block exposed as `.struct PPU`.
+Bind it to its base address to get typed field access:
+
+    .import "@std/snes/ppu"
+
+    ppu := (PPU_BASE as PPU)
+        lda ppu.INIDISP
+        sta ppu.OAMADDL
+
+All fields are byte-wide because the SNES PPU register interface is
+strictly 8-bit at $21xx; multi-byte registers (e.g. BG offsets) are
+written as two consecutive byte stores.
+"""
+
+PPU_BASE = 0x2100
+
+.struct PPU {
+    byte INIDISP
+    byte OBSEL
+    byte OAMADDL
+    byte OAMADDH
+    byte OAMDATA
+    byte BGMODE
+    byte MOSAIC
+    byte BG1SC
+    byte BG2SC
+    byte BG3SC
+    byte BG4SC
+    byte BG12NBA
+    byte BG34NBA
+    byte BG1HOFS
+    byte BG1VOFS
+    byte BG2HOFS
+    byte BG2VOFS
+    byte BG3HOFS
+    byte BG3VOFS
+    byte BG4HOFS
+    byte BG4VOFS
+    byte VMAIN
+    byte VMADDL
+    byte VMADDH
+    byte VMDATAL
+    byte VMDATAH
+    byte M7SEL
+    byte M7A
+    byte M7B
+    byte M7C
+    byte M7D
+    byte M7X
+    byte M7Y
+    byte CGADD
+    byte CGDATA
+    byte W12SEL
+    byte W34SEL
+    byte WOBJSEL
+    byte WH0
+    byte WH1
+    byte WH2
+    byte WH3
+    byte WBGLOG
+    byte WOBJLOG
+    byte TM
+    byte TS
+    byte TMW
+    byte TSW
+    byte CGWSEL
+    byte CGADSUB
+    byte COLDATA
+    byte SETINI
+    byte MPYL
+    byte MPYM
+    byte MPYH
+    byte SLHV
+    byte OAMDATAREAD
+    byte VMDATALREAD
+    byte VMDATAHREAD
+    byte CGDATAREAD
+    byte OPHCT
+    byte OPVCT
+    byte STAT77
+    byte STAT78
+}

--- a/a816/stdlib/snes/wram.s
+++ b/a816/stdlib/snes/wram.s
@@ -1,0 +1,25 @@
+"""SNES WRAM access registers ($2180-$2183).
+
+The serial WRAM port — useful when DMA isn't an option (e.g. inside
+NMI / IRQ when the DMA controller is committed elsewhere). Set
+`WMADDL/WMADDH/WMADDB` once, then read or write `WMDATA` in a tight
+loop with the WRAM address auto-incrementing.
+
+    .import "@std/snes/wram"
+
+    wram := (WRAM_BASE as WRAM)
+        lda #0x00
+        sta wram.WMADDL
+        sta wram.WMADDH
+        sta wram.WMADDB
+        ; subsequent loads from wram.WMDATA stream WRAM bytes
+"""
+
+WRAM_BASE = 0x2180
+
+.struct WRAM {
+    byte WMDATA
+    byte WMADDL
+    byte WMADDH
+    byte WMADDB
+}

--- a/docs/docs/stdlib.md
+++ b/docs/docs/stdlib.md
@@ -1,0 +1,66 @@
+# Standard library
+
+a816 ships a small standard library of `.struct` declarations for SNES
+hardware registers. The modules live inside the wheel and are reached
+via the `@std/` virtual prefix — they never collide with user modules,
+and there is no path to configure.
+
+```ca65
+.import "@std/snes/ppu"
+
+*=0x008000
+init:
+    ppu := (PPU_BASE as PPU)
+        lda ppu.INIDISP
+        sta ppu.OAMDATA
+    rts
+```
+
+## What's included
+
+| Module               | Covers                                            |
+|----------------------|---------------------------------------------------|
+| `@std/snes/ppu`      | `$2100`–`$213F` PPU control / VRAM / CGRAM / OAM  |
+| `@std/snes/cpu`      | `$4200`–`$421F` NMI / IRQ / math / joypad shadows |
+| `@std/snes/dma`      | `$4300`–`$437F` DMA channels (16-byte stride)     |
+| `@std/snes/apu`      | `$2140`–`$2143` APU communication ports           |
+| `@std/snes/joypad`   | `$4016`–`$4017` serial joypad ports               |
+| `@std/snes/wram`     | `$2180`–`$2183` WRAM streaming port               |
+
+Each module exports a single struct named after the block (`PPU`,
+`CPU_REGS`, `DMAChannel`, …) plus a base-address constant
+(`PPU_BASE`, `CPU_REGS_BASE`, `DMA_BASE`, …). Pair the two via a
+typed bind to get auto-sized opcode emission on every field access:
+
+```ca65
+.import "@std/snes/cpu"
+
+cpu := (CPU_REGS_BASE as CPU_REGS)
+    lda cpu.RDNMI                 ; → LDA $4210
+```
+
+## How resolution works
+
+When the parser sees `.import "@std/snes/ppu"` it strips the `@std/`
+prefix and looks for `<wheel>/a816/stdlib/snes/ppu.s` (or `.o`). If
+the file is missing the import fails with the usual
+`Module not found:` error — there is no implicit fallback to user
+search paths once `@std/` is on the front.
+
+To browse the bundled source from a Python REPL:
+
+```python
+from importlib.resources import files
+print((files("a816.stdlib") / "snes" / "ppu.s").read_text())
+```
+
+## Extending
+
+To add another block of registers, drop a `.s` file under
+`a816/stdlib/<arch>/<name>.s` in this repository and ship it in the
+next release. The wheel build picks the file up automatically; the
+resolver has no per-file allowlist.
+
+For project-private "stdlib" modules (game-specific RAM layouts,
+shared macro bundles), keep using regular `module_paths` configured
+in `a816.toml` — `@std/` is reserved for assembler-bundled content.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -13,6 +13,7 @@ nav = [
         { "Splitting a project into modules" = "tutorials/modules-walkthrough.md" },
     ] },
     { "Directives" = "directives.md" },
+    { "Standard library" = "stdlib.md" },
     { "Modules" = "modules.md" },
     { "Freespace pools" = "freespace-pools.md" },
     { "Fluff (lint + format)" = "fluff.md" },

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -1,0 +1,121 @@
+"""Bundled `@std/...` modules resolve through the import machinery and
+produce the expected SNES register offsets.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from a816.context import AssemblyMode
+from a816.program import Program
+
+
+def _resolve_symbols(src: str) -> dict[str, int]:
+    program = Program()
+    # `.import` only inlines source under DIRECT mode; the default
+    # (parse-only) path produces ExternNodes which intentionally don't
+    # publish the struct symbols.
+    program.resolver.context.mode = AssemblyMode.DIRECT
+    program.assemble_string_with_emitter(src, "main.s", _NoopEmitter())
+    return {
+        name: value
+        for scope in program.resolver.scopes
+        for name, value in scope.symbols.items()
+        if isinstance(value, int)
+    }
+
+
+def test_ppu_struct_loads_canonical_offsets() -> None:
+    symbols = _resolve_symbols('.import "@std/snes/ppu"\n')
+    assert symbols["PPU.INIDISP"] == 0x00
+    assert symbols["PPU.OAMADDL"] == 0x02
+    assert symbols["PPU.OAMDATA"] == 0x04
+    assert symbols["PPU.VMADDL"] == 0x16
+    assert symbols["PPU.VMDATAL"] == 0x18
+    assert symbols["PPU.CGADD"] == 0x21
+    assert symbols["PPU.STAT78"] == 0x3F
+    assert symbols["PPU.__size"] == 0x40
+
+
+def test_cpu_struct_loads_canonical_offsets() -> None:
+    symbols = _resolve_symbols('.import "@std/snes/cpu"\n')
+    assert symbols["CPU_REGS.NMITIMEN"] == 0x00
+    assert symbols["CPU_REGS.MDMAEN"] == 0x0B
+    assert symbols["CPU_REGS.HDMAEN"] == 0x0C
+    assert symbols["CPU_REGS.RDNMI"] == 0x10
+    assert symbols["CPU_REGS.HVBJOY"] == 0x12
+    assert symbols["CPU_REGS.PAD1L"] == 0x18
+    assert symbols["CPU_REGS.PAD4H"] == 0x1F
+
+
+def test_dma_channel_struct_lays_out_16_bytes() -> None:
+    symbols = _resolve_symbols('.import "@std/snes/dma"\n')
+    assert symbols["DMAChannel.DMAP"] == 0
+    assert symbols["DMAChannel.BBAD"] == 1
+    assert symbols["DMAChannel.A1TL"] == 2
+    assert symbols["DMAChannel.NTRL"] == 0x0A
+    assert symbols["DMAChannel.__size"] == 0x10
+
+
+def test_apu_struct_is_four_ports() -> None:
+    symbols = _resolve_symbols('.import "@std/snes/apu"\n')
+    assert symbols["APU.APUIO0"] == 0
+    assert symbols["APU.APUIO3"] == 3
+    assert symbols["APU.__size"] == 4
+
+
+def test_wram_struct() -> None:
+    symbols = _resolve_symbols('.import "@std/snes/wram"\n')
+    assert symbols["WRAM.WMDATA"] == 0
+    assert symbols["WRAM.WMADDB"] == 3
+    assert symbols["WRAM.__size"] == 4
+
+
+def test_joypad_struct() -> None:
+    symbols = _resolve_symbols('.import "@std/snes/joypad"\n')
+    assert symbols["JOYPAD_SERIAL.JOYSER0"] == 0
+    assert symbols["JOYPAD_SERIAL.JOYSER1"] == 1
+
+
+def test_typed_bind_against_ppu_emits_lda_w() -> None:
+    """End-to-end: import + typed bind + auto-sized opcode emit."""
+    src = """
+.import "@std/snes/ppu"
+.a8
+*=0x008000
+ppu := (PPU_BASE as PPU)
+    lda ppu.OAMDATA
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        asm = root / "main.s"
+        asm.write_text(src, encoding="utf-8")
+        ips = root / "out.ips"
+        program = Program()
+        assert program.assemble_as_patch(str(asm), ips) == 0
+        data = ips.read_bytes()
+        # Base 0x2100 + OAMDATA offset 0x04 = $2104 → LDA $2104 → AD 04 21
+        assert b"\xad\x04\x21" in data
+
+
+def test_unknown_stdlib_module_falls_through_to_user_paths() -> None:
+    """`@std/...` that doesn't exist in the bundle should error like any
+    other missing module rather than silently dropping the import."""
+    import pytest
+
+    from a816.parse.nodes import NodeError
+
+    program = Program()
+    with pytest.raises(NodeError, match="Module not found"):
+        program.assemble_string_with_emitter('.import "@std/snes/nonexistent"\n', "x.s", _NoopEmitter())
+
+
+class _NoopEmitter:
+    def begin(self) -> None: ...
+
+    def end(self) -> None: ...
+
+    def write_block_header(self, *_: object, **__: object) -> None: ...
+
+    def write_block(self, *_: object, **__: object) -> None: ...


### PR DESCRIPTION
## Summary

Bundles canonical `.struct` definitions for SNES hardware registers and exposes them via a new `@std/` virtual import prefix. Users no longer need to copy-paste register layouts into every project.

```ca65
.import "@std/snes/ppu"
.a8
*=0x008000
ppu := (PPU_BASE as PPU)
    lda ppu.INIDISP            ; → LDA $2100
    sta ppu.OAMDATA            ; → STA $2104
```

## What ships

| Module               | Covers                                            |
|----------------------|---------------------------------------------------|
| `@std/snes/ppu`      | `$2100`–`$213F` PPU control / VRAM / CGRAM / OAM  |
| `@std/snes/cpu`      | `$4200`–`$421F` NMI / IRQ / math / joypad shadows |
| `@std/snes/dma`      | `$4300`–`$437F` DMA channels (16-byte stride)     |
| `@std/snes/apu`      | `$2140`–`$2143` APU communication ports           |
| `@std/snes/joypad`   | `$4016`–`$4017` serial joypad ports               |
| `@std/snes/wram`     | `$2180`–`$2183` WRAM streaming port               |

Each module exports one `.struct` plus a `*_BASE` address constant.

## Resolution

- `_resolve_stdlib_module` (`a816/parse/codegen.py`) strips `@std/` and maps to `<wheel>/a816/stdlib/...`. Resolves both `.o` and `.s` extensions. Falls through to a `Module not found:` error if the bundle has no match — there is no implicit user-path fallback for the `@std/` prefix.
- Wheel packaging already includes everything under `a816/`; verified `a816/stdlib/snes/*.s` lands inside the built wheel.
- Pairs naturally with the typed-bind + auto-size machinery shipped in #60/#63: `ppu := (PPU_BASE as PPU)` then `lda ppu.field` picks the correct addressing mode automatically.

## Test plan

- [ ] \`hatch run tests:all\` — 959 passing, ruff + mypy strict clean
- [ ] \`scry analyse\` — 0 issues, 88% coverage
- [ ] Wheel verification: \`VERSION=0.0.1.dev0 hatch build --target wheel && unzip -l dist/*.whl | grep stdlib\` shows all six \`.s\` files
- [ ] End-to-end smoke (\`tests/test_stdlib.py::test_typed_bind_against_ppu_emits_lda_w\`) confirms an opcode using the bundled struct emits the correct bytes