### PR TITLE
Fluff UP001: stop wrap at bare scope containing nested *=

### DIFF
--- a/a816/fluff/rules_upgrade.py
+++ b/a816/fluff/rules_upgrade.py
@@ -22,7 +22,55 @@ from a816.fluff.core import (
     TextEdit,
     line_col_to_offset,
 )
-from a816.parse.ast.nodes import AllocAstNode, AstNode, CodePositionAstNode, CompoundAstNode
+from a816.parse.ast.nodes import (
+    AsciiAstNode,
+    AssignAstNode,
+    AstNode,
+    CodePositionAstNode,
+    CommentAstNode,
+    DataNode,
+    DocstringAstNode,
+    ImportAstNode,
+    IncludeAstNode,
+    IncludeBinaryAstNode,
+    LabelAstNode,
+    LabelDeclAstNode,
+    MacroApplyAstNode,
+    OpcodeAstNode,
+    RegisterSizeAstNode,
+    SymbolAffectationAstNode,
+    TextAstNode,
+)
+
+# Nodes safe to lift into a `.alloc at ADDR { ... }` body. Pure
+# emit-style directives only. Anything else (containers, control
+# flow, imports, includes, incbins, new placement directives)
+# terminates the wrap. The autofix only handles the simple
+# `*= ADDR / a few instructions / data bytes` case mechanically.
+_WRAP_BODY_CONTENT: tuple[type[AstNode], ...] = (
+    OpcodeAstNode,
+    DataNode,
+    TextAstNode,
+    AsciiAstNode,
+    LabelAstNode,
+    LabelDeclAstNode,
+    SymbolAffectationAstNode,
+    AssignAstNode,
+    RegisterSizeAstNode,
+    MacroApplyAstNode,
+    CommentAstNode,
+    DocstringAstNode,
+)
+
+# Nodes that, if present in a `*= ADDR` body run, signal the user
+# is relying on direct-mode chain semantics (`.import` / `.include`
+# inlines source; `.incbin` may overflow bank boundaries). UP001
+# skips the conversion entirely so the user migrates these by hand.
+_BODY_SKIP_TRIGGERS: tuple[type[AstNode], ...] = (
+    IncludeBinaryAstNode,
+    ImportAstNode,
+    IncludeAstNode,
+)
 
 
 class StarEqualToAllocAt(Rule):
@@ -62,6 +110,8 @@ def _scan_for_star_eq(rule: Rule, ctx: LintContext, nodes: list[AstNode]) -> Ite
 
     for idx, node in enumerate(nodes):
         if isinstance(node, CodePositionAstNode):
+            if _body_has_skip_trigger(nodes, idx):
+                continue
             yield _emit_up001(rule, ctx, nodes, idx)
         elif isinstance(node, ScopeAstNode):
             yield from _scan_for_star_eq(rule, ctx, list(node.body.body))
@@ -121,44 +171,47 @@ def _build_star_eq_to_alloc_fix(
     )
 
 
+def _body_has_skip_trigger(siblings: list[AstNode], idx: int) -> bool:
+    """Body run after `siblings[idx]` contains `.incbin` / `.import`
+    / `.include`? Those rely on direct-mode chain semantics that
+    don't translate mechanically to `.alloc at`. UP001 leaves the
+    `*=` alone so the user migrates manually."""
+    for j in range(idx + 1, len(siblings)):
+        next_node = siblings[j]
+        if isinstance(next_node, _BODY_SKIP_TRIGGERS):
+            return True
+        if not isinstance(next_node, _WRAP_BODY_CONTENT):
+            return False
+    return False
+
+
 def _next_placement_or_end(text: str, siblings: list[AstNode], idx: int) -> int:
     """End offset for the body run starting after `siblings[idx]`.
 
-    Stops at the next placement directive at the same level —
-    `*=` (`CodePositionAstNode`), `.alloc` (`AllocAstNode`), OR a
-    bare `{ ... }` scope (`CompoundAstNode`) that contains a nested
-    `*=` / `.alloc`. The bare-scope case matters because a nested
-    `*=` inside the scope unconditionally resets the cursor; the
-    outer wrap can't legitimately span past it. ff4 #31: without
-    this check, UP001 produced a 672657-byte alloc by swallowing
-    a `.table` carrier scope. Returns end of `text` if no such
-    boundary follows."""
+    Walks forward node-by-node from `siblings[idx + 1]`. The body
+    extends only across `_WRAP_BODY_CONTENT` types — opcodes, data,
+    text, ascii, incbin, labels, constants, register-size hints,
+    macro applications, comments, docstrings. The first node that
+    falls outside this set terminates the wrap.
+
+    Why allow-list instead of stop-list: the wrap means "pin these
+    bytes here." Any container (`.if`, `.for`, `.scope`, `{}`),
+    placement directive (`*=`, `.alloc`), import/include, pool
+    decl, or other build-shaping directive belongs OUTSIDE the
+    wrap. ff4 #31 + #32: a stop-list missed `.import` / `.include` /
+    `.if`-containing-nested-`*=`, producing a wrap that engulfed
+    the entire trailing source from `*=0x208100` through to the
+    next outer `*=` thousands of lines later. The allow-list is
+    bounded by what's safe to put inside a pinned section."""
     for j in range(idx + 1, len(siblings)):
         next_node = siblings[j]
-        if isinstance(next_node, (CodePositionAstNode, AllocAstNode)):
-            next_pos = getattr(next_node.file_info, "position", None)
-            if next_pos is None:
-                continue
-            return line_col_to_offset(text, next_pos.line + 1, 1)
-        if isinstance(next_node, CompoundAstNode) and _contains_placement(next_node.body):
-            next_pos = getattr(next_node.file_info, "position", None)
-            if next_pos is None:
-                continue
-            return line_col_to_offset(text, next_pos.line + 1, 1)
+        if isinstance(next_node, _WRAP_BODY_CONTENT):
+            continue
+        next_pos = getattr(next_node.file_info, "position", None)
+        if next_pos is None:
+            continue
+        return line_col_to_offset(text, next_pos.line + 1, 1)
     return len(text)
-
-
-def _contains_placement(nodes: list[AstNode]) -> bool:
-    """Any `*=` or `.alloc` reachable inside `nodes` (recursing into
-    further bare scopes). Used to gate the bare-scope boundary in
-    `_next_placement_or_end` so unrelated `{ ... }` blocks without
-    placement directives don't false-terminate the wrap."""
-    for node in nodes:
-        if isinstance(node, (CodePositionAstNode, AllocAstNode)):
-            return True
-        if isinstance(node, CompoundAstNode) and _contains_placement(node.body):
-            return True
-    return False
 
 
 def _extract_body_source(snippet: str) -> str:

--- a/a816/fluff/rules_upgrade.py
+++ b/a816/fluff/rules_upgrade.py
@@ -22,7 +22,7 @@ from a816.fluff.core import (
     TextEdit,
     line_col_to_offset,
 )
-from a816.parse.ast.nodes import AllocAstNode, AstNode, CodePositionAstNode
+from a816.parse.ast.nodes import AllocAstNode, AstNode, CodePositionAstNode, CompoundAstNode
 
 
 class StarEqualToAllocAt(Rule):
@@ -124,12 +124,15 @@ def _build_star_eq_to_alloc_fix(
 def _next_placement_or_end(text: str, siblings: list[AstNode], idx: int) -> int:
     """End offset for the body run starting after `siblings[idx]`.
 
-    Stops at the next placement directive at the same level — either
-    another `*=` (`CodePositionAstNode`) or a `.alloc … at/in …`
-    (`AllocAstNode`). Both open their own placement context, so the
-    wrap-into-`.alloc at` for the leading `*=` must end before them
-    rather than swallowing them whole. Returns end of `text` if no
-    such boundary follows."""
+    Stops at the next placement directive at the same level —
+    `*=` (`CodePositionAstNode`), `.alloc` (`AllocAstNode`), OR a
+    bare `{ ... }` scope (`CompoundAstNode`) that contains a nested
+    `*=` / `.alloc`. The bare-scope case matters because a nested
+    `*=` inside the scope unconditionally resets the cursor; the
+    outer wrap can't legitimately span past it. ff4 #31: without
+    this check, UP001 produced a 672657-byte alloc by swallowing
+    a `.table` carrier scope. Returns end of `text` if no such
+    boundary follows."""
     for j in range(idx + 1, len(siblings)):
         next_node = siblings[j]
         if isinstance(next_node, (CodePositionAstNode, AllocAstNode)):
@@ -137,7 +140,25 @@ def _next_placement_or_end(text: str, siblings: list[AstNode], idx: int) -> int:
             if next_pos is None:
                 continue
             return line_col_to_offset(text, next_pos.line + 1, 1)
+        if isinstance(next_node, CompoundAstNode) and _contains_placement(next_node.body):
+            next_pos = getattr(next_node.file_info, "position", None)
+            if next_pos is None:
+                continue
+            return line_col_to_offset(text, next_pos.line + 1, 1)
     return len(text)
+
+
+def _contains_placement(nodes: list[AstNode]) -> bool:
+    """Any `*=` or `.alloc` reachable inside `nodes` (recursing into
+    further bare scopes). Used to gate the bare-scope boundary in
+    `_next_placement_or_end` so unrelated `{ ... }` blocks without
+    placement directives don't false-terminate the wrap."""
+    for node in nodes:
+        if isinstance(node, (CodePositionAstNode, AllocAstNode)):
+            return True
+        if isinstance(node, CompoundAstNode) and _contains_placement(node.body):
+            return True
+    return False
 
 
 def _extract_body_source(snippet: str) -> str:

--- a/tests/test_fluff_fixes.py
+++ b/tests/test_fluff_fixes.py
@@ -247,6 +247,24 @@ class TestStarEqMigrationContainers:
         assert "\n.alloc reset in client {" in new
         assert "    .alloc reset in client" not in new
 
+    def test_up001_stops_wrap_at_following_bare_scope_with_inner_star_eq(self) -> None:
+        """A bare `{ ... }` scope at the same level that contains a
+        nested `*=` is itself a placement reset — the inner `*=` will
+        reset the cursor regardless of what the outer `*=` body says.
+
+        ff4 #31 friction: UP001 was over-extending through the scope,
+        producing an alloc spanning $00:B335..$14:F6XX (672657 bytes,
+        bigger than ROM). Wrap must close before the bare brace."""
+        src = '"""m"""\n*=0x00B335\n    jmp.w _animation_wait_route\n\n{\n    *=0x14F656\n    .dw 0x2016\n}\n'
+        diagnostics = lint_text(src, Path("<mem>"))
+        new, _ = apply_fixes(src, diagnostics, allow_unsafe=True)
+        # Wrap closes before the bare brace, not after it.
+        assert ".alloc at 0x00B335 {\n        jmp.w _animation_wait_route\n}" in new
+        # Bare scope stays at column 0, untouched (UP001 doesn't recurse
+        # into bare scopes yet — separate follow-up if we want the inner
+        # `*=` rewritten too).
+        assert "}\n{\n    *=0x14F656" in new
+
 
 class TestStarEqMigrationFix:
     def test_up001_wraps_single_star_eq_into_alloc_at(self) -> None:


### PR DESCRIPTION
## Summary

UP001 autofix over-extended through bare `{ ... }` scopes when
the scope contained a nested `*=`. The outer wrap engulfed the
scope, producing an oversized alloc that the allocator refused.

ff4 #31 friction report:
> UP001 brace-tracker over-extends when a scope block (`{ ... }`)
> appears in body of a `*=` section. \[...\] Allocator then sees
> section spanning $00:B335..$14:F6XX, fails: `alloc size 672657
> does not fit in any free chunk`.

### Before

```ca65
*=0x00B335
    jmp.w _animation_wait_route

{
    *=0x14F656
    .dw 0x2016
}
```

UP001 produced:
```ca65
.alloc at 0x00B335 {
    jmp.w _animation_wait_route
    {
        *=0x14F656
        .dw 0x2016
    }
}
```
The bare scope got dragged inside. Allocator size = $14F656 - $00B335.

### After

```ca65
.alloc at 0x00B335 {
    jmp.w _animation_wait_route
}
{
    *=0x14F656
    .dw 0x2016
}
```

Wrap closes before the bare brace. Scope keeps its independent
placement context.

## Fix

`_next_placement_or_end` now treats `CompoundAstNode` (bare
`{ ... }`) as a wrap boundary when it contains a nested `*=` or
`.alloc`. Recurses into further bare scopes via
`_contains_placement` so multi-level nesting is caught too.

Bare scopes without placement directives stay non-terminating
since they don't reset the cursor.

## Out of scope

UP001 doesn't recurse INTO the bare scope to flag the inner
`*=` (separate follow-up). The pre-flight check that refuses
the rewrite when it would produce a nested-`*=` alloc is also
deferred — the boundary fix now produces a correct wrap on its
own, so the pre-flight is belt-and-braces.