### PR TITLE
Fluff UP001: stop wrap at following .alloc directive

### DIFF
--- a/a816/fluff/rules_upgrade.py
+++ b/a816/fluff/rules_upgrade.py
@@ -22,7 +22,7 @@ from a816.fluff.core import (
     TextEdit,
     line_col_to_offset,
 )
-from a816.parse.ast.nodes import AstNode, CodePositionAstNode
+from a816.parse.ast.nodes import AllocAstNode, AstNode, CodePositionAstNode
 
 
 class StarEqualToAllocAt(Rule):
@@ -124,12 +124,15 @@ def _build_star_eq_to_alloc_fix(
 def _next_placement_or_end(text: str, siblings: list[AstNode], idx: int) -> int:
     """End offset for the body run starting after `siblings[idx]`.
 
-    Stops at the next `CodePositionAstNode` at the same level, or at
-    end of `text` if none follows. Includes the trailing newline so
-    the run leaves no blank line behind it."""
+    Stops at the next placement directive at the same level — either
+    another `*=` (`CodePositionAstNode`) or a `.alloc … at/in …`
+    (`AllocAstNode`). Both open their own placement context, so the
+    wrap-into-`.alloc at` for the leading `*=` must end before them
+    rather than swallowing them whole. Returns end of `text` if no
+    such boundary follows."""
     for j in range(idx + 1, len(siblings)):
         next_node = siblings[j]
-        if isinstance(next_node, CodePositionAstNode):
+        if isinstance(next_node, (CodePositionAstNode, AllocAstNode)):
             next_pos = getattr(next_node.file_info, "position", None)
             if next_pos is None:
                 continue

--- a/tests/test_fluff_fixes.py
+++ b/tests/test_fluff_fixes.py
@@ -237,17 +237,14 @@ class TestStarEqMigrationContainers:
         assert len(up1) == 1
 
     def test_up001_stops_wrap_at_following_alloc(self) -> None:
-        # `.alloc NAME in POOL { ... }` and `.alloc NAME at ADDR { ... }`
-        # are placement directives too — the `*=` body run must end
-        # there, not swallow the alloc whole.
+        """`.alloc NAME in POOL { ... }` and `.alloc NAME at ADDR { ... }`
+        are placement directives too — the `*=` body run must end
+        there, not swallow the alloc whole."""
         src = '"""m"""\n.pool client { range 0x008100 0x008200 }\n*=0x008000\n.db 0\n.alloc reset in client {\n    .db 1\n}\n'
         diagnostics = lint_text(src, Path("<mem>"))
         new, _ = apply_fixes(src, diagnostics, allow_unsafe=True)
-        # The `.alloc reset in client` block must stay outside the
-        # generated `.alloc at 0x008000` wrap.
         assert ".alloc at 0x008000 {\n    .db 0\n}" in new
         assert "\n.alloc reset in client {" in new
-        # Sanity: the alloc body wasn't dragged inside the wrap.
         assert "    .alloc reset in client" not in new
 
 

--- a/tests/test_fluff_fixes.py
+++ b/tests/test_fluff_fixes.py
@@ -236,6 +236,20 @@ class TestStarEqMigrationContainers:
         up1 = [d for d in diagnostics if d.code == "UP001"]
         assert len(up1) == 1
 
+    def test_up001_stops_wrap_at_following_alloc(self) -> None:
+        # `.alloc NAME in POOL { ... }` and `.alloc NAME at ADDR { ... }`
+        # are placement directives too — the `*=` body run must end
+        # there, not swallow the alloc whole.
+        src = '"""m"""\n.pool client { range 0x008100 0x008200 }\n*=0x008000\n.db 0\n.alloc reset in client {\n    .db 1\n}\n'
+        diagnostics = lint_text(src, Path("<mem>"))
+        new, _ = apply_fixes(src, diagnostics, allow_unsafe=True)
+        # The `.alloc reset in client` block must stay outside the
+        # generated `.alloc at 0x008000` wrap.
+        assert ".alloc at 0x008000 {\n    .db 0\n}" in new
+        assert "\n.alloc reset in client {" in new
+        # Sanity: the alloc body wasn't dragged inside the wrap.
+        assert "    .alloc reset in client" not in new
+
 
 class TestStarEqMigrationFix:
     def test_up001_wraps_single_star_eq_into_alloc_at(self) -> None:


### PR DESCRIPTION
## Summary

UP001 autofix was dragging trailing `.alloc … in POOL { ... }` and
`.alloc … at ADDR { ... }` blocks INSIDE the generated wrap because
the boundary detector only stopped at `*=` (`CodePositionAstNode`).

### Before
```ca65
*=0x008000
.db 0
.alloc reset in client {
    .db 1
}
```
got rewritten to:
```ca65
.alloc at 0x008000 {
    .db 0
    .alloc reset in client {
        .db 1
    }
}
```
which silently changes semantics — the alloc now lives inside a
pinned section's body instead of standing on its own.

### After
```ca65
.alloc at 0x008000 {
    .db 0
}
.alloc reset in client {
    .db 1
}
```

Fix: include `AllocAstNode` in `_next_placement_or_end`. Both `.alloc`
shapes open their own placement context — they must close the
preceding `*=` wrap, not get folded into it.

## Test plan

- [x] New `test_up001_stops_wrap_at_following_alloc` reproduces the
  user-reported case and now passes
- [ ] Write legacy star eq and test the unsafe fix.