### PR TITLE
Add brl long branch ($82) to the assembler

### DIFF
--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -56,6 +56,27 @@ class OpcodeWithoutOperand(OpcodeProtocol):
 
 
 class RelativeJumpOpcode(OpcodeWithoutOperand):
+    # Offset width of the PC-relative displacement. 1 byte for the 8-bit
+    # branches (`bra`, `bcc`, …); `RelativeLongJumpOpcode` overrides to 2
+    # for `brl`. The displacement is measured from the instruction *after*
+    # the branch, i.e. `dest - pc - (1 + OFFSET_BYTES)`.
+    OFFSET_BYTES = 1
+    _PACK = "b"
+    _RANGE = "signed 8-bit range (-128 to 127)"
+
+    def _relative_delta(self, value_node: "ValueNodeProtocol", resolver: "Resolver") -> int:
+        value = value_node.get_value()
+        # Use duck typing: ExpressionNode has 'expression' attribute, ValueNode does not
+        if hasattr(value_node, "expression"):
+            physical_destination = resolver.get_bus().get_address(value).physical
+            if physical_destination is None:
+                raise RuntimeError(
+                    f"Cannot compute relative jump: target address {value:#x} "
+                    "has no physical mapping (RAM addresses not supported)"
+                )
+            return physical_destination - resolver.pc - (1 + self.OFFSET_BYTES)
+        return value
+
     def emit(
         self,
         value_node: "ValueNodeProtocol | None",
@@ -64,29 +85,11 @@ class RelativeJumpOpcode(OpcodeWithoutOperand):
     ) -> bytes:
         if value_node is None:
             raise MissingOperandError("branch")
-        value = value_node.get_value()
-
-        # Use duck typing: ExpressionNode has 'expression' attribute, ValueNode does not
-        if hasattr(value_node, "expression"):
-            pc = resolver.pc
-            physical_destination = resolver.get_bus().get_address(value).physical
-
-            if physical_destination is None:
-                raise RuntimeError(
-                    f"Cannot compute relative jump: target address {value:#x} "
-                    "has no physical mapping (RAM addresses not supported)"
-                )
-
-            delta = physical_destination - pc
-            delta -= 2
-        else:
-            delta = value
+        delta = self._relative_delta(value_node, resolver)
         try:
-            return super().emit(value_node, resolver, size) + struct.pack("b", delta)
+            return super().emit(value_node, resolver, size) + struct.pack(self._PACK, delta)
         except struct.error as e:
-            raise RuntimeError(
-                f"Branch target out of range: offset {delta} exceeds signed 8-bit range (-128 to 127)"
-            ) from e
+            raise RuntimeError(f"Branch target out of range: offset {delta} exceeds {self._RANGE}") from e
 
     def supposed_length(
         self,
@@ -94,7 +97,17 @@ class RelativeJumpOpcode(OpcodeWithoutOperand):
         size: ValueSize | None = None,
         resolver: "Resolver | None" = None,
     ) -> int:
-        return 2
+        return 1 + self.OFFSET_BYTES
+
+
+class RelativeLongJumpOpcode(RelativeJumpOpcode):
+    """`brl` ($82): unconditional PC-relative branch with a 16-bit signed
+    displacement (±32 KB). The link-invariant long-jump primitive: unlike
+    `jmp.w`, it stays relative and never consults the symbol table."""
+
+    OFFSET_BYTES = 2
+    _PACK = "<h"
+    _RANGE = "signed 16-bit range (-32768 to 32767)"
 
 
 def guess_value_size(
@@ -337,6 +350,7 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
     "bne": {AddressingMode.direct: RelativeJumpOpcode(0xD0)},
     "bpl": {AddressingMode.direct: RelativeJumpOpcode(0x10)},
     "bra": {AddressingMode.direct: RelativeJumpOpcode(0x80)},
+    "brl": {AddressingMode.direct: RelativeLongJumpOpcode(0x82)},
     # BRK / COP / WDM are 2-byte instructions on 65816: opcode + a
     # signature byte the handler reads off the stack (PC pushed is the
     # instruction + 2). Force callers to supply the signature so the

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -44,6 +44,40 @@ class EmitTest(unittest.TestCase):
 
         self.assertEqual(unpacked, (128, -5))
 
+    def test_long_branch_brl(self) -> None:
+        """`brl` ($82) encodes a 16-bit signed PC-relative displacement."""
+        program = Program()
+        _, nodes = program.parser.parse("my_label:\n    nop\n    brl my_label\n")
+        program.resolve_labels(nodes)
+
+        program.resolver.pc = 1  # `nop` consumed one byte before the branch
+        machine_code = nodes[-1].emit(program.resolver.reloc_address)
+        opcode, offset = struct.unpack("<Bh", machine_code)
+        # my_label at 0, branch at pc=1; offset = 0 - 1 - 3 = -4.
+        self.assertEqual((opcode, offset), (0x82, -4))
+
+    def test_long_branch_out_of_range(self) -> None:
+        program = Program()
+        _, nodes = program.parser.parse("    brl 0x40000\n")
+        program.resolve_labels(nodes)
+        program.resolver.pc = 0
+        with self.assertRaisesRegex(RuntimeError, "signed 16-bit range"):
+            nodes[-1].emit(program.resolver.reloc_address)
+
+    def test_long_branch_literal_offset_and_missing_operand(self) -> None:
+        from a816.cpu.cpu_65c816 import RelativeLongJumpOpcode
+        from a816.exceptions import MissingOperandError
+        from a816.parse.nodes import ValueNode
+
+        program = Program()
+        opcode = RelativeLongJumpOpcode(0x82)
+        # A plain ValueNode is taken as a literal displacement (no PC math).
+        emitted = opcode.emit(ValueNode("0x10"), program.resolver)
+        self.assertEqual(emitted, b"\x82\x10\x00")
+        # A branch with no operand is rejected.
+        with self.assertRaises(MissingOperandError):
+            opcode.emit(None, program.resolver)
+
     def test_long_data_node(self) -> None:
         input_program = """
         .dl 0xf01ac5


### PR DESCRIPTION
## Why

`brl` ($82) — the 65816's unconditional 16-bit PC-relative branch (±32 KB) — was assemble-unsupported. The disassembler already decoded it (`0x82: ("brl", RELATIVE_LONG, 2)`), but the opcode table had no entry, so you could read `brl` but not write it.

The consequence: a long intra-routine back-edge (loop body > 127 bytes, past `bra` range) had to use `jmp.w <local>` — absolute, deferred to the linker, touching the symbol table. That's the exact path behind the recently-fixed local-label collisions (#88, #89). `brl` is the correct primitive: PC-relative, resolved in-section at assemble time, layout-invariant, never consults a symbol — immune to that whole class.

Closes the "natural fix" the jmp.w-local report flagged.

## What

- `RelativeJumpOpcode` parametrized by offset width (`OFFSET_BYTES`); displacement = `dest - pc - (1 + OFFSET_BYTES)`. Existing 8-bit branches unchanged.
- `RelativeLongJumpOpcode` (2-byte signed offset, range ±32767) → `brl` = `$82`.

## Test plan

- `brl <backward label>` / `<forward label>` encode `82 lo hi` with the correct signed-16 displacement, both directions.
- Target past ±32767 errors with "signed 16-bit range".
- 8-bit branches (`bra`/`bcc`/…) still encode identically (shared, re-parametrized path).
