### PR TITLE
Harden xobj inspector + module-graph test assertions

### DIFF
--- a/a816/xobj.py
+++ b/a816/xobj.py
@@ -255,7 +255,7 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="xobj",
         description="Inspect a816 .o object files.",
     )
-    p.add_argument("files", nargs="+", type=Path, help="object file(s)")
+    p.add_argument("paths", nargs="+", type=Path, help="object file(s)")
     p.add_argument("--summary", action="store_true", help="high-level counts (default)")
     p.add_argument("--sections", action="store_true", help="section table")
     p.add_argument("--bytes", type=int, default=0, metavar="N", help="dump first N bytes of each section")
@@ -331,25 +331,25 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     out = sys.stdout
 
-    for path in args.files:
+    for path in args.paths:
         if not path.exists():
             print(f"xobj: file not found: {path}", file=sys.stderr)
             return 2
 
     if args.diff:
-        if len(args.files) != 2:
+        if len(args.paths) != 2:
             print("xobj: --diff requires exactly two files", file=sys.stderr)
             return 2
         try:
-            obj_a = _load_tolerant(args.files[0], sys.stderr)
-            obj_b = _load_tolerant(args.files[1], sys.stderr)
+            obj_a = _load_tolerant(args.paths[0], sys.stderr)
+            obj_b = _load_tolerant(args.paths[1], sys.stderr)
         except ValueError as exc:
             print(f"xobj: {exc}", file=sys.stderr)
             return 2
-        print_diff(args.files[0], args.files[1], obj_a, obj_b, out)
+        print_diff(args.paths[0], args.paths[1], obj_a, obj_b, out)
         return 0
 
-    for i, path in enumerate(args.files):
+    for i, path in enumerate(args.paths):
         try:
             obj = _load_tolerant(path, sys.stderr)
         except ValueError as exc:

--- a/tests/test_module_builder.py
+++ b/tests/test_module_builder.py
@@ -71,6 +71,63 @@ class TestModuleGraph:
         assert order.index("a") < order.index("main")
         assert order.index("b") < order.index("main")
 
+    def test_self_loop_raises_error(self) -> None:
+        """A module that imports itself is a degenerate circular cycle."""
+        graph = ModuleGraph()
+        graph.add_module("self_ref", Path("self_ref.s"))
+        graph.add_dependency("self_ref", "self_ref")
+
+        with pytest.raises(ValueError, match="Circular dependency"):
+            graph.topological_sort()
+
+    def test_unknown_dependency_skipped(self) -> None:
+        """Dependencies on modules that aren't registered in the graph
+        are silently skipped — they're typically stdlib or extern-only
+        targets resolved separately by the linker."""
+        graph = ModuleGraph()
+        graph.add_module("main", Path("main.s"))
+        graph.add_dependency("main", "@std/snes/ppu")  # not added
+
+        order = graph.topological_sort()
+        assert order == ["main"]
+
+    def test_topological_sort_is_deterministic(self) -> None:
+        """Same inputs should produce the same order across runs so
+        incremental rebuilds key stably on the compile sequence."""
+        graph = ModuleGraph()
+        for name in ("main", "a", "b", "c"):
+            graph.add_module(name, Path(f"{name}.s"))
+        graph.add_dependency("main", "a")
+        graph.add_dependency("main", "b")
+        graph.add_dependency("a", "c")
+        graph.add_dependency("b", "c")
+
+        first = graph.topological_sort()
+        second = graph.topological_sort()
+        assert first == second
+
+    def test_disconnected_modules_all_appear(self) -> None:
+        """Modules with no dependency edges still land in the sort
+        output (else they'd silently drop from the build)."""
+        graph = ModuleGraph()
+        graph.add_module("orphan_a", Path("a.s"))
+        graph.add_module("orphan_b", Path("b.s"))
+
+        order = graph.topological_sort()
+        assert sorted(order) == ["orphan_a", "orphan_b"]
+
+    def test_indirect_circular_dependency_raises(self) -> None:
+        """Three-node cycle (a → b → c → a)."""
+        graph = ModuleGraph()
+        for name in ("a", "b", "c"):
+            graph.add_module(name, Path(f"{name}.s"))
+        graph.add_dependency("a", "b")
+        graph.add_dependency("b", "c")
+        graph.add_dependency("c", "a")
+
+        with pytest.raises(ValueError, match="Circular dependency"):
+            graph.topological_sort()
+
     def test_circular_dependency_raises_error(self) -> None:
         """Test that circular dependencies are detected."""
         graph = ModuleGraph()

--- a/tests/test_xobj.py
+++ b/tests/test_xobj.py
@@ -99,3 +99,95 @@ def test_diff_two_files(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
     assert "sections:" in captured.out
     assert "$008000" in captured.out
     assert "$018000" in captured.out
+
+
+def test_lines_table_listed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`--lines` walks each section's debug-line table and prints the
+    `(file:line:col)` per source-mapped byte. The fixture maps offset
+    0 of the first section to fixture.s:12:4."""
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--lines"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "fixture.s" in out
+    assert "12" in out
+
+
+def test_files_table_listed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`--files` enumerates the debug-info file table; fixture.s is
+    the only entry registered."""
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--files"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "fixture.s" in out
+
+
+def test_aliases_section_listed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Aliases (deferred constant bindings) round-trip through `--aliases`."""
+    section = Section.anonymous_pinned(base_address=0x008000, code=b"\xea")
+    obj = ObjectFile([section], [], aliases=[("font_ptr", "target + 0x40")])
+    obj.write(str(tmp_path / "fix.o"))
+    rc = main([str(tmp_path / "fix.o"), "--aliases"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "font_ptr" in out
+    assert "target + 0x40" in out
+
+
+def test_all_includes_every_section(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`--all` is a convenience for sections + symbols + relocs + lines
+    + files + aliases at once. Single fixture exercising the union."""
+    p = _make_fixture(tmp_path / "fix.o")
+    rc = main([str(p), "--all"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # Each subsection's header (or representative content) shows up.
+    assert "[0] base=" in out
+    assert "foo" in out  # symbol
+    assert "ext_sym" in out  # relocation
+    assert "fixture.s" in out  # debug line / file
+
+
+def test_bytes_dump_prefix(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`--bytes N` prepends a hex dump of the first N bytes per section."""
+    section = Section.anonymous_pinned(base_address=0x008000, code=bytes(range(32)))
+    ObjectFile([section], []).write(str(tmp_path / "fix.o"))
+    rc = main([str(tmp_path / "fix.o"), "--sections", "--bytes", "8"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # Eight bytes from `bytes(range(32))` — 00..07 — in the dump.
+    assert "00 01 02 03 04 05 06 07" in out
+
+
+def test_diff_marks_size_change(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Sections sharing a base but differing in size are flagged `!`
+    by the diff renderer."""
+    section_a = Section.anonymous_pinned(base_address=0x008000, code=b"\xea\xea")
+    section_b = Section.anonymous_pinned(base_address=0x008000, code=b"\xea\xea\xea")
+    ObjectFile([section_a], []).write(str(tmp_path / "a.o"))
+    ObjectFile([section_b], []).write(str(tmp_path / "b.o"))
+    rc = main([str(tmp_path / "a.o"), str(tmp_path / "b.o"), "--diff"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # Output marks the differing section row, naming both byte counts.
+    assert "! section" in out
+    assert "size 2 -> 3" in out
+
+
+def test_diff_handles_added_and_removed_sections(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A second section in B (none in A) shows up as `+`, and vice
+    versa as `-`."""
+    section_only_in_b = Section.anonymous_pinned(base_address=0x028000, code=b"\xea")
+    ObjectFile([], []).write(str(tmp_path / "a.o"))
+    ObjectFile([section_only_in_b], []).write(str(tmp_path / "b.o"))
+    rc = main([str(tmp_path / "a.o"), str(tmp_path / "b.o"), "--diff"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "+ section[0] only in B" in out
+
+    # Reverse direction.
+    rc = main([str(tmp_path / "b.o"), str(tmp_path / "a.o"), "--diff"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "- section[0] only in A" in out


### PR DESCRIPTION
## Summary

Two outstanding test-assertion tickets (#63, #64) plus the bug surfaced while writing them.

### xobj inspector (#63)

- Added coverage for previously-untested CLI surfaces: `--lines`, `--files`, `--aliases`, `--all`, `--bytes N`.
- Diff renderer: assertions for size-mismatch (`!`), only-in-A (`-`), only-in-B (`+`) cases.
- **Bug found**: positional `files` collided with the `--files` flag — argparse stored the flag's bool over the positional list, breaking `xobj --files foo.o`. Renamed positional to `paths`. Internal-only surface change; CLI invocation unchanged.

### ModuleGraph (#64)

Edge cases the previous suite didn't pin down:

- Self-loop (`a → a`) raises.
- Three-node indirect cycle (`a → b → c → a`) raises.
- Dependencies on unregistered modules (typical for stdlib / extern-only targets) are silently skipped.
- Topological sort is deterministic across runs.
- Disconnected orphan modules still appear in the output.

## Test plan

- [x] 1093 unit + 4 integration pass
- [x] mypy + ruff clean
- [x] scry: 0 issues, coverage holds at 88.5%