### PR TITLE
Detect overlapping byte writes between emit regions

### DIFF
--- a/a816/context.py
+++ b/a816/context.py
@@ -26,6 +26,12 @@ class AssemblyContext:
     module_paths: list[Path] = field(default_factory=list)
     include_paths: list[Path] = field(default_factory=list)
     prelude_file: Path | None = None
+    # How the WriteAuditor reacts to overlapping byte writes from
+    # different `*=` / `.alloc` / `.relocate` regions. `"warn"` keeps
+    # behaviour backwards-compatible (log + continue); flip to
+    # `"error"` to abort on the first overlap, or `"off"` to skip the
+    # check entirely.
+    overlap_mode: str = "warn"
 
     @property
     def is_object_mode(self) -> bool:

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -320,9 +320,7 @@ def generate_map(
     return []
 
 
-def _infer_typed_operand_size(
-    operand: ExpressionAstNode | None, resolver: Resolver
-) -> str | None:
+def _infer_typed_operand_size(operand: ExpressionAstNode | None, resolver: Resolver) -> str | None:
     """Pick `b`/`w`/`l` from a typed-instance field reference, else None.
 
     Covers the `lda p.field` shorthand: when the operand is exactly one
@@ -359,9 +357,7 @@ def _opcode_register_width(opcode: str, resolver: Resolver) -> int | None:
     return None
 
 
-def _typed_field_lookup(
-    operand: ExpressionAstNode | None, resolver: Resolver
-) -> tuple[str, str, int] | None:
+def _typed_field_lookup(operand: ExpressionAstNode | None, resolver: Resolver) -> tuple[str, str, int] | None:
     """Resolve a `p.field` operand to `(instance, full_name, field_width)`."""
     if operand is None or not isinstance(operand, ExpressionAstNode) or len(operand.tokens) != 1:
         return None
@@ -410,8 +406,7 @@ def _maybe_warn_register_width_mismatch(node: OpcodeAstNode, resolver: Resolver)
     register_label = _register_label(node.opcode)
     rep_sep = "rep" if field_width > register_width else "sep"
     logger.warning(
-        "field width (%d byte%s) does not match %s register size (%d bits) on `%s %s`; "
-        "consider `%s #$%02x` first",
+        "field width (%d byte%s) does not match %s register size (%d bits) on `%s %s`; consider `%s #$%02x` first",
         field_width,
         "" if field_width == 1 else "s",
         register_label,

--- a/a816/program.py
+++ b/a816/program.py
@@ -21,7 +21,7 @@ from a816.parse.nodes import (
 )
 from a816.protocols import NodeProtocol
 from a816.symbols import Resolver
-from a816.writers import IPSWriter, ObjectWriter, SFCWriter, Writer
+from a816.writers import IPSWriter, ObjectWriter, SFCWriter, WriteAuditor, Writer
 
 logger = logging.getLogger("a816")
 
@@ -517,7 +517,18 @@ class Program:
         # Stash the resolved node list so the .adbg producer can introspect
         # LinkedModuleNode placements after emission.
         self._program_nodes = list(nodes)
-        self.emit(nodes, emitter)
+        self.emit(nodes, self._wrap_emitter_for_overlap_audit(emitter))
+
+    def _wrap_emitter_for_overlap_audit(self, emitter: Writer) -> Writer:
+        """Auto-wrap SFC / IPS emitters so overlapping writes get reported.
+
+        `ObjectWriter` is left untouched — it tracks regions in a richer
+        structure and the linker has its own overlap pass.
+        """
+        mode = self.resolver.context.overlap_mode
+        if mode == "off" or isinstance(emitter, ObjectWriter):
+            return emitter
+        return WriteAuditor(emitter, mode=mode)  # type: ignore[arg-type]
 
     def assemble_with_emitter(self, asm_file: str, emitter: Writer, prelude: str | None = None) -> int:
         """CLI-facing wrapper around `assemble_string_with_emitter`.

--- a/a816/writers.py
+++ b/a816/writers.py
@@ -1,7 +1,10 @@
+import logging
 import struct
-from typing import BinaryIO, Protocol
+from typing import BinaryIO, Literal, Protocol
 
 from a816.object_file import ObjectFile, PoolAlloc, PoolDecl, Region, RelocationType, SymbolSection, SymbolType
+
+logger = logging.getLogger("a816.writers")
 
 
 class Writer(Protocol):
@@ -16,6 +19,65 @@ class Writer(Protocol):
 
     def end(self) -> None:
         """Writes the footer."""
+
+
+OverlapMode = Literal["error", "warn", "off"]
+
+
+class WriteAuditor:
+    """Wraps a `Writer` to detect overlapping byte writes.
+
+    Every `write_block` records the `[addr, addr + len)` byte range it
+    served. Subsequent writes that touch any already-recorded byte are
+    reported per the configured `mode`:
+
+      - `error`: raise `OverlapError`
+      - `warn` (default): log a WARNING and continue
+      - `off`: silent passthrough
+
+    Non-overlapping adjacent blocks are silent. The implementation is
+    naive O(n) per write — fine for typical ROM patches that emit a
+    handful of regions; if that ever becomes hot, switch the inner
+    structure to an interval tree.
+    """
+
+    def __init__(self, inner: Writer, mode: OverlapMode = "warn") -> None:
+        self._inner = inner
+        self._mode: OverlapMode = mode
+        self._ranges: list[tuple[int, int]] = []  # sorted by start; non-overlapping when no conflicts
+
+    def begin(self) -> None:
+        self._inner.begin()
+
+    def write_block_header(self, block: bytes, block_address: int) -> None:
+        self._inner.write_block_header(block, block_address)
+
+    def write_block(self, block: bytes, block_address: int) -> None:
+        if self._mode != "off" and block:
+            self._check_overlap(block_address, block_address + len(block))
+        self._inner.write_block(block, block_address)
+
+    def end(self) -> None:
+        self._inner.end()
+
+    def _check_overlap(self, start: int, end: int) -> None:
+        for existing_start, existing_end in self._ranges:
+            if start < existing_end and existing_start < end:
+                overlap_start = max(start, existing_start)
+                overlap_end = min(end, existing_end)
+                message = (
+                    f"write at ${start:06x}..${end - 1:06x} overlaps previous "
+                    f"write at ${existing_start:06x}..${existing_end - 1:06x} "
+                    f"(${overlap_start:06x}..${overlap_end - 1:06x} would be silently overwritten)"
+                )
+                if self._mode == "error":
+                    raise OverlapError(message)
+                logger.warning(message)
+        self._ranges.append((start, end))
+
+
+class OverlapError(Exception):
+    """Raised by `WriteAuditor` in `error` mode when two writes share bytes."""
 
 
 class IPSWriter(Writer):

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -33,6 +33,23 @@ ram_routine:
     rts
 ```
 
+### Write-overlap detection
+
+When two `*=` regions (or one `*=` block plus a `.alloc` placement,
+etc.) produce byte spans that share addresses, the assembler emits a
+diagnostic so a routine that silently grew past its expected end is
+caught early. The default mode is `warn` (logged, assembly continues);
+set it to `error` to abort on the first overlap or `off` to silence
+the check entirely.
+
+The mode lives on `Program.resolver.context.overlap_mode` and is
+intended to be wired through `a816.toml` / a CLI flag in a follow-up.
+
+```
+WARNING write at $008004..$00800b overlaps previous write at
+        $008000..$008009 ($008004..$008009 would be silently overwritten)
+```
+
 ### `.map` — memory map
 
 Selects the cartridge address mapping. Affects how `*=` translates

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -1,0 +1,121 @@
+"""WriteAuditor: catches overlapping byte writes from multiple `*=`
+regions, `.alloc` blocks, etc."""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+import pytest
+
+from a816.writers import IPSWriter, OverlapError, WriteAuditor
+
+
+def _audit(mode: str = "warn") -> tuple[WriteAuditor, io.BytesIO]:
+    buf = io.BytesIO()
+    inner = IPSWriter(buf)
+    return WriteAuditor(inner, mode=mode), buf  # type: ignore[arg-type]
+
+
+def test_non_overlapping_writes_are_silent(caplog: pytest.LogCaptureFixture) -> None:
+    auditor, _ = _audit()
+    auditor.begin()
+    with caplog.at_level(logging.WARNING):
+        auditor.write_block(b"\xaa\xbb", 0x008000)
+        auditor.write_block(b"\xcc\xdd", 0x008010)
+    auditor.end()
+    assert not any("overlap" in rec.message for rec in caplog.records)
+
+
+def test_adjacent_writes_are_silent(caplog: pytest.LogCaptureFixture) -> None:
+    """`[0x8000, 0x8004)` then `[0x8004, 0x8008)` share zero bytes — fine."""
+    auditor, _ = _audit()
+    auditor.begin()
+    with caplog.at_level(logging.WARNING):
+        auditor.write_block(b"\xaa\xbb\xcc\xdd", 0x008000)
+        auditor.write_block(b"\xee\xff\x11\x22", 0x008004)
+    auditor.end()
+    assert not any("overlap" in rec.message for rec in caplog.records)
+
+
+def test_full_overlap_warns(caplog: pytest.LogCaptureFixture) -> None:
+    auditor, _ = _audit()
+    auditor.begin()
+    with caplog.at_level(logging.WARNING):
+        auditor.write_block(b"\xaa\xbb\xcc\xdd", 0x008000)
+        auditor.write_block(b"\x11\x22\x33\x44", 0x008000)
+    auditor.end()
+    warnings = [rec for rec in caplog.records if "overlap" in rec.message]
+    assert len(warnings) == 1
+    assert "$008000" in warnings[0].message
+    assert "$008003" in warnings[0].message
+
+
+def test_partial_overlap_warns(caplog: pytest.LogCaptureFixture) -> None:
+    auditor, _ = _audit()
+    auditor.begin()
+    with caplog.at_level(logging.WARNING):
+        auditor.write_block(b"\xaa" * 16, 0x008000)
+        auditor.write_block(b"\xbb" * 16, 0x008008)
+    auditor.end()
+    warnings = [rec for rec in caplog.records if "overlap" in rec.message]
+    assert len(warnings) == 1
+    assert "$008008" in warnings[0].message
+    assert "$00800f" in warnings[0].message
+
+
+def test_error_mode_raises() -> None:
+    auditor, _ = _audit(mode="error")
+    auditor.begin()
+    auditor.write_block(b"\xaa" * 16, 0x008000)
+    with pytest.raises(OverlapError, match=r"\$008008"):
+        auditor.write_block(b"\xbb" * 16, 0x008008)
+
+
+def test_off_mode_is_passthrough(caplog: pytest.LogCaptureFixture) -> None:
+    auditor, _ = _audit(mode="off")
+    auditor.begin()
+    with caplog.at_level(logging.WARNING):
+        auditor.write_block(b"\xaa" * 16, 0x008000)
+        auditor.write_block(b"\xbb" * 16, 0x008000)
+    auditor.end()
+    assert not any("overlap" in rec.message for rec in caplog.records)
+
+
+def test_empty_block_skipped() -> None:
+    """Zero-byte writes record no range and never report overlap."""
+    auditor, _ = _audit()
+    auditor.begin()
+    auditor.write_block(b"", 0x008000)
+    auditor.write_block(b"\xaa", 0x008000)
+    auditor.end()
+    # No assertion needed — passes if no exception even though both calls
+    # used the same start address. Zero-length records nothing.
+
+
+def test_default_mode_is_warn() -> None:
+    auditor, _ = _audit()
+    assert auditor._mode == "warn"  # noqa: SLF001 — testing default
+
+
+def test_end_to_end_overlap_via_two_star_eq_blocks(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+    """Two `*=` regions writing to overlapping byte spans → warning."""
+    from a816.program import Program
+
+    src = tmp_path / "main.s"
+    src.write_text(
+        """
+        *=0x008000
+            .db 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
+        *=0x008004
+            .db 0xAA, 0xBB, 0xCC, 0xDD
+        """,
+        encoding="utf-8",
+    )
+    ips = tmp_path / "out.ips"
+    program = Program()
+    with caplog.at_level(logging.WARNING):
+        assert program.assemble_as_patch(str(src), ips) == 0
+    warnings = [rec for rec in caplog.records if "overlap" in rec.message]
+    assert warnings, "expected overlap warning from two overlapping `*=` regions"


### PR DESCRIPTION
## Summary

Adds a `WriteAuditor` wrapper that catches the classic ROM-hacking
bug: two `*=` blocks (or a `*=` block plus a `.alloc` placement, or
two `.alloc`'d blocks that overflow their reservations) produce byte
ranges that share addresses, silently overwriting one routine with
another.

```ca65
*=0x008000
    .db 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
*=0x008004
    .db 0xAA, 0xBB, 0xCC, 0xDD
```

→

```
WARNING write at $008004..$008007 overlaps previous write at
        $008000..$008007 ($008004..$008007 would be silently overwritten)
```

## Mechanics

- New `WriteAuditor` class in `a816/writers.py` wraps any `Writer`.
  Records `[addr, addr + len)` per `write_block`; on a new write that
  shares any byte with an existing range, reports per the configured
  mode.
- Three modes via `AssemblyContext.overlap_mode`:
  - `warn` (default): log + continue. Backwards-compatible.
  - `error`: raise `OverlapError`. For projects that want hard
    enforcement.
  - `off`: passthrough.
- `Program.assemble_string_with_emitter` auto-wraps SFC / IPS emitters
  via `_wrap_emitter_for_overlap_audit`. `ObjectWriter` is left alone
  — the linker already tracks regions in a richer structure.

## What it does not catch (yet)

- Source attribution: the warning includes addresses, not the
  emitting `.s:line`. Plumbing the source through `write_block` is a
  separate PR.
- `.reclaim`d ranges are not excluded — if a user reclaims and rewrites
  on purpose, the auditor still warns. Follow-up.
- CLI flag / `a816.toml` knob to flip the mode — wiring deferred to a
  follow-up; for now the mode is set programmatically.

## Test plan

- [ ] \`hatch run tests:all\` — 979 passing, ruff + mypy strict clean
- [ ] \`scry analyse\` — 0 issues, 88% coverage
- [ ] Edge cases covered (\`tests/test_overlap_detection.py\`):
  non-overlap silent, adjacent silent, full overlap warns, partial
  overlap warns, error mode raises, off mode passthrough, empty block
  ignored, end-to-end via two \`*=\` regions