### PR TITLE
Quiet error logs by default; --verbose surfaces traceback

### DIFF
--- a/a816/cli.py
+++ b/a816/cli.py
@@ -249,8 +249,11 @@ def _run_assemble(args: argparse.Namespace) -> int:
 
 def cli_main() -> None:
     """a816 CLI entry. Exit 0 success, 1 assembly/link error, -1 invalid input."""
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
     argv = sys.argv[1:]
+    # `--verbose` flips root logger to DEBUG so caught NodeError/IPS/etc.
+    # paths emit their stashed traceback via `logger.debug(exc_info=True)`.
+    level = logging.DEBUG if "--verbose" in argv else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s - %(message)s")
     try:
         rc = _dispatch_subcommand(argv)
         if rc is not None:

--- a/a816/module_builder.py
+++ b/a816/module_builder.py
@@ -156,7 +156,8 @@ class ModuleBuilder:
                     logger.warning(f"Could not find source for module '{import_name}'")
 
         except OSError as e:
-            logger.exception(f"Error reading {source_path}: {e}")
+            logger.error(f"Error reading {source_path}: {e}")  # NOSONAR python:S8572
+            logger.debug("Source read traceback", exc_info=True)
             raise
 
     def _collect_imports(self, nodes: list[AstNode]) -> list[str]:
@@ -364,7 +365,8 @@ def build_with_imports(
         return BuildResult(exit_code=exit_code, symbol_map=symbol_map, program=program)
 
     except Exception as e:
-        logger.exception(f"Build failed: {e}")
+        logger.error(f"Build failed: {e}")  # NOSONAR python:S8572
+        logger.debug("Build traceback", exc_info=True)
         return BuildResult(exit_code=1, diagnostics=[str(e)])
 
 
@@ -530,5 +532,6 @@ def build_with_imports_direct(
         )
 
     except Exception as e:
-        logger.exception(f"Build failed: {e}")
+        logger.error(f"Build failed: {e}")  # NOSONAR python:S8572
+        logger.debug("Build traceback", exc_info=True)
         return BuildResult(exit_code=1, diagnostics=[str(e)])

--- a/a816/program/assemble.py
+++ b/a816/program/assemble.py
@@ -112,10 +112,12 @@ class AssembleMixin:
                     # `logger.error` (not `logger.exception`) is intentional.
                     logger.error(str(e))  # NOSONAR python:S8572
                     return 128
-                except NodeError:
-                    # Codegen failure: include the traceback — these can
-                    # surface internal bugs the user should report.
-                    logger.exception("Codegen failed")
+                except NodeError as e:
+                    # NodeError already carries source location + hint;
+                    # surface that as the user-facing line, keep the
+                    # traceback at debug for postmortem.
+                    logger.error(str(e))  # NOSONAR python:S8572
+                    logger.debug("Codegen failure traceback", exc_info=True)
                     return 128
                 except OverlapError as e:
                     # Section-overlap = hard error since the default flip
@@ -229,7 +231,8 @@ class AssembleMixin:
 
                 self.emit_with_relocations(nodes, object_writer)
             except NodeError as e:
-                logger.exception(str(e))
+                logger.error(str(e))  # NOSONAR python:S8572
+                logger.debug("Object emit failure traceback", exc_info=True)
                 return -1
         except RuntimeError as e:
             self.logger.exception(_ASSEMBLY_FAILED_MSG, e)

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -398,7 +398,8 @@ def _apply_ips_to_temp(input_file: Path, ips_file: Path) -> tuple[Path, Path]:
         logger.info(f"Applying IPS patch: {ips_file}")
         apply_ips_patch(input_file, ips_file, tmp_path)
     except ValueError as e:
-        logger.exception(str(e))
+        logger.error(str(e))  # NOSONAR python:S8572
+        logger.debug("IPS apply traceback", exc_info=True)
         sys.exit(-1)
     return tmp_path, tmp_path
 

--- a/tests/test_quiet_error_logs.py
+++ b/tests/test_quiet_error_logs.py
@@ -1,0 +1,121 @@
+"""Caught-error paths log a clean message at ERROR and stash the
+Python traceback at DEBUG. Default CLI log level shows the message
+only; `--verbose` flips to DEBUG and the traceback comes back."""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from a816.module_builder import build_with_imports
+from a816.program import Program
+from a816.writers import ObjectWriter
+
+
+def _write(src: str, name: str = "main.s") -> tuple[Path, Path]:
+    tmp = Path(tempfile.mkdtemp())
+    path = tmp / name
+    path.write_text(src, encoding="utf-8")
+    return tmp, path
+
+
+def test_object_emit_nodeerror_logs_error_not_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # `nop #0x00` raises NodeError during emit (nop has no immediate
+    # addressing). We want: ERROR with the message, DEBUG with the
+    # stashed traceback, no exception bubbling.
+    tmp, asm = _write("nop #0x00\n")
+    obj = tmp / "out.o"
+    writer = ObjectWriter(str(obj))
+    writer.begin()
+    with caplog.at_level(logging.DEBUG):
+        rc = Program().assemble_with_object_emitter(str(asm), writer)
+    assert rc == -1
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    debug_traces = [r for r in caplog.records if r.levelno == logging.DEBUG and "traceback" in r.message.lower()]
+    assert error_records, "expected an ERROR-level diagnostic"
+    assert debug_traces, "expected the traceback stashed at DEBUG"
+    # The DEBUG record carries exc_info (the actual traceback).
+    assert debug_traces[0].exc_info is not None
+
+
+def test_module_builder_failure_demotes_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Module with a codegen error -> build_with_imports catches the
+    # RuntimeError, logs the user-facing message at ERROR, traceback
+    # at DEBUG.
+    tmp, main = _write("nop #0x00\n")
+    with caplog.at_level(logging.DEBUG):
+        result = build_with_imports(main, tmp / "out.ips", output_dir=tmp / "build")
+    assert result.exit_code != 0
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    debug_traces = [r for r in caplog.records if r.levelno == logging.DEBUG and "traceback" in r.message.lower()]
+    assert error_records
+    assert debug_traces
+    assert debug_traces[0].exc_info is not None
+
+
+def test_module_builder_failure_quiet_at_info_level(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # At INFO level (CLI default), the DEBUG traceback record does
+    # not appear. The user only sees the rendered error.
+    tmp, main = _write("nop #0x00\n")
+    with caplog.at_level(logging.INFO):
+        build_with_imports(main, tmp / "out.ips", output_dir=tmp / "build")
+    traceback_records = [r for r in caplog.records if "traceback" in r.message.lower()]
+    assert traceback_records == [], "no traceback should appear at INFO level"
+
+
+def test_ips_apply_value_error_demotes_traceback(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    from a816.xdds import _apply_ips_to_temp
+
+    rom = tmp_path / "rom.sfc"
+    rom.write_bytes(b"\x00" * 0x10000)
+    bad_ips = tmp_path / "bad.ips"
+    bad_ips.write_bytes(b"not-an-ips-file")
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(SystemExit):
+            _apply_ips_to_temp(rom, bad_ips)
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    debug_traces = [r for r in caplog.records if r.levelno == logging.DEBUG and "traceback" in r.message.lower()]
+    assert error_records
+    assert debug_traces
+    assert debug_traces[0].exc_info is not None
+
+
+def test_verbose_flag_enables_debug_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `--verbose` in argv flips logging.basicConfig to DEBUG so the
+    # stashed tracebacks become visible. We don't fully run cli_main
+    # (it would call sys.exit); just verify the level-selection logic.
+    import sys
+
+    from a816 import cli
+
+    captured: dict[str, int] = {}
+
+    def fake_basic_config(**kwargs: object) -> None:
+        level = kwargs["level"]
+        assert isinstance(level, int)
+        captured["level"] = level
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+    monkeypatch.setattr(sys, "argv", ["a816", "--verbose", "--help"])
+    monkeypatch.setattr(cli, "_dispatch_subcommand", lambda _argv: 0)
+    with pytest.raises(SystemExit):
+        cli.cli_main()
+    assert captured["level"] == logging.DEBUG
+
+    captured.clear()
+    monkeypatch.setattr(sys, "argv", ["a816", "--help"])
+    with pytest.raises(SystemExit):
+        cli.cli_main()
+    assert captured["level"] == logging.INFO

--- a/tests/test_quiet_error_logs.py
+++ b/tests/test_quiet_error_logs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from a816.module_builder import build_with_imports
+from a816.module_builder import build_with_imports, build_with_imports_direct
 from a816.program import Program
 from a816.writers import ObjectWriter
 
@@ -70,6 +70,48 @@ def test_module_builder_failure_quiet_at_info_level(
         build_with_imports(main, tmp / "out.ips", output_dir=tmp / "build")
     traceback_records = [r for r in caplog.records if "traceback" in r.message.lower()]
     assert traceback_records == [], "no traceback should appear at INFO level"
+
+
+def test_module_builder_direct_failure_demotes_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Direct-mode (position-dependent) build path has its own
+    # top-level except. Same demotion behavior expected.
+    tmp, main = _write("*=0x008000\nnop #0x00\n")
+    with caplog.at_level(logging.DEBUG):
+        result = build_with_imports_direct(main, tmp / "out.ips", output_dir=tmp / "build")
+    assert result.exit_code != 0
+    debug_traces = [r for r in caplog.records if r.levelno == logging.DEBUG and "traceback" in r.message.lower()]
+    assert debug_traces
+    assert debug_traces[0].exc_info is not None
+
+
+def test_discover_imports_oserror_demotes_traceback(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `_discover_imports_recursive` opens source files to scan for
+    # nested .imports. Patch Path.read_text to raise PermissionError
+    # mid-walk to exercise the OSError handler.
+    from a816 import module_builder
+
+    tmp, main = _write("*=0x008000\nnop\n")
+
+    original_read = Path.read_text
+
+    def fake_read(self: Path, *a: object, **kw: object) -> str:
+        if self == main:
+            raise PermissionError(f"denied: {self}")
+        return original_read(self, *a, **kw)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", fake_read)
+    builder = module_builder.ModuleBuilder(output_dir=tmp / "build")
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(OSError):
+            builder._discover_imports_recursive(main, "__main__")
+    debug_traces = [r for r in caplog.records if r.levelno == logging.DEBUG and "traceback" in r.message.lower()]
+    assert debug_traces
+    assert debug_traces[0].exc_info is not None
 
 
 def test_ips_apply_value_error_demotes_traceback(


### PR DESCRIPTION
## Summary

Caught-error paths (NodeError, AssemblyError, OverlapError,
OSError on source read, IPS apply ValueError, module-builder
top-level failures) already render a nice diagnostic with
source location + caret + hint. Pairing that with a full Python
traceback buries the signal under irrelevant frames.

Demote the trace to \`logger.debug(\"...\", exc_info=True)\` so
it only shows up when the user asks for it. Wire the long-declared
\`--verbose\` CLI flag to flip the root logger to DEBUG so the
trace comes back when needed for postmortem.

### Before
\`\`\`
ERROR - error[E0200]: ` + "`undefined_sym`" + ` is not defined in the current scope
  --> /tmp/badsym.s:1:1
ERROR - Build failed: Failed to compile module '__main__'
Traceback (most recent call last):
  File \"a816/module_builder.py\", line 346, ...
  File \"a816/cpu/cpu_65c816.py\", line 168, ...
  [... 20 more frames ...]
\`\`\`

### After (default)
\`\`\`
ERROR - error[E0200]: ` + "`undefined_sym`" + ` is not defined in the current scope
  --> /tmp/badsym.s:1:1
ERROR - Build failed: Failed to compile module '__main__'
\`\`\`

### After (\`--verbose\`)
Same as default + \`DEBUG - Build traceback\` followed by the
stack trace.

## Files

- \`a816/cli.py\` — wire \`--verbose\` to root logger level
- \`a816/program/assemble.py\` — NodeError paths (codegen +
  object emit)
- \`a816/xdds.py\` — IPS apply ValueError
- \`a816/module_builder.py\` — top-level Exception + OSError
  on source read

## Test plan

- [x] \`hatch run tests:all\` -> 1100 pass, 1 skip
- [x] Smoke: \`a816 badsym.s\` -> clean error, no trace
- [x] Smoke: \`a816 --verbose badsym.s\` -> error + DEBUG trace