### PR TITLE
Rename MZParser to A816Parser, keep deprecated alias

### DIFF
--- a/a816/fluff_lint.py
+++ b/a816/fluff_lint.py
@@ -45,7 +45,7 @@ from a816.parse.ast.nodes import (
     StructAstNode,
     SymbolAffectationAstNode,
 )
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 
 MAX_LINE_LENGTH = 120
 
@@ -1031,7 +1031,7 @@ def lint_text(
     fills it from the project's `a816.toml`; callers without a config
     can pass it explicitly.
     """
-    result = MZParser.parse_as_ast(text, str(path), include_paths=include_paths)
+    result = A816Parser.parse_as_ast(text, str(path), include_paths=include_paths)
     parse_failed = bool(result.error)
     nodes = None if parse_failed else list(result.nodes)
     ctx = LintContext(path=path, text=text, nodes=nodes, parse_failed=parse_failed)

--- a/a816/formatter.py
+++ b/a816/formatter.py
@@ -39,7 +39,7 @@ from a816.parse.ast.nodes import (
     TextAstNode,
 )
 from a816.parse.errors import ParserSyntaxError
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 
 
 class FormattingOptions:
@@ -100,7 +100,7 @@ class A816Formatter:
         source = file_path or "<input>"
         try:
             # Parse the content into an AST
-            result = MZParser.parse_as_ast(content, source, include_paths=include_paths)
+            result = A816Parser.parse_as_ast(content, source, include_paths=include_paths)
 
             if result.error:
                 raise FormattingError(f"Unable to format {source}:\n{result.error}")

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -92,7 +92,7 @@ from a816.parse.ast.nodes import (
     Term,
 )
 from a816.parse.errors import ParseError, ParserSyntaxError, ScannerException
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.parse.scanner_states import KEYWORDS
 from a816.parse.tokens import Token, TokenType
 from a816.util import uri_to_path
@@ -166,7 +166,7 @@ class A816Document:
         """Analyze document using the parser and extract symbols, labels, and diagnostics"""
         try:
             # Parse using the actual a816 parser
-            parser_result = MZParser.parse_as_ast(self.content, self.uri, include_paths=self.include_paths)
+            parser_result = A816Parser.parse_as_ast(self.content, self.uri, include_paths=self.include_paths)
             self.ast_nodes = parser_result.nodes
             self.parse_error = parser_result.parse_error
             self.parse_errors = list(parser_result.parse_errors or [])
@@ -178,7 +178,7 @@ class A816Document:
             self._collect_docstrings()
 
         except (ScannerException, ParserSyntaxError) as e:
-            # These should be handled by MZParser.parse_as_ast, but just in case
+            # These should be handled by A816Parser.parse_as_ast, but just in case
             self.parse_error = ParseError(
                 message=str(e),
                 filename=self.uri,
@@ -186,7 +186,7 @@ class A816Document:
                 column=0,
             )
             self.ast_nodes = []
-            logger.warning("Parser exception not caught by MZParser: %s", e)
+            logger.warning("Parser exception not caught by A816Parser: %s", e)
         except (AttributeError, KeyError, IndexError, TypeError) as e:
             # Catch AST processing exceptions
             self.parse_error = ParseError(

--- a/a816/module_builder.py
+++ b/a816/module_builder.py
@@ -21,7 +21,7 @@ from a816.parse.ast.nodes import (
     CodeRelocationAstNode,
     ImportAstNode,
 )
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 
 logger = logging.getLogger("a816.module_builder")
 
@@ -140,7 +140,7 @@ class ModuleBuilder:
                 nodes = parsed_nodes
             else:
                 content = source_path.read_text(encoding="utf-8")
-                nodes = MZParser.parse_as_ast(content, str(source_path)).nodes
+                nodes = A816Parser.parse_as_ast(content, str(source_path)).nodes
 
             imports = self._collect_imports(nodes)
 
@@ -321,7 +321,7 @@ def build_with_imports(
 
     # Check if the main file uses *= or @= directives (position-dependent code)
     # If so, use the direct assembly approach instead of full object linking
-    parse_result = MZParser.parse_as_ast(main_source.read_text(encoding="utf-8"), str(main_source))
+    parse_result = A816Parser.parse_as_ast(main_source.read_text(encoding="utf-8"), str(main_source))
     main_nodes = parse_result.nodes
     if _has_position_directives(main_nodes):
         logger.info("Detected position-dependent code (*=), using direct assembly mode")

--- a/a816/parse/codegen.py
+++ b/a816/parse/codegen.py
@@ -698,10 +698,10 @@ def _import_from_source(
 ) -> GenNodes | None:
     try:
         if direct_mode:
-            from a816.parse.mzparser import MZParser
+            from a816.parse.mzparser import A816Parser
 
             content = src_path.read_text(encoding="utf-8")
-            result = MZParser.parse_as_ast(content, str(src_path))
+            result = A816Parser.parse_as_ast(content, str(src_path))
             return _code_gen(result.nodes, resolver, macro_definitions) if result.nodes else []
 
         return [ExternNode(symbol_name, resolver) for symbol_name in _extract_public_symbols_from_source(src_path)]
@@ -786,13 +786,13 @@ def _extract_public_symbols_from_source(source_path: Path) -> list[str]:
 
     Uses the full parser to correctly handle comments, strings, conditionals, etc.
     """
-    from a816.parse.mzparser import MZParser
+    from a816.parse.mzparser import A816Parser
 
     symbols: list[str] = []
     content = source_path.read_text(encoding="utf-8")
 
     # Parse using the actual parser
-    result = MZParser.parse_as_ast(content, str(source_path))
+    result = A816Parser.parse_as_ast(content, str(source_path))
 
     # Extract symbols from AST nodes
     _collect_public_symbols(result.nodes, symbols)

--- a/a816/parse/mzparser.py
+++ b/a816/parse/mzparser.py
@@ -40,7 +40,7 @@ class ParserResult:
         return [node.to_representation() for node in self.nodes]
 
 
-class MZParser:
+class A816Parser:
     def __init__(self, resolver: Resolver) -> None:
         self.resolver = resolver
 
@@ -151,3 +151,9 @@ def _gather_context(position: Any, *, before: int, after: int) -> tuple[list[str
     before_lines = [lines[i] for i in range(max(0, line_idx - before), line_idx)]
     after_lines = [lines[i] for i in range(line_idx + 1, min(len(lines), line_idx + 1 + after))]
     return before_lines, after_lines
+
+
+# Deprecated alias for the prior `MZParser` name. Downstream callers can
+# keep working through one more alpha cycle while they migrate to
+# `A816Parser`; remove this on the 1.2.0 line.
+MZParser = A816Parser

--- a/a816/program.py
+++ b/a816/program.py
@@ -8,7 +8,7 @@ from a816.context import AssemblyMode
 from a816.cpu.cpu_65c816 import RomType
 from a816.exceptions import AssemblyError
 from a816.object_file import ObjectFile, SymbolSection, SymbolType
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.parse.nodes import (
     AllocNode,
     BinaryNode,
@@ -60,17 +60,17 @@ class Program:
         ...     print("Assembly successful")
     """
 
-    def __init__(self, parser: MZParser | None = None, dump_symbols: bool = False):
+    def __init__(self, parser: A816Parser | None = None, dump_symbols: bool = False):
         """Initialize the assembler program.
 
         Args:
-            parser: Optional custom parser instance. If None, creates a default MZParser.
+            parser: Optional custom parser instance. If None, creates a default A816Parser.
             dump_symbols: If True, prints the symbol table after assembly.
         """
         self.resolver = Resolver()
         self.logger = logging.getLogger("a816")
         self.dump_symbols = dump_symbols
-        self.parser = parser or MZParser(self.resolver)
+        self.parser = parser or A816Parser(self.resolver)
         self._debug_capture: bool = False
         # (address, filename, line, column) recorded during emit() when capture is on.
         self._debug_lines: list[tuple[int, str, int, int]] = []

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -6,7 +6,7 @@ from a816.cpu.cpu_65c816 import AddressingMode
 from a816.parse.ast.expression import eval_expression
 from a816.parse.ast.nodes import AssignAstNode
 from a816.parse.codegen import code_gen
-from a816.parse.mzparser import MZParser, ParserResult
+from a816.parse.mzparser import A816Parser, ParserResult
 from a816.program import Program
 from a816.symbols import Resolver
 from tests import StubWriter
@@ -17,7 +17,7 @@ class TestParse(TestCase):
 
     @staticmethod
     def _get_result_for(program_text: str) -> ParserResult:
-        return MZParser.parse_as_ast(program_text)
+        return A816Parser.parse_as_ast(program_text)
 
     def _get_ast_for(self, program_text: str) -> list[tuple[Any, ...]]:
         return self._get_result_for(program_text).ast

--- a/tests/test_comment_ast.py
+++ b/tests/test_comment_ast.py
@@ -5,7 +5,7 @@ Unit tests for CommentAstNode and comment parsing functionality
 from unittest import TestCase
 
 from a816.parse.ast.nodes import CommentAstNode
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.parse.tokens import File, Position, Token, TokenType
 
 
@@ -76,7 +76,7 @@ class TestCommentParsing(TestCase):
         """Test parsing a single comment line"""
         program_text = "; This is a comment"
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
         self.assertEqual(len(result.nodes), 1)
@@ -92,7 +92,7 @@ class TestCommentParsing(TestCase):
 ; Another comment
 ; Final comment"""
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
         self.assertEqual(len(result.nodes), 3)
@@ -115,7 +115,7 @@ main:
     sta 0x2000
 ; Footer comment"""
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
 
@@ -135,7 +135,7 @@ main:
         """Test that comment AST can be converted back to representation"""
         program_text = "; Test comment"
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
         self.assertEqual(len(result.nodes), 1)
@@ -160,7 +160,7 @@ main:
 
 ; End of program"""
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
 
@@ -187,7 +187,7 @@ main:
 
 ; Comment 3"""
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
 
@@ -198,7 +198,7 @@ main:
         """Test parsing comments with special characters"""
         program_text = "; Comment with special chars: @#$%^&*()[]{}|\\:;\"'<>?/.,`~"
 
-        result = MZParser.parse_as_ast(program_text)
+        result = A816Parser.parse_as_ast(program_text)
 
         self.assertIsNone(result.error)
         self.assertEqual(len(result.nodes), 1)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -8,7 +8,7 @@ import pytest
 from a816.linker import Linker
 from a816.object_file import ObjectFile, SymbolType
 from a816.parse.ast.nodes import ImportAstNode
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.parse.nodes import ExternNode
 from a816.program import Program
 
@@ -19,7 +19,7 @@ class TestImportParsing:
     def test_parse_import_directive(self) -> None:
         """Test that .import "module" is parsed correctly."""
         source = '.import "vwf"'
-        result = MZParser.parse_as_ast(source, "test.s")
+        result = A816Parser.parse_as_ast(source, "test.s")
 
         assert len(result.nodes) == 1
         assert isinstance(result.nodes[0], ImportAstNode)
@@ -28,7 +28,7 @@ class TestImportParsing:
     def test_parse_import_with_path(self) -> None:
         """Test that .import "path/to/module" is parsed correctly."""
         source = '.import "battle/sram"'
-        result = MZParser.parse_as_ast(source, "test.s")
+        result = A816Parser.parse_as_ast(source, "test.s")
 
         assert len(result.nodes) == 1
         assert isinstance(result.nodes[0], ImportAstNode)
@@ -41,7 +41,7 @@ class TestImportParsing:
 .import "dialog"
 .import "utils/math"
 """
-        result = MZParser.parse_as_ast(source, "test.s")
+        result = A816Parser.parse_as_ast(source, "test.s")
 
         import_nodes = [n for n in result.nodes if isinstance(n, ImportAstNode)]
         assert len(import_nodes) == 3
@@ -52,7 +52,7 @@ class TestImportParsing:
     def test_import_ast_representation(self) -> None:
         """Test ImportAstNode representation methods."""
         source = '.import "vwf"'
-        result = MZParser.parse_as_ast(source, "test.s")
+        result = A816Parser.parse_as_ast(source, "test.s")
         node = result.nodes[0]
 
         assert isinstance(node, ImportAstNode)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -6,7 +6,7 @@ from typing import cast
 from a816.cpu.cpu_65c816 import AddressingMode
 from a816.parse.ast.nodes import DocstringAstNode, IncludeIpsAstNode, MacroAstNode, ScopeAstNode, Term, UnaryOp
 from a816.parse.codegen import code_gen
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.parse.nodes import OpcodeNode
 from a816.parse.tokens import Token, TokenType
 from a816.program import Program
@@ -177,7 +177,7 @@ class ParseTest(unittest.TestCase):
         """
 
         program = Program()
-        program.parser = MZParser(program.resolver)
+        program.parser = A816Parser(program.resolver)
         ast = program.parser.parse_as_ast(input_program)
         print(ast)
         nodes = program.parser.parse(input_program)

--- a/tests/test_pool_codegen.py
+++ b/tests/test_pool_codegen.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from a816.parse.codegen import code_gen
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.pool import Strategy
 from a816.program import Program
 from a816.symbols import Resolver
@@ -12,7 +12,7 @@ from tests import StubWriter
 
 def _gen(src: str) -> Resolver:
     resolver = Resolver()
-    result = MZParser.parse_as_ast(src, filename="t.s")
+    result = A816Parser.parse_as_ast(src, filename="t.s")
     assert result.parse_error is None
     code_gen(result.nodes, resolver)
     return resolver
@@ -117,7 +117,7 @@ class TestAllocCodegen:
         from a816.parse.nodes import AllocNode
 
         resolver = Resolver()
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             """
             .pool p { range 0x028000 0x0280ff }
             .alloc fn in p {
@@ -183,7 +183,7 @@ class TestRelocateCodegen:
         from a816.parse.nodes import RelocateNode
 
         resolver = Resolver()
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             """
             .pool p { range 0x028000 0x0280ff }
             .relocate fn 0x02c000 0x02c17f into p {
@@ -892,7 +892,7 @@ class TestPoolExpressions:
         from a816.symbols import Resolver
 
         resolver = Resolver()
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             """
             .pool p {
                 range undefined_symbol 0x0280ff
@@ -968,7 +968,7 @@ class TestAllocNodeInternals:
         from a816.parse.nodes import AllocNode
 
         resolver = Resolver()
-        result = MZParser.parse_as_ast(src, filename="t.s")
+        result = A816Parser.parse_as_ast(src, filename="t.s")
         assert result.parse_error is None
         nodes = code_gen(result.nodes, resolver)
         allocs = [n for n in nodes if isinstance(n, AllocNode)]
@@ -1037,7 +1037,7 @@ class TestRelocateNodeInternals:
         from a816.parse.nodes import RelocateNode
 
         resolver = Resolver()
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             """
             .pool p { range 0x028000 0x0280ff }
             .relocate fn 0x02c000 0x02c17f into p {

--- a/tests/test_pool_parse.py
+++ b/tests/test_pool_parse.py
@@ -11,11 +11,11 @@ from a816.parse.ast.nodes import (
     ReclaimAstNode,
     RelocateAstNode,
 )
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 
 
 def _parse(src: str) -> list[AstNode]:
-    result = MZParser.parse_as_ast(src, filename="t.s")
+    result = A816Parser.parse_as_ast(src, filename="t.s")
     assert result.parse_error is None, result.parse_error and result.parse_error.format()
     return result.nodes
 
@@ -57,7 +57,7 @@ class TestPoolDirective:
         assert node.strategy == "order"
 
     def test_empty_pool_is_error(self) -> None:
-        result = MZParser.parse_as_ast(".pool empty {}", filename="t.s")
+        result = A816Parser.parse_as_ast(".pool empty {}", filename="t.s")
         assert result.parse_error is not None
         assert "no ranges" in result.parse_error.message
 
@@ -67,7 +67,7 @@ class TestPoolDirective:
         from a816.symbols import Resolver
 
         resolver = Resolver()
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             ".pool p { range 0x028000 0x028fff fill 0x100 }",
             filename="t.s",
         )
@@ -76,7 +76,7 @@ class TestPoolDirective:
             code_gen(result.nodes, resolver)
 
     def test_unknown_strategy_is_error(self) -> None:
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             ".pool p { range 0x028000 0x028fff strategy bogus }",
             filename="t.s",
         )
@@ -84,7 +84,7 @@ class TestPoolDirective:
         assert "unknown pool strategy" in result.parse_error.message
 
     def test_unknown_attribute_is_error(self) -> None:
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             ".pool p { range 0x028000 0x028fff bogus 1 }",
             filename="t.s",
         )
@@ -119,7 +119,7 @@ class TestAllocDirective:
         assert len(opcodes) == 1
 
     def test_missing_in_keyword_is_error(self) -> None:
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             ".alloc helper bank20 { rts }",
             filename="t.s",
         )
@@ -148,7 +148,7 @@ class TestRelocateDirective:
         assert len(opcodes) == 2
 
     def test_missing_into_keyword_is_error(self) -> None:
-        result = MZParser.parse_as_ast(
+        result = A816Parser.parse_as_ast(
             ".relocate fn 0x02c000 0x02c17f bank02 { rts }",
             filename="t.s",
         )

--- a/tests/test_stellar_errors.py
+++ b/tests/test_stellar_errors.py
@@ -8,7 +8,7 @@ import pytest
 
 from a816.diagnostics.suggest import closest_matches, did_you_mean_hint
 from a816.error_codes import all_codes, lookup
-from a816.parse.mzparser import MZParser
+from a816.parse.mzparser import A816Parser
 from a816.parse.nodes import NodeError
 from a816.program import Program
 from a816.symbols import Resolver
@@ -41,7 +41,7 @@ def test_lookup_known_and_unknown_codes() -> None:
 
 
 def test_parser_error_renders_code_and_hint() -> None:
-    result = MZParser.parse_as_ast(".pool p { range 0x1000 0x1fff bogus 1 }\n", "demo.s")
+    result = A816Parser.parse_as_ast(".pool p { range 0x1000 0x1fff bogus 1 }\n", "demo.s")
     assert result.error is not None
     assert "[E0106]" in result.error
     assert "unknown `.pool` attribute" in result.error
@@ -51,7 +51,7 @@ def test_parser_error_renders_code_and_hint() -> None:
 
 def test_parser_error_includes_context_lines() -> None:
     src = "; line above\n.lalala foo\n; line below\n"
-    result = MZParser.parse_as_ast(src, "ctx.s")
+    result = A816Parser.parse_as_ast(src, "ctx.s")
     assert result.error is not None
     # Above + below should appear in the rendered block.
     assert "; line above" in result.error
@@ -97,7 +97,7 @@ def test_multi_error_collects_top_level_failures() -> None:
 }
 lda.w (0x2100).hp
 """
-    result = MZParser.parse_as_ast(src, "multi.s")
+    result = A816Parser.parse_as_ast(src, "multi.s")
     assert result.parse_errors is not None
     assert len(result.parse_errors) >= 2
     rendered = result.error or ""
@@ -107,7 +107,7 @@ lda.w (0x2100).hp
 
 def test_token_type_label_uses_friendly_name() -> None:
     """Generic expect_token errors no longer leak `TokenType.X` to the user."""
-    result = MZParser.parse_as_ast(".include\n", "missing.s")
+    result = A816Parser.parse_as_ast(".include\n", "missing.s")
     assert result.error is not None
     assert "quoted string" in result.error
     assert "TokenType" not in result.error
@@ -120,7 +120,7 @@ def test_typed_bind_with_equal_shows_code_and_hint() -> None:
 }
 p = 0x100 as Pt
 """
-    result = MZParser.parse_as_ast(src, "tb.s")
+    result = A816Parser.parse_as_ast(src, "tb.s")
     assert result.error is not None
     assert "[E0104]" in result.error
     assert "use `name := expr as T`" in result.error
@@ -135,7 +135,7 @@ def _strip_ansi(s: str) -> str:
 def test_format_error_respects_no_color_env() -> None:
     """With NO_COLOR set, no ANSI escapes leak into the output."""
     src = ".pool p { range 0x1000 0x1fff bogus 1 }\n"
-    result = MZParser.parse_as_ast(src, "nc.s")
+    result = A816Parser.parse_as_ast(src, "nc.s")
     assert result.error is not None
     assert "\x1b[" not in result.error, "ANSI escapes leaked despite NO_COLOR"
     assert _strip_ansi(result.error) == result.error


### PR DESCRIPTION
## Summary

`MZParser` was the lone class breaking the `A816*` / no-prefix
convention used everywhere else in the codebase. Renames it to
`A816Parser`; keeps the old name as a deprecated alias for one alpha
cycle so any external consumer (LSP plugin, ff4-modules, etc.) gets a
grace period.

```python
# Old (still works via alias, will be removed on 1.2.0)
from a816.parse.mzparser import MZParser

# New
from a816.parse.mzparser import A816Parser
```

The module file `a816/parse/mzparser.py` keeps its current name to
avoid breaking import paths — only the class moved.

## Scope

- `a816/parse/mzparser.py` — class rename + `MZParser = A816Parser` alias
- 13 internal callsites updated (program, formatter, fluff_lint, lsp,
  module_builder, codegen, tests)

## Test plan

- [ ] \`hatch run tests:all\` — 979 passing, ruff + mypy strict clean
- [ ] \`scry analyse\` — 0 issues, 88% coverage