### PR TITLE
Unify module file resolution via shared module_loader

### DIFF
--- a/a816/fluff/rules_style.py
+++ b/a816/fluff/rules_style.py
@@ -12,6 +12,7 @@ from a816.fluff.core import (
     Rule,
     flatten_nodes,
 )
+from a816.module_loader import resolve_module
 from a816.parse.ast.nodes import (
     AssignAstNode,
     AstNode,
@@ -28,7 +29,6 @@ from a816.parse.ast.nodes import (
     SymbolAffectationAstNode,
 )
 from a816.parse.mzparser import A816Parser
-from a816.stdlib import resolve_stdlib_module
 
 
 class LineTooLong(Rule):
@@ -114,22 +114,15 @@ def _collect_imported_struct_types(ctx: LintContext) -> set[str]:
 def _resolve_import_for_lint(module_name: str, ctx: LintContext) -> Path | None:
     """Map a `.import` module name to an absolute path.
 
-    Tries the stdlib `@std/...` mapping first, then the lint context's
-    configured `module_paths`, then the document's own directory.
+    Search order (via the shared `module_loader`): stdlib `@std/...`,
+    then the lint context's configured `module_paths`, then the
+    document's own directory.
     """
-    stdlib_path = resolve_stdlib_module(module_name, ".s")
-    if stdlib_path is not None:
-        return stdlib_path
-    candidates: list[Path] = []
+    search_paths: list[Path] = []
     if ctx.module_paths:
-        candidates.extend(ctx.module_paths)
-    candidates.append(ctx.path.parent)
-    file_name = module_name + ".s"
-    for base in candidates:
-        candidate = base / file_name
-        if candidate.exists():
-            return candidate
-    return None
+        search_paths.extend(ctx.module_paths)
+    search_paths.append(ctx.path.parent)
+    return resolve_module(module_name, ".s", search_paths)
 
 
 def _struct_names_in_file(path: Path, seen_paths: set[str]) -> set[str]:
@@ -148,7 +141,7 @@ def _struct_names_in_file(path: Path, seen_paths: set[str]) -> set[str]:
         if isinstance(node, StructAstNode):
             names.add(node.name)
         elif isinstance(node, ImportAstNode):
-            transitive = resolve_stdlib_module(node.module_name, ".s")
+            transitive = resolve_module(node.module_name, ".s", [])
             if transitive is not None:
                 names |= _struct_names_in_file(transitive, seen_paths)
     return names

--- a/a816/lsp/server.py
+++ b/a816/lsp/server.py
@@ -2709,32 +2709,19 @@ class A816LanguageServer:
     def _resolve_module_path(self, module_name: str, current_uri: str) -> str | None:
         """Resolve module name to source file path for .import directives.
 
-        Search order:
-        1. Bundled `@std/...` stdlib module (wheel-relative)
-        2. Same directory as current file
-        3. module_paths configured in a816.toml
+        Search order: stdlib `@std/...` → current file's directory →
+        workspace `module_paths`. Backed by the shared `module_loader`.
         """
         try:
-            stdlib_path = resolve_stdlib_module(module_name, ".s")
-            if stdlib_path is not None:
-                return str(stdlib_path)
+            from a816.module_loader import resolve_module
 
             current_dir = uri_to_path(current_uri).parent
-            module_file = module_name + ".s"
-
-            candidate = (current_dir / module_file).resolve()
-            if candidate.exists():
-                return str(candidate)
-
+            search_paths = [current_dir]
             workspace = self.workspace_index
             if workspace:
-                for search_dir in workspace.module_paths:
-                    workspace_candidate = (search_dir / module_file).resolve()
-                    if workspace_candidate.exists():
-                        return str(workspace_candidate)
-
-            return None
-
+                search_paths.extend(workspace.module_paths)
+            resolved = resolve_module(module_name, ".s", search_paths)
+            return str(resolved.resolve()) if resolved is not None else None
         except (OSError, ValueError) as e:
             logger.debug(f"Error resolving module path '{module_name}' from '{current_uri}': {e}")
             return None

--- a/a816/module_builder.py
+++ b/a816/module_builder.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from a816.program import Program
 
 from a816.linker import Linker
+from a816.module_loader import resolve_module
 from a816.object_file import ObjectFile
 from a816.parse.ast.nodes import (
     AstNode,
@@ -22,7 +23,6 @@ from a816.parse.ast.nodes import (
     ImportAstNode,
 )
 from a816.parse.mzparser import A816Parser
-from a816.stdlib import resolve_stdlib_module
 
 logger = logging.getLogger("a816.module_builder")
 
@@ -166,29 +166,11 @@ class ModuleBuilder:
         return [node.module_name for node in walk(nodes) if isinstance(node, ImportAstNode)]
 
     def _resolve_module_source(self, module_name: str, base_dir: Path) -> Path | None:
-        """Find the source file for a module.
+        """Find the source file for a module via the shared `module_loader`.
 
-        Args:
-            module_name: The module name (e.g., "vwf" or "battle/sram",
-              or `@std/snes/ppu` for bundled stdlib).
-            base_dir: The directory of the importing file
-
-        Returns:
-            Path to the source file, or None if not found.
+        Search order: stdlib `@std/...` → `base_dir` → configured `module_paths`.
         """
-        stdlib_path = resolve_stdlib_module(module_name, ".s")
-        if stdlib_path is not None:
-            return stdlib_path
-
-        search_paths = [base_dir] + self.module_paths
-        module_file = module_name + ".s"
-
-        for search_path in search_paths:
-            candidate = search_path / module_file
-            if candidate.exists():
-                return candidate
-
-        return None
+        return resolve_module(module_name, ".s", [base_dir, *self.module_paths])
 
     def _needs_recompilation(self, module_name: str) -> bool:
         """Check if a module needs to be recompiled.

--- a/a816/module_loader.py
+++ b/a816/module_loader.py
@@ -1,0 +1,39 @@
+"""Single source of truth for `.import` module file resolution.
+
+Search order (highest precedence first):
+1. Bundled `@std/...` stdlib mapping
+2. Each `search_paths` directory in declared order
+
+Used by codegen (resolves `.import` at AST→Node time), module_builder
+(resolves dependencies during the build pipeline), the LSP server
+(go-to-definition for `.import` targets), and fluff lint S001 (follows
+`.import` chains to discover cross-module struct names).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from a816.stdlib import resolve_stdlib_module
+
+
+def resolve_module(module_name: str, extension: str, search_paths: list[Path]) -> Path | None:
+    """Locate a module's source / object file.
+
+    `module_name` may contain `/` (e.g. "battle/sram"). Tries the stdlib
+    `@std/...` mapping first; on miss, joins `module_name + extension`
+    against each search path and returns the first existing candidate.
+
+    Returns the raw join (no `.resolve()`); callers that need a canonical
+    path should call `.resolve()` themselves.
+    """
+    stdlib_path = resolve_stdlib_module(module_name, extension)
+    if stdlib_path is not None:
+        return stdlib_path
+
+    module_file = module_name + extension
+    for search_path in search_paths:
+        candidate = search_path / module_file
+        if candidate.exists():
+            return candidate
+    return None

--- a/a816/parse/codegen/modules.py
+++ b/a816/parse/codegen/modules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from a816.module_loader import resolve_module
 from a816.parse.ast.nodes import (
     AssignAstNode,
     AstNode,
@@ -16,7 +17,6 @@ from a816.parse.ast.nodes import (
 from a816.parse.codegen.base import GenNodes, MacroDefinitions, _code_gen, generators, logger
 from a816.parse.nodes import ExternNode, LinkedModuleNode, NodeError
 from a816.parse.tokens import Token
-from a816.stdlib import resolve_stdlib_module as _resolve_stdlib_module
 from a816.symbols import Resolver
 
 
@@ -96,13 +96,13 @@ def generate_import(
     direct_mode = resolver.context.is_direct_mode and not resolver.context.is_object_mode
     search_paths = _import_search_paths(resolver, file_info)
 
-    obj_path = _resolve_stdlib_module(module_name, ".o") or _resolve_module_path(module_name, ".o", search_paths)
+    obj_path = resolve_module(module_name, ".o", search_paths)
     if obj_path:
         nodes = _import_from_object(module_name, obj_path, resolver, direct_mode)
         if nodes is not None:
             return nodes
 
-    src_path = _resolve_stdlib_module(module_name, ".s") or _resolve_module_path(module_name, ".s", search_paths)
+    src_path = resolve_module(module_name, ".s", search_paths)
     if src_path:
         if direct_mode:
             key = _canonical(src_path)
@@ -115,28 +115,6 @@ def generate_import(
             return nodes
 
     raise NodeError(f'Module not found: "{module_name}"', file_info)
-
-
-def _resolve_module_path(module_name: str, extension: str, search_paths: list[Path]) -> Path | None:
-    """Resolve a module name to a file path.
-
-    Args:
-        module_name: The module name (e.g., "vwf" or "battle/sram")
-        extension: File extension to try (e.g., ".o" or ".s")
-        search_paths: List of directories to search
-
-    Returns:
-        Path to the module file if found, None otherwise
-    """
-    # Module name can contain path separators (e.g., "battle/sram")
-    module_file = module_name + extension
-
-    for search_path in search_paths:
-        candidate = search_path / module_file
-        if candidate.exists():
-            return candidate
-
-    return None
 
 
 def _extract_public_symbols_from_source(source_path: Path) -> list[str]:


### PR DESCRIPTION
## Summary
Four call sites were running the same `.import` path-resolution dance — stdlib `@std/...` first, then a list of search paths, file by `module_name + extension`:

- `a816/parse/codegen/modules.py::_resolve_module_path`
- `a816/module_builder.py::ModuleBuilder._resolve_module_source`
- `a816/lsp/server.py::A816LanguageServer._resolve_module_path`
- `a816/fluff/rules_style.py::_resolve_import_for_lint`

Each had subtle drift — different fallback orders, one called `.resolve()` and others didn't, the LSP one inlined the loop. Extract a single `a816/module_loader.py::resolve_module(name, ext, search_paths) -> Path | None` and route every site through it. Net -21 lines.

The four call sites still own how they assemble their search-path list (each has a different idea of "where the importer lives"), but the algorithm itself is no longer duplicated.

## Test plan
- [ ] `hatch run tests:all` — 1010 passed, ruff clean, mypy strict (147 files) clean
- [ ] `scry analyse` — gate green (cov 88.0%, 0 issues, 0 dup, complexity 3197)
- [ ] LSP go-to-definition on `.import` targets still works
- [ ] `a816 fluff check` still resolves `.import` chains for S001