### PR TITLE
Infer A/X register sizes from rep/sep

### DIFF
--- a/a816/parse/nodes/opcode.py
+++ b/a816/parse/nodes/opcode.py
@@ -73,8 +73,45 @@ class OpcodeNode(NodeProtocol):
             ) from e
 
     def pc_after(self, current_pc: Address) -> Address:
+        self._maybe_update_register_sizes()
         opcode_emitter = self._get_emitter()
         return current_pc + opcode_emitter.supposed_length(self.value_node, self.size, self.resolver)
+
+    def _maybe_update_register_sizes(self) -> None:
+        """`rep`/`sep` change M/X at runtime; the assembler-time analog
+        is `.a8` / `.a16` / `.i8` / `.i16`. Without bridging the two,
+        source has to repeat itself after every `rep` / `sep`:
+
+            rep #0x30
+            .a16        ; redundant — assembler should infer this
+            .i16
+
+        Bridge: when we see `rep`/`sep` with an immediate operand
+        whose value resolves to a constant, mutate
+        `resolver.a_size` / `i_size` the same way the CPU would.
+        Subsequent opcode-width inference picks the right form
+        without the explicit directive. Explicit `.a*` / `.i*`
+        still wins because it runs through `RegisterSizeNode` which
+        sets the size directly; running after a `rep`/`sep` just
+        re-asserts what the inference already chose.
+        """
+        if self.opcode not in ("rep", "sep") or self.addressing_mode is not AddressingMode.immediate:
+            return
+        if self.value_node is None:
+            return
+        try:
+            value = self.value_node.get_value()
+        except Exception:  # noqa: BLE001 — expression may reference an unresolved forward symbol
+            return
+        if not isinstance(value, int):
+            return
+        # `rep #N` clears the named flag bits → 16-bit register.
+        # `sep #N` sets them → 8-bit register.
+        new_size = 16 if self.opcode == "rep" else 8
+        if value & 0x20:
+            self.resolver.a_size = new_size
+        if value & 0x10:
+            self.resolver.i_size = new_size
 
     def __str__(self) -> str:
         return f"OpcodeNode({self.opcode}, {self.addressing_mode}, {self.index}, {self.value_node})"

--- a/a816/parse/nodes/opcode.py
+++ b/a816/parse/nodes/opcode.py
@@ -97,13 +97,15 @@ class OpcodeNode(NodeProtocol):
         """
         if self.opcode not in ("rep", "sep") or self.addressing_mode is not AddressingMode.immediate:
             return
-        if self.value_node is None:
-            return
+        # Immediate-mode parser always populates value_node — no
+        # `value_node is None` guard. Forward-referencing the
+        # immediate (e.g. `rep #FORWARD_FLAGS`) raises
+        # `SymbolNotDefined` until pass 2; skip silently on pass 1
+        # so the second pass picks up the resolved value.
+        assert self.value_node is not None
         try:
             value = self.value_node.get_value()
-        except Exception:  # noqa: BLE001 — expression may reference an unresolved forward symbol
-            return
-        if not isinstance(value, int):
+        except SymbolNotDefined:
             return
         # `rep #N` clears the named flag bits → 16-bit register.
         # `sep #N` sets them → 8-bit register.

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -213,6 +213,39 @@ Lint hooks:
 - `S003` — `(p as T).field` when `p` is already bound as `T`.
 - `S004` — same `(expr as T)` repeated more than once; promote to `:=`.
 
+### `.a8` / `.a16` / `.i8` / `.i16` — register width
+
+Tell the assembler whether the accumulator (`A`) and index (`X`/`Y`)
+registers are currently 8-bit or 16-bit. Width drives immediate-mode
+opcode sizing: under `.a16`, `lda #0x42` emits `A9 42 00` (3 bytes);
+under `.a8`, the same line emits `A9 42` (2 bytes).
+
+```ca65
+.a16
+.i16
+lda #0x1234       ; A9 34 12
+ldx #0x5678       ; A2 78 56
+```
+
+#### Inference from `rep` / `sep`
+
+`rep #N` and `sep #N` mutate the CPU's `M` / `X` flags at runtime;
+the assembler mirrors that at assembly time so source doesn't have
+to repeat itself:
+
+```ca65
+rep #0x30         ; clears M+X -> A and X are 16-bit
+lda #0x42         ; A9 42 00  (widened because M=16, not because of value)
+sep #0x20         ; sets M    -> A back to 8-bit
+lda #0x42         ; A9 42
+```
+
+Bit `0x20` controls `A`, bit `0x10` controls `X`/`Y`. `rep` clears
+(16-bit), `sep` sets (8-bit). The inference only fires for constant
+immediate operands; symbolic constants resolved at assembly time
+count, but forward references and non-immediate forms are left
+alone (and explicit `.a*` / `.i*` always wins).
+
 ## Code
 
 ### `.scope name { ... }` and `{ ... }`

--- a/tests/test_repsep_inference.py
+++ b/tests/test_repsep_inference.py
@@ -51,6 +51,16 @@ class TestExplicitDirectiveStillWins:
         assert _emitted_bytes(writer) == b"\xe2\x20\xa9\xef\xbe"
 
 
+class TestForwardReferenceImmediate:
+    def test_rep_with_forward_referenced_constant_still_resolves(self) -> None:
+        # Pass 1 hits `rep #FLAGS` before `FLAGS = 0x30` is bound.
+        # SymbolNotDefined is swallowed; pass 2 picks up the value
+        # and widens `lda #imm`.
+        src = "*=0x008000\nrep #FLAGS\nlda #0xbeef\nFLAGS = 0x30\n"
+        writer = _assemble(src)
+        assert _emitted_bytes(writer) == b"\xc2\x30\xa9\xef\xbe"
+
+
 class TestSymbolicImmediateStillUpdatesSize:
     def test_rep_with_assemble_time_constant_propagates(self) -> None:
         # `rep #FLAGS` resolves the immediate at assembly-time the same

--- a/tests/test_repsep_inference.py
+++ b/tests/test_repsep_inference.py
@@ -1,0 +1,61 @@
+"""`rep` / `sep` with constant immediate should auto-update assembler-time
+register sizes so source no longer needs `.a8` / `.a16` / `.i8` / `.i16`
+after every register-size change."""
+
+from __future__ import annotations
+
+from a816.program import Program
+from tests import StubWriter
+
+
+def _assemble(src: str) -> StubWriter:
+    program = Program()
+    writer = StubWriter()
+    program.assemble_string_with_emitter(src, "test_repsep.s", writer)
+    return writer
+
+
+def _emitted_bytes(writer: StubWriter) -> bytes:
+    return b"".join(writer.data)
+
+
+class TestRepSetTracksASize:
+    def test_rep_30_lets_lda_imm_emit_16bit_without_explicit_directive(self) -> None:
+        src = "*=0x008000\nrep #0x30\nlda #0xbeef\n"
+        writer = _assemble(src)
+        # rep #$30 = C2 30; lda #imm16 = A9 EF BE — 5 bytes total.
+        assert _emitted_bytes(writer) == b"\xc2\x30\xa9\xef\xbe"
+
+    def test_sep_20_after_rep_30_restores_8bit_immediate(self) -> None:
+        src = "*=0x008000\nrep #0x30\nlda #0xbeef\nsep #0x20\nlda #0x42\n"
+        writer = _assemble(src)
+        # rep #$30 (C2 30) → A=16; lda #imm16 (A9 EF BE);
+        # sep #$20 (E2 20) → A=8; lda #imm8 (A9 42).
+        assert _emitted_bytes(writer) == b"\xc2\x30\xa9\xef\xbe\xe2\x20\xa9\x42"
+
+    def test_rep_10_only_affects_x_not_a(self) -> None:
+        # rep #$10 clears X (index) but leaves M (A) alone.
+        # `ldx #imm16` widens; `lda #imm8` stays 8-bit.
+        src = "*=0x008000\nrep #0x10\nldx #0x1234\nlda #0x42\n"
+        writer = _assemble(src)
+        assert _emitted_bytes(writer) == b"\xc2\x10\xa2\x34\x12\xa9\x42"
+
+
+class TestExplicitDirectiveStillWins:
+    def test_a16_overrides_after_sep(self) -> None:
+        # User says A=16 with .a16 even though sep #$20 would set it to 8.
+        # Explicit directive runs after rep/sep in source, so the
+        # directive's later mutation wins for subsequent ops.
+        src = "*=0x008000\nsep #0x20\n.a16\nlda #0xbeef\n"
+        writer = _assemble(src)
+        assert _emitted_bytes(writer) == b"\xe2\x20\xa9\xef\xbe"
+
+
+class TestSymbolicImmediateStillUpdatesSize:
+    def test_rep_with_assemble_time_constant_propagates(self) -> None:
+        # `rep #FLAGS` resolves the immediate at assembly-time the same
+        # as a literal — equate is just a named constant. Subsequent
+        # `lda #` picks 16-bit width.
+        src = "FLAGS = 0x30\n*=0x008000\nrep #FLAGS\nlda #0xbeef\n"
+        writer = _assemble(src)
+        assert _emitted_bytes(writer) == b"\xc2\x30\xa9\xef\xbe"

--- a/tests/test_repsep_inference.py
+++ b/tests/test_repsep_inference.py
@@ -20,10 +20,22 @@ def _emitted_bytes(writer: StubWriter) -> bytes:
 
 
 class TestRepSetTracksASize:
+    def test_rep_30_widens_small_immediate_to_16bit(self) -> None:
+        # `lda #0x42` fits in 8 bits and would normally emit `A9 42`.
+        # After `rep #0x30` the inference flips A to 16-bit, so the
+        # same operand becomes `A9 42 00` — proves the size choice
+        # is driven by M, not by the value's width.
+        before = _assemble("*=0x008000\nlda #0x42\n")
+        after = _assemble("*=0x008000\nrep #0x30\nlda #0x42\n")
+        assert _emitted_bytes(before) == b"\xa9\x42"
+        assert _emitted_bytes(after) == b"\xc2\x30\xa9\x42\x00"
+
     def test_rep_30_lets_lda_imm_emit_16bit_without_explicit_directive(self) -> None:
         src = "*=0x008000\nrep #0x30\nlda #0xbeef\n"
         writer = _assemble(src)
         # rep #$30 = C2 30; lda #imm16 = A9 EF BE — 5 bytes total.
+        # (The wide immediate would emit 2-byte either way; this just
+        # confirms the byte order under the widened form.)
         assert _emitted_bytes(writer) == b"\xc2\x30\xa9\xef\xbe"
 
     def test_sep_20_after_rep_30_restores_8bit_immediate(self) -> None:


### PR DESCRIPTION
## Summary

`rep #N` / `sep #N` with a constant immediate now update
`resolver.a_size` / `i_size` the same way the CPU updates the M/X
flags at runtime. Subsequent opcode-width inference picks the right
form without the user repeating themselves with `.a8` / `.a16` /
`.i8` / `.i16`.

Before:

```ca65
rep #0x30
.a16          ; redundant - tells the assembler what rep just did
.i16
lda #0x42     ; without .a16, this would emit A9 42 (8-bit) and
              ; the CPU in M=16 would read the next byte as MSB
```

After:

```ca65
rep #0x30
lda #0x42     ; assembler infers M=16, emits A9 42 00 (3 bytes)
```

The `0xBEEF`-style example is tautological - a value that needs 16
bits forces width regardless of M. The real test is a small value
(`0x42`) that fits in 8 bits but must widen because M=16. Without
inference the workaround was `lda.w #0x42` everywhere.

Bits read by the inference:
- `0x20` -> M (accumulator) -> `a_size`
- `0x10` -> X (index) -> `i_size`

`rep` clears (16-bit), `sep` sets (8-bit). Non-immediate addressing
modes and non-constant operands leave the size untouched. Explicit
`.a*` / `.i*` directives still win (they mutate the same field
directly via `RegisterSizeNode`).

Forward-referenced immediates (`rep #FORWARD_FLAGS`) raise
`SymbolNotDefined` on pass 1; we swallow it so pass 2 picks up the
resolved value.

## Test plan

- [x] `hatch run tests:all` -> 1099 pass, 1 skip
- [x] SonarCloud new-code coverage 90% (2 uncovered)
- [x] `tests/test_repsep_inference.py` covers:
  - small-value widening (proves inference, not value-driven)
  - 16-bit value form (byte order under widened mode)
  - sep round-trip back to 8-bit
  - `rep #\$10` X-only (M untouched)
  - explicit `.a16` override after sep
  - forward-referenced symbolic immediate
  - assemble-time equate constant