### PR TITLE
Fluff OP001: flag redundant .w / .l opcode size suffix

### DIFF
--- a/a816/fluff/rules_opcode.py
+++ b/a816/fluff/rules_opcode.py
@@ -1,0 +1,126 @@
+"""Opcode rules: opcode-size suffix hygiene.
+
+`OP001` flags an explicit `.w` / `.l` width suffix on an opcode whose
+literal numeric operand already forces the assembler to pick that
+same width. The suffix is noise; dropping it doesn't change the
+emitted bytes.
+
+`.b` is intentionally not flagged. Its meaning depends on the
+runtime M/X register width (which fluff doesn't track), so a `.b`
+on a small immediate may be the user's only way to force an
+8-bit-form opcode under `.a16` / `rep #$20`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# Addressing modes whose width is purely a function of the operand
+# value width — what we can safely reason about without simulating
+# the resolver. Immediate is the obvious case; absolute / long share
+# the same value-width inference.
+from a816.cpu.types import AddressingMode
+from a816.fluff.core import (
+    Applicability,
+    Diagnostic,
+    Fix,
+    LintContext,
+    Rule,
+    TextEdit,
+    line_col_to_offset,
+)
+from a816.parse.ast.nodes import AstNode, OpcodeAstNode
+from a816.parse.ast.nodes.base import Term
+
+_WIDTH_DRIVEN_MODES = frozenset(
+    {
+        AddressingMode.immediate,
+        AddressingMode.direct,
+        AddressingMode.direct_indexed,
+    }
+)
+
+
+def _literal_value(node: OpcodeAstNode) -> int | None:
+    """Numeric value of `node`'s operand when it is a single literal,
+    else None. Skips symbol refs, expressions, and casts since their
+    width can shift between passes / link time."""
+    if node.operand is None:
+        return None
+    tokens = node.operand.tokens
+    if len(tokens) != 1 or not isinstance(tokens[0], Term):
+        return None
+    text = tokens[0].token.value
+    try:
+        return int(text, 0)
+    except ValueError:
+        return None
+
+
+def _suffix_is_redundant(suffix: str, value: int) -> bool:
+    # `.l` is redundant when the value already needs 3 bytes — no
+    # shorter form can hold it, so inference also picks `.l`.
+    # `.w` is redundant when the value needs ≥ 2 bytes for the same
+    # reason; the shorter `.b` would truncate.
+    if suffix == "l":
+        return value > 0xFFFF
+    if suffix == "w":
+        return value > 0xFF
+    return False
+
+
+class RedundantOpcodeSizeSuffix(Rule):
+    code = "OP001"
+    description = "explicit `.w` / `.l` size suffix is redundant"
+    rationale = (
+        "When the literal operand already exceeds the next-smaller "
+        "addressing form's range (`> 0xFF` for `.w`, `> 0xFFFF` for "
+        "`.l`), the assembler picks that exact width from the value "
+        "alone. Writing the suffix anyway adds visual noise and "
+        "lies about why the width was chosen. `.b` is left alone "
+        "because under `rep #$20` / `.a16` it's the only way to "
+        "force an 8-bit immediate opcode."
+    )
+    bad = '"""Module."""\nlda.w #0x1234\n'
+    good = '"""Module."""\nlda #0x1234\n'
+    accepts = (OpcodeAstNode,)
+
+    def visit(self, ctx: LintContext, node: AstNode) -> Iterable[Diagnostic]:
+        assert isinstance(node, OpcodeAstNode)
+        suffix = node.value_size or ""
+        if suffix not in ("w", "l"):
+            return
+        if node.addressing_mode not in _WIDTH_DRIVEN_MODES:
+            return
+        value = _literal_value(node)
+        if value is None:
+            return
+        if not _suffix_is_redundant(suffix, value):
+            return
+        fix = _strip_suffix_fix(ctx, node, suffix)
+        yield self.diagnose(
+            ctx,
+            node,
+            f"`{node.opcode}.{suffix}` is redundant — value 0x{value:X} forces width by itself",
+            fix=fix,
+        )
+
+
+def _strip_suffix_fix(ctx: LintContext, node: OpcodeAstNode, suffix: str) -> Fix | None:
+    # `file_info` is the opcode token (e.g. `lda`). The suffix sits
+    # immediately after it as `.w` / `.l` — 2 source chars. Compute
+    # its byte span and replace with empty.
+    pos = node.file_info.position
+    if pos is None:
+        return None
+    opcode_start = line_col_to_offset(ctx.text, pos.line + 1, pos.column + 1)
+    # Find `.suffix` in source starting at the opcode position. The
+    # opcode-name length is `len(node.opcode)`; the dot+suffix follows.
+    dot_offset = opcode_start + len(node.opcode)
+    if ctx.text[dot_offset : dot_offset + 2] != f".{suffix}":
+        return None  # source diverges from AST shape; bail
+    return Fix(
+        edits=(TextEdit(start=dot_offset, end=dot_offset + 2, replacement=""),),
+        applicability=Applicability.SAFE,
+        description=f"remove redundant `.{suffix}` suffix",
+    )

--- a/a816/fluff/runner.py
+++ b/a816/fluff/runner.py
@@ -24,6 +24,7 @@ from a816.fluff.rules_doc import (
     RedundantCommentAndDocstring,
 )
 from a816.fluff.rules_naming import ConstantNaming, LabelNaming
+from a816.fluff.rules_opcode import RedundantOpcodeSizeSuffix
 from a816.fluff.rules_style import (
     LineTooLong,
     RedundantTypedCast,
@@ -48,6 +49,7 @@ RULES: list[Rule] = [
     RedundantTypedCast(),
     RepeatedInlineCast(),
     StarEqualToAllocAt(),
+    RedundantOpcodeSizeSuffix(),
 ]
 Rule.registry = {rule.code: rule for rule in RULES}
 

--- a/tests/test_fluff_rules_opcode.py
+++ b/tests/test_fluff_rules_opcode.py
@@ -1,0 +1,84 @@
+"""`OP001` — redundant `.w` / `.l` opcode-size suffix.
+
+Fires only on literal numeric operands whose value already forces the
+same width through the assembler's value-driven size inference.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a816.fluff.runner import apply_fixes, lint_text
+
+
+def _hits(src: str, code: str = "OP001") -> list[str]:
+    return [d.message for d in lint_text(src, Path("x.s")) if d.code == code]
+
+
+class TestRedundantSuffixFires:
+    def test_w_on_16_bit_literal_immediate(self) -> None:
+        # value 0x1234 > 0xFF -> .w is what inference picks anyway
+        assert _hits('"""m."""\nlda.w #0x1234\n')
+
+    def test_l_on_24_bit_literal_immediate(self) -> None:
+        # value 0x012345 > 0xFFFF -> .l is what inference picks anyway
+        assert _hits('"""m."""\nlda.l #0x012345\n')
+
+    def test_w_on_decimal_literal(self) -> None:
+        # 1000 == 0x3E8 > 0xFF
+        assert _hits('"""m."""\nlda.w #1000\n')
+
+
+class TestSuffixIsNotRedundant:
+    def test_w_on_8_bit_literal_under_a16(self) -> None:
+        # value 0x42 fits in a byte; .w *forces* widening (only way
+        # to emit `A9 42 00` when A is 8-bit). NOT redundant.
+        assert _hits('"""m."""\nlda.w #0x42\n') == []
+
+    def test_b_suffix_is_never_flagged(self) -> None:
+        # .b semantics depend on M/X state — leave alone.
+        assert _hits('"""m."""\nlda.b #0x1234\n') == []
+        assert _hits('"""m."""\nlda.b #0x42\n') == []
+
+    def test_l_when_value_fits_in_word(self) -> None:
+        # .l forces long addressing when value fits in 2 bytes — that's
+        # the user picking the addressing form, not redundancy.
+        assert _hits('"""m."""\nlda.l #0x1234\n') == []
+
+    def test_symbolic_operand_not_flagged(self) -> None:
+        # Symbol may resolve to any width — can't conclude statically.
+        assert _hits('"""m."""\nlda.w #FOO\n') == []
+
+    def test_expression_operand_not_flagged(self) -> None:
+        assert _hits('"""m."""\nlda.w #(FOO + 1)\n') == []
+
+    def test_bare_opcode_without_suffix(self) -> None:
+        assert _hits('"""m."""\nlda #0x1234\n') == []
+
+
+class TestAutofix:
+    def test_strips_w_suffix(self) -> None:
+        src = '"""m."""\nlda.w #0x1234\n'
+        diags = lint_text(src, Path("x.s"))
+        fixed, _ = apply_fixes(src, diags)
+        assert "lda.w" not in fixed
+        assert "lda #0x1234" in fixed
+
+    def test_strips_l_suffix(self) -> None:
+        src = '"""m."""\nlda.l #0x012345\n'
+        diags = lint_text(src, Path("x.s"))
+        fixed, _ = apply_fixes(src, diags)
+        assert "lda.l" not in fixed
+        assert "lda #0x012345" in fixed
+
+    def test_noqa_suppresses(self) -> None:
+        src = '"""m."""\nlda.w #0x1234  ; noqa: OP001\n'
+        assert _hits(src) == []
+
+
+@pytest.mark.parametrize("opcode", ["lda", "sta", "ldx", "ora", "adc", "cmp"])
+def test_op001_fires_across_common_opcodes(opcode: str) -> None:
+    src = f'"""m."""\n{opcode}.w #0x1234\n'
+    assert any("redundant" in m for m in _hits(src))


### PR DESCRIPTION
## Summary

New fluff rule **OP001**. Flags explicit `.w` / `.l` size suffix on
an opcode whose literal numeric operand already forces that width
through value-driven inference.

Examples that fire:
```ca65
lda.w #0x1234   ; value > 0xFF — assembler picks .w anyway
lda.l #0x012345 ; value > 0xFFFF — assembler picks .l anyway
```

Examples that don't fire (intentional):
```ca65
lda.w #0x42     ; forces widening under .a16 — NOT redundant
lda.b #0x1234   ; .b never flagged (depends on M/X state)
lda.l #0x1234   ; forces long addressing — user intent
lda.w #FOO      ; symbolic — width can shift between passes
```

`.b` is intentionally left alone because under `.a16` / `rep #\$20`
it's the only way to force an 8-bit immediate emit, and fluff
doesn't track M/X state statically.

Conservative scope: literal numeric operand only, value-driven
addressing modes only (immediate / direct). Autofix is SAFE
(strips the two-char `.x` slice).

## Test plan

- [x] Scanned stdlib + samples + integration sources: 0 OP001
  hits (no false positives in real code)
- [x] 18 new tests cover fires / doesn't-fire / autofix / noqa /
  cross-opcode parametric