### PR TITLE
Byte-less bss pools + .reserve for WRAM/RAM layout

### DIFF
--- a/a816/linker.py
+++ b/a816/linker.py
@@ -443,7 +443,13 @@ class Linker:
             raise RelocationError(symbol_name, kind, value, f"is out of range (must be {low:#x} to {high:#x})")
 
     def _patch_relocation(
-        self, code: bytearray, offset: int, final_address: int, symbol_name: str, address: int, reloc_type: RelocationType
+        self,
+        code: bytearray,
+        offset: int,
+        final_address: int,
+        symbol_name: str,
+        address: int,
+        reloc_type: RelocationType,
     ) -> None:
         match reloc_type:
             case RelocationType.ABSOLUTE_16:

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -141,6 +141,7 @@ class Linker:
             ranges=[PoolRange(start=s, end=e, allow_bank_cross=(s >> 16) != (e >> 16)) for s, e in decl.ranges],
             fill=decl.fill,
             strategy=Strategy(decl.strategy),
+            bss=decl.bss,
         )
 
     def _merge_bus_mappings(self) -> None:
@@ -192,6 +193,7 @@ class Linker:
                 ranges=[(r.start, r.end) for r in p.ranges],
                 fill=p.fill,
                 strategy=p.strategy.value,
+                bss=p.bss,
             )
             for p in merged.values()
         ]
@@ -212,6 +214,10 @@ class Linker:
             raise ValueError(
                 f"pool {decl.name!r} declared with conflicting strategies: "
                 f"{existing.strategy.value!r} vs {decl.strategy!r}"
+            )
+        if existing.bss != decl.bss:
+            raise ValueError(
+                f"pool {decl.name!r} declared with conflicting bss flags: {existing.bss} vs {decl.bss}"
             )
         # Dedupe identical ranges: a prelude-declared pool replicates
         # across every module's .o, and reclaiming the same bytes twice

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -216,9 +216,7 @@ class Linker:
                 f"{existing.strategy.value!r} vs {decl.strategy!r}"
             )
         if existing.bss != decl.bss:
-            raise ValueError(
-                f"pool {decl.name!r} declared with conflicting bss flags: {existing.bss} vs {decl.bss}"
-            )
+            raise ValueError(f"pool {decl.name!r} declared with conflicting bss flags: {existing.bss} vs {decl.bss}")
         # Dedupe identical ranges: a prelude-declared pool replicates
         # across every module's .o, and reclaiming the same bytes twice
         # is an error. Skip ranges already covered; only contribute

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -265,6 +265,7 @@ class Linker:
                     for offset, file_idx, line, column, flags in section.lines
                 ],
             )
+            new_section.bss = section.bss
             self.linked_sections.append(new_section)
             self._section_obj[section_idx] = obj_idx
 

--- a/a816/object_file.py
+++ b/a816/object_file.py
@@ -111,7 +111,7 @@ class PoolAlloc:
 
 class ObjectFile:
     MAGIC_NUMBER = 0x41383136  # 'A816'
-    VERSION = 0x0009  # Version 9: bus mappings serialized for cross-TU bus replay.
+    VERSION = 0x000A  # Version 10: per-section flags byte (bss reservation sections).
 
     def __init__(
         self,
@@ -260,6 +260,8 @@ class ObjectFile:
         f.write(struct.pack("<H", len(self.sections)))
         for section in self.sections:
             f.write(struct.pack("<II", section.base_address, len(section.code)))
+            section_flags = 0x01 if section.bss else 0x00
+            f.write(struct.pack("<B", section_flags))
             f.write(
                 struct.pack("<HHI", len(section.relocations), len(section.expression_relocations), len(section.lines))
             )
@@ -308,6 +310,7 @@ class ObjectFile:
         sections: list[Section] = []
         for _ in range(count):
             base_address, code_size = struct.unpack("<II", f.read(8))
+            (section_flags,) = struct.unpack("<B", f.read(1))
             num_relocs, num_expr_relocs, num_lines = struct.unpack("<HHI", f.read(8))
             code = f.read(code_size)
             relocs: list[tuple[int, str, RelocationType]] = []
@@ -326,15 +329,15 @@ class ObjectFile:
             for _ in range(num_lines):
                 offset, file_idx, line, column, flags = struct.unpack("<IIIHB", f.read(15))
                 lines.append((offset, file_idx, line, column, flags))
-            sections.append(
-                Section.anonymous_pinned(
-                    base_address=base_address,
-                    code=code,
-                    relocations=relocs,
-                    expression_relocations=expr_relocs,
-                    lines=lines,
-                )
+            section = Section.anonymous_pinned(
+                base_address=base_address,
+                code=code,
+                relocations=relocs,
+                expression_relocations=expr_relocs,
+                lines=lines,
             )
+            section.bss = bool(section_flags & 0x01)
+            sections.append(section)
         return sections
 
     @staticmethod

--- a/a816/object_file.py
+++ b/a816/object_file.py
@@ -73,6 +73,10 @@ class PoolDecl:
     ranges: list[tuple[int, int]]
     fill: int
     strategy: str
+    bss: bool = False
+    """Byte-less pool: reservations emit nothing into the image. Must round-trip
+    through the object format, else an imported bss pool deserializes as bss=False
+    and `generate_pool`'s shape-check rejects the inline (bss=True) re-declaration."""
 
 
 @dataclass
@@ -111,7 +115,7 @@ class PoolAlloc:
 
 class ObjectFile:
     MAGIC_NUMBER = 0x41383136  # 'A816'
-    VERSION = 0x000A  # Version 10: per-section flags byte (bss reservation sections).
+    VERSION = 0x000B  # Version 11: PoolDecl carries the bss flag (round-trips through import).
 
     def __init__(
         self,
@@ -209,6 +213,7 @@ class ObjectFile:
             f.write(name_bytes)
             f.write(struct.pack("<B", len(strategy_bytes)))
             f.write(strategy_bytes)
+            f.write(struct.pack("<B", 1 if decl.bss else 0))
             f.write(struct.pack("<BH", decl.fill, len(decl.ranges)))
             for start, end in decl.ranges:
                 f.write(struct.pack("<II", start, end))
@@ -381,12 +386,13 @@ class ObjectFile:
             name = f.read(name_len).decode("utf-8")
             (strategy_len,) = struct.unpack("<B", f.read(1))
             strategy = f.read(strategy_len).decode("utf-8")
+            (bss_flag,) = struct.unpack("<B", f.read(1))
             fill, range_count = struct.unpack("<BH", f.read(3))
             ranges: list[tuple[int, int]] = []
             for _ in range(range_count):
                 start, end = struct.unpack("<II", f.read(8))
                 ranges.append((start, end))
-            out.append(PoolDecl(name=name, ranges=ranges, fill=fill, strategy=strategy))
+            out.append(PoolDecl(name=name, ranges=ranges, fill=fill, strategy=strategy, bss=bool(bss_flag)))
         return out
 
     @staticmethod

--- a/a816/parse/ast/nodes/__init__.py
+++ b/a816/parse/ast/nodes/__init__.py
@@ -41,6 +41,7 @@ from a816.parse.ast.nodes.directives import (
     MapArgs,
     MapAstNode,
     RegisterSizeAstNode,
+    ReserveAstNode,
     TableAstNode,
     TextAstNode,
 )
@@ -107,6 +108,7 @@ __all__ = [
     "ReclaimAstNode",
     "RegisterSizeAstNode",
     "RelocateAstNode",
+    "ReserveAstNode",
     "ScopeAstNode",
     "StructAstNode",
     "SymbolAffectationAstNode",

--- a/a816/parse/ast/nodes/__init__.py
+++ b/a816/parse/ast/nodes/__init__.py
@@ -42,6 +42,7 @@ from a816.parse.ast.nodes.directives import (
     MapAstNode,
     RegisterSizeAstNode,
     ReserveAstNode,
+    ReserveTypedAstNode,
     TableAstNode,
     TextAstNode,
 )
@@ -109,6 +110,7 @@ __all__ = [
     "RegisterSizeAstNode",
     "RelocateAstNode",
     "ReserveAstNode",
+    "ReserveTypedAstNode",
     "ScopeAstNode",
     "StructAstNode",
     "SymbolAffectationAstNode",

--- a/a816/parse/ast/nodes/directives.py
+++ b/a816/parse/ast/nodes/directives.py
@@ -184,6 +184,22 @@ class DataNode(AstNode):
         return f".{self.kind} {', '.join(values)}"
 
 
+class ReserveAstNode(AstNode):
+    """`.res N`: reserve N bytes of address space without emitting any."""
+
+    size: ExpressionAstNode
+
+    def __init__(self, size: ExpressionAstNode, file_info: Token):
+        super().__init__("res", file_info)
+        self.size = size
+
+    def to_representation(self) -> tuple[Any, ...]:
+        return self.kind, self.size.to_representation()[0]
+
+    def to_canonical(self) -> str:
+        return f".res {self.size.to_canonical()}"
+
+
 class TableAstNode(AstNode):
     file_path: str
 

--- a/a816/parse/ast/nodes/directives.py
+++ b/a816/parse/ast/nodes/directives.py
@@ -200,6 +200,27 @@ class ReserveAstNode(AstNode):
         return f".res {self.size.to_canonical()}"
 
 
+class ReserveTypedAstNode(AstNode):
+    """`.reserve NAME as TYPE in POOL`: reserve sizeof(TYPE) in a bss pool and
+    publish NAME plus NAME.<field> at the allocator-assigned address."""
+
+    name: str
+    type_name: str
+    pool_name: str
+
+    def __init__(self, name: str, type_name: str, pool_name: str, file_info: Token):
+        super().__init__("reserve_typed", file_info)
+        self.name = name
+        self.type_name = type_name
+        self.pool_name = pool_name
+
+    def to_representation(self) -> tuple[Any, ...]:
+        return self.kind, self.name, self.type_name, self.pool_name
+
+    def to_canonical(self) -> str:
+        return f".reserve {self.name} as {self.type_name} in {self.pool_name}"
+
+
 class TableAstNode(AstNode):
     file_path: str
 

--- a/a816/parse/ast/nodes/pool.py
+++ b/a816/parse/ast/nodes/pool.py
@@ -27,18 +27,22 @@ class PoolAstNode(AstNode):
         fill: ExpressionAstNode,
         strategy: str,
         file_info: Token,
+        bss: bool = False,
     ) -> None:
         super().__init__("pool", file_info)
         self.pool_name = name
         self.ranges = ranges
         self.fill = fill
         self.strategy = strategy
+        self.bss = bss
 
     def to_representation(self) -> tuple[Any, ...]:
         return self.kind, self.pool_name, len(self.ranges), self.strategy
 
     def to_canonical(self) -> str:
         lines = [f".pool {self.pool_name} {{"]
+        if self.bss:
+            lines.append("    bss")
         for start, end in self.ranges:
             lines.append(f"    range {start.to_canonical()} {end.to_canonical()}")
         lines.append(f"    fill {self.fill.to_canonical()}")

--- a/a816/parse/codegen/directives.py
+++ b/a816/parse/codegen/directives.py
@@ -20,6 +20,7 @@ from a816.parse.ast.nodes import (
     LabelAstNode,
     LabelDeclAstNode,
     RegisterSizeAstNode,
+    ReserveAstNode,
     TableAstNode,
     TextAstNode,
 )
@@ -37,6 +38,7 @@ from a816.parse.nodes import (
     LongNode,
     RegisterSizeNode,
     RelocationAddressNode,
+    ReserveNode,
     TableNode,
     TextNode,
     WordNode,
@@ -143,6 +145,15 @@ def generate_register_size(
     return [RegisterSizeNode(node.register, node.size, resolver)]
 
 
+def generate_reserve(
+    node: ReserveAstNode,
+    resolver: Resolver,
+    macro_definitions: MacroDefinitions,
+    file_info: Token,
+) -> GenNodes:
+    return [ReserveNode(ExpressionNode(node.size, resolver, file_info), resolver, file_info)]
+
+
 def generate_label(
     node: LabelAstNode,
     resolver: Resolver,
@@ -228,6 +239,7 @@ generators["dw"] = generate_dw
 generators["dl"] = generate_dl
 generators["pointer"] = generate_dl
 generators["register_size"] = generate_register_size
+generators["res"] = generate_reserve
 generators["label"] = generate_label
 generators["label_decl"] = generate_label_decl
 generators["text"] = generate_text

--- a/a816/parse/codegen/modules.py
+++ b/a816/parse/codegen/modules.py
@@ -128,6 +128,7 @@ def _register_imported_object_pools(obj_file: ObjectFile, resolver: Resolver) ->
             ranges=[PoolRange(start=lo, end=hi, allow_bank_cross=(lo >> 16) != (hi >> 16)) for lo, hi in decl.ranges],
             fill=decl.fill,
             strategy=Strategy(decl.strategy),
+            bss=decl.bss,
         )
 
 

--- a/a816/parse/codegen/pool.py
+++ b/a816/parse/codegen/pool.py
@@ -79,6 +79,7 @@ def generate_pool(
             ranges=ranges,
             fill=fill_value,
             strategy=Strategy(node.strategy),
+            bss=node.bss,
         )
         if node.pool_name in resolver.pools:
             existing = resolver.pools[node.pool_name]
@@ -86,6 +87,7 @@ def generate_pool(
                 [(r.start, r.end) for r in existing.ranges] == [(r.start, r.end) for r in pool.ranges]
                 and existing.fill == pool.fill
                 and existing.strategy == pool.strategy
+                and existing.bss == pool.bss
             )
             if not same_shape:
                 raise NodeError(f"pool {node.pool_name!r} already declared with different shape", file_info)

--- a/a816/parse/codegen/pool.py
+++ b/a816/parse/codegen/pool.py
@@ -7,14 +7,19 @@ from a816.exceptions import (
     ExternalSymbolReference,
     SymbolNotDefined,
 )
-from a816.parse.ast.expression import eval_expression
+from a816.parse.ast.expression import eval_expression, expr_to_ast
 from a816.parse.ast.nodes import (
     AllocAstNode,
+    AstNode,
+    BlockAstNode,
     CodePositionAstNode,
     ExpressionAstNode,
+    LabelAstNode,
     PoolAstNode,
     ReclaimAstNode,
     RelocateAstNode,
+    ReserveAstNode,
+    ReserveTypedAstNode,
 )
 from a816.parse.ast.visitor import walk
 from a816.parse.codegen.base import GenNodes, MacroDefinitions, _code_gen, generators
@@ -184,6 +189,43 @@ def generate_alloc(
     return [AllocNode(alloc_name, pool_name, body_nodes, resolver, file_info)]
 
 
+def generate_reserve_typed(
+    node: ReserveTypedAstNode,
+    resolver: Resolver,
+    macro_definitions: MacroDefinitions,
+    file_info: Token,
+) -> GenNodes:
+    """Expand `.reserve NAME as TYPE in POOL` against TYPE's layout.
+
+    Builds an `.alloc NAME in POOL { ... }` whose body lays out a label
+    `NAME.<field>` at each struct offset (padding the gaps with `.res`) and
+    reserves the struct's full size. The field labels bind as alloc-body
+    labels, so the linker rebases them with NAME to the allocator-chosen
+    address: the byte-less equivalent of a typed bind over fixed memory.
+    """
+    if node.type_name not in resolver.struct_sizes:
+        raise NodeError(
+            f".reserve {node.name!r} as unknown struct type {node.type_name!r}",
+            file_info,
+        )
+    size = resolver.struct_sizes[node.type_name]
+    layout = sorted(resolver.struct_layouts[node.type_name], key=lambda field: field[1])
+
+    body: list[AstNode] = []
+    cursor = 0
+    for field_path, offset, _width in layout:
+        if offset > cursor:
+            body.append(ReserveAstNode(expr_to_ast(hex(offset - cursor)), file_info))
+            cursor = offset
+        body.append(LabelAstNode(f"{node.name}.{field_path}", file_info))
+    if size > cursor:
+        body.append(ReserveAstNode(expr_to_ast(hex(size - cursor)), file_info))
+
+    resolver.typed_instances[node.name] = node.type_name
+    alloc = AllocAstNode(node.name, node.pool_name, BlockAstNode(body, file_info), file_info)
+    return generate_alloc(alloc, resolver, macro_definitions, file_info)
+
+
 _NESTED_PLACEMENT_KINDS = {
     AllocAstNode: ".alloc",
     RelocateAstNode: ".relocate",
@@ -316,5 +358,6 @@ def generate_relocate(
 
 generators["pool"] = generate_pool
 generators["alloc"] = generate_alloc
+generators["reserve_typed"] = generate_reserve_typed
 generators["relocate"] = generate_relocate
 generators["reclaim"] = generate_reclaim

--- a/a816/parse/codegen/pool.py
+++ b/a816/parse/codegen/pool.py
@@ -115,6 +115,7 @@ def generate_pool(
                 ranges=[(r.start, r.end) for r in pool.ranges],
                 fill=pool.fill,
                 strategy=pool.strategy.value,
+                bss=pool.bss,
             )
         )
     return []
@@ -325,6 +326,7 @@ def _synthesize_pinned_pool(
                 ranges=[(r.start, r.end) for r in ranges],
                 fill=0x00,
                 strategy=Strategy.PACK.value,
+                bss=False,  # pinned allocs emit bytes; never byte-less
             )
         )
     return pool_name

--- a/a816/parse/nodes/__init__.py
+++ b/a816/parse/nodes/__init__.py
@@ -16,6 +16,7 @@ from a816.parse.nodes.data import (
     DebugNode,
     LongNode,
     RegisterSizeNode,
+    ReserveNode,
     WordNode,
     _SizedValueNode,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "PointerNode",
     "PopScopeNode",
     "RegisterSizeNode",
+    "ReserveNode",
     "RelocateNode",
     "RelocationAddressNode",
     "ScopeNode",

--- a/a816/parse/nodes/data.py
+++ b/a816/parse/nodes/data.py
@@ -7,7 +7,9 @@ import re
 
 from a816.cpu.mapping import Address
 from a816.parse.ast.expression import eval_expression_str
+from a816.parse.nodes.errors import NodeError
 from a816.parse.nodes.expr import ExpressionNode
+from a816.parse.tokens import Token
 from a816.protocols import NodeProtocol, ValueNodeProtocol
 from a816.symbols import Resolver
 
@@ -39,6 +41,35 @@ class RegisterSizeNode(NodeProtocol):
 
     def __str__(self) -> str:
         return f"RegisterSizeNode({self.register}{self.size})"
+
+
+class ReserveNode(NodeProtocol):
+    """`.res N`: reserve N bytes of address space, emitting none.
+
+    Advances the PC by N so surrounding labels bind to real addresses, but
+    produces no output bytes. This is the building block for BSS-style
+    layout: `.alloc NAME in <wram-pool> { foo: .res 2  bar: .res 1 }` lets
+    the pool allocator assign collision-free WRAM addresses and publish them
+    as symbols without writing anything into the ROM image.
+    """
+
+    def __init__(self, size_node: ValueNodeProtocol, resolver: Resolver, file_info: Token) -> None:
+        self.size_node = size_node
+        self.resolver = resolver
+        self.file_info = file_info
+
+    def _size(self) -> int:
+        size = self.size_node.get_value()
+        if not isinstance(size, int) or size < 0:
+            raise NodeError(f".res size must be a non-negative integer, got {size!r}", self.file_info)
+        return size
+
+    def pc_after(self, current_pc: Address) -> Address:
+        return current_pc + self._size()
+
+    def emit(self, current_addr: Address) -> bytes:
+        del current_addr
+        return b""
 
 
 class BinaryNode(NodeProtocol):

--- a/a816/parse/nodes/module.py
+++ b/a816/parse/nodes/module.py
@@ -100,6 +100,7 @@ class LinkedModuleNode(NodeProtocol):
                 ],
                 fill=decl.fill,
                 strategy=Strategy(decl.strategy),
+                bss=decl.bss,
             )
 
     def _compute_delta_and_base(self, current_pc: Address) -> None:

--- a/a816/parse/parser_states/core.py
+++ b/a816/parse/parser_states/core.py
@@ -18,6 +18,7 @@ from a816.parse.ast.nodes import (
     IncludeBinaryAstNode,
     KeywordAstNode,
     LabelAstNode,
+    ReserveAstNode,
     TableAstNode,
     TextAstNode,
 )
@@ -88,6 +89,7 @@ _DIRECTIVE_HANDLERS: dict[str, Callable[[Parser, Token], AstNode]] = {
     "alloc": lambda p, _kw: parse_alloc(p),
     "relocate": lambda p, _kw: parse_relocate(p),
     "reclaim": lambda p, _kw: parse_reclaim(p),
+    "res": lambda p, kw: ReserveAstNode(parse_expression(p), kw),
     "a8": _register_size("a", 8),
     "a16": _register_size("a", 16),
     "i8": _register_size("i", 8),

--- a/a816/parse/parser_states/core.py
+++ b/a816/parse/parser_states/core.py
@@ -49,6 +49,7 @@ from a816.parse.parser_states.directives import (
     parse_pool,
     parse_reclaim,
     parse_relocate,
+    parse_reserve,
     parse_scope,
     parse_struct,
 )
@@ -90,6 +91,7 @@ _DIRECTIVE_HANDLERS: dict[str, Callable[[Parser, Token], AstNode]] = {
     "relocate": lambda p, _kw: parse_relocate(p),
     "reclaim": lambda p, _kw: parse_reclaim(p),
     "res": lambda p, kw: ReserveAstNode(parse_expression(p), kw),
+    "reserve": lambda p, _kw: parse_reserve(p),
     "a8": _register_size("a", 8),
     "a16": _register_size("a", 16),
     "i8": _register_size("i", 8),

--- a/a816/parse/parser_states/directives.py
+++ b/a816/parse/parser_states/directives.py
@@ -374,6 +374,7 @@ class _PoolAttrs:
     ranges: list[tuple[ExpressionAstNode, ExpressionAstNode]]
     fill: ExpressionAstNode
     strategy: str
+    bss: bool = False
 
 
 def _parse_pool_attr(p: Parser, key_token: Token, attrs: _PoolAttrs) -> None:
@@ -386,12 +387,14 @@ def _parse_pool_attr(p: Parser, key_token: Token, attrs: _PoolAttrs) -> None:
         attrs.fill = parse_expression(p)
     elif key == "strategy":
         attrs.strategy = _parse_pool_strategy(p)
+    elif key == "bss":
+        attrs.bss = True  # bare flag: byte-less (WRAM/SRAM/custom-RAM) pool
     else:
         raise ParserSyntaxError(
             f"unknown `.pool` attribute `{key}`",
             key_token,
             code=str(E_PARSER_UNKNOWN_DIRECTIVE_ATTR),
-            hint="expected one of: range, fill, strategy",
+            hint="expected one of: range, fill, strategy, bss",
         )
 
 
@@ -429,6 +432,7 @@ def parse_pool(p: Parser) -> PoolAstNode:
         attrs.fill,
         attrs.strategy,
         keyword,
+        bss=attrs.bss,
     )
 
 

--- a/a816/parse/parser_states/directives.py
+++ b/a816/parse/parser_states/directives.py
@@ -39,6 +39,8 @@ from a816.parse.ast.nodes import (
     ReclaimAstNode,
     RegisterSizeAstNode,
     RelocateAstNode,
+    ReserveAstNode,
+    ReserveTypedAstNode,
     ScopeAstNode,
     StructAstNode,
     Term,
@@ -496,6 +498,37 @@ def _parse_pinned_alloc_tail(p: Parser, parse_block: ParseBlockFn, keyword: Toke
     at_size = _parse_optional_size_clause(p)
     body = _parse_alloc_body(p, parse_block)
     return AllocAstNode(name, None, body, keyword, at_address=at_address, at_size=at_size)
+
+
+def parse_reserve(p: Parser) -> AllocAstNode | ReserveTypedAstNode:
+    """Parse a flat byte-less reservation into a `bss` pool:
+
+    * `.reserve NAME SIZE in POOL`: reserve SIZE bytes.
+    * `.reserve NAME as TYPE in POOL`: reserve sizeof(TYPE) + publish fields.
+
+    The size form desugars to `.alloc NAME in POOL { .res SIZE }`; the `as`
+    form is expanded against the struct layout at codegen.
+    """
+    keyword = p.current()
+    name_token = p.next()
+    expect_token(name_token, TokenType.IDENTIFIER)
+
+    # `.reserve NAME as TYPE in POOL`: struct-typed reservation.
+    if p.current().type == TokenType.IDENTIFIER and p.current().value == "as":
+        p.next()  # consume `as`
+        type_token = p.next()
+        expect_token(type_token, TokenType.IDENTIFIER)
+        _expect_contextual_keyword(p, "in")
+        pool_token = p.next()
+        expect_token(pool_token, TokenType.IDENTIFIER)
+        return ReserveTypedAstNode(name_token.value, type_token.value, pool_token.value, keyword)
+
+    size_expr = parse_expression(p)
+    _expect_contextual_keyword(p, "in")
+    pool_token = p.next()
+    expect_token(pool_token, TokenType.IDENTIFIER)
+    body = BlockAstNode([ReserveAstNode(size_expr, keyword)], keyword)
+    return AllocAstNode(name_token.value, pool_token.value, body, keyword)
 
 
 def _parse_alloc_body(p: Parser, parse_block: ParseBlockFn) -> BlockAstNode:

--- a/a816/parse/scanner_states.py
+++ b/a816/parse/scanner_states.py
@@ -282,6 +282,7 @@ DIRECTIVE_NAMES = {
     "alloc",
     "relocate",
     "reclaim",
+    "res",
     "a8",
     "a16",
     "i8",

--- a/a816/parse/scanner_states.py
+++ b/a816/parse/scanner_states.py
@@ -283,6 +283,7 @@ DIRECTIVE_NAMES = {
     "relocate",
     "reclaim",
     "res",
+    "reserve",
     "a8",
     "a16",
     "i8",

--- a/a816/pool.py
+++ b/a816/pool.py
@@ -74,6 +74,10 @@ class Pool:
     ranges: list[PoolRange]
     fill: int = 0x00
     strategy: Strategy = Strategy.PACK
+    bss: bool = False
+    """Byte-less pool: allocations reserve + overlap-check address space (WRAM,
+    SRAM, custom RAM maps) but emit nothing into the image. Bodies may only
+    reserve (`.res`) / label / assign; emitting a byte is an error."""
     allocations: list[Allocation] = field(default_factory=list)
     _allocated: bool = field(default=False, init=False)
 

--- a/a816/program/assemble.py
+++ b/a816/program/assemble.py
@@ -10,6 +10,7 @@ writer.
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -95,6 +96,13 @@ class AssembleMixin:
           128 on `A816Error` (covers both `AssemblyError` and `NodeError`)
           -1  on `RuntimeError` (mapping / bus failures bubbling up)
         """
+        warnings.warn(
+            "Direct assembly mode is deprecated; the build path is object "
+            "compilation + linking (`assemble_as_object` / `build_with_imports`). "
+            "New features land in object mode only.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         previous_mode = self.resolver.context.mode
         try:
             self.resolver.context.mode = AssemblyMode.DIRECT

--- a/a816/program/object_emit.py
+++ b/a816/program/object_emit.py
@@ -100,8 +100,18 @@ class ObjectEmitMixin:
                 from a816.parse.nodes import NodeError
 
                 raise NodeError(
-                    f".alloc in bss pool {node.pool_name!r} cannot emit bytes; "
-                    f"reserve space with `.res` instead",
+                    f".alloc in bss pool {node.pool_name!r} cannot emit bytes; reserve space with `.res` instead",
+                    node.file_info,
+                )
+            if not is_bss and object_writer._current_section is None:
+                # A byte-less body (only `.res` / `.reserve`) into a non-bss
+                # pool: there is nothing to place, and the section bookkeeping
+                # would mis-index. Reservations belong in a `bss` pool.
+                from a816.parse.nodes import NodeError
+
+                raise NodeError(
+                    f"reservation into non-bss pool {node.pool_name!r} emits no bytes; "
+                    f"declare the pool `bss` to reserve RAM",
                     node.file_info,
                 )
         finally:

--- a/a816/program/object_emit.py
+++ b/a816/program/object_emit.py
@@ -88,12 +88,22 @@ class ObjectEmitMixin:
         self._flush_object_block(object_writer, state)
         saved_pc = self.resolver.pc
         saved_reloc = self.resolver.reloc_address
+        pool = self.resolver.pools.get(node.pool_name)
+        is_bss = bool(pool and pool.bss)
         try:
             self.resolver.set_position(sandbox_logical)
-            object_writer.start_section(sandbox_logical, explicit=True)
+            object_writer.start_section(sandbox_logical, explicit=True, bss=is_bss)
             for child in node.body:
                 self._object_emit_one(child, object_writer, state)
             self._flush_object_block(object_writer, state)
+            if is_bss and object_writer.sections and object_writer.sections[-1].code:
+                from a816.parse.nodes import NodeError
+
+                raise NodeError(
+                    f".alloc in bss pool {node.pool_name!r} cannot emit bytes; "
+                    f"reserve space with `.res` instead",
+                    node.file_info,
+                )
         finally:
             self.resolver.pc = saved_pc
             self.resolver.reloc_address = saved_reloc

--- a/a816/program/object_emit.py
+++ b/a816/program/object_emit.py
@@ -92,28 +92,28 @@ class ObjectEmitMixin:
         is_bss = bool(pool and pool.bss)
         try:
             self.resolver.set_position(sandbox_logical)
-            object_writer.start_section(sandbox_logical, explicit=True, bss=is_bss)
+            # Always force-create the body section (`bss=True` here means
+            # "byte-less-capable": survives the writer's drop-empty pass and
+            # gets a stable index for the PoolAlloc). A label-only `.alloc at`
+            # (entry-point marker) and a `.reserve` both legitimately emit no
+            # bytes; both must survive. Sections that DO emit bytes get their
+            # bss flag cleared below so the final SFC/IPS emit still writes them.
+            object_writer.start_section(sandbox_logical, explicit=True, bss=True)
             for child in node.body:
                 self._object_emit_one(child, object_writer, state)
             self._flush_object_block(object_writer, state)
-            if is_bss and object_writer.sections and object_writer.sections[-1].code:
-                from a816.parse.nodes import NodeError
+            section = object_writer.sections[-1] if object_writer.sections else None
+            if section is not None and section.code:
+                if is_bss:
+                    from a816.parse.nodes import NodeError
 
-                raise NodeError(
-                    f".alloc in bss pool {node.pool_name!r} cannot emit bytes; reserve space with `.res` instead",
-                    node.file_info,
-                )
-            if not is_bss and object_writer._current_section is None:
-                # A byte-less body (only `.res` / `.reserve`) into a non-bss
-                # pool: there is nothing to place, and the section bookkeeping
-                # would mis-index. Reservations belong in a `bss` pool.
-                from a816.parse.nodes import NodeError
-
-                raise NodeError(
-                    f"reservation into non-bss pool {node.pool_name!r} emits no bytes; "
-                    f"declare the pool `bss` to reserve RAM",
-                    node.file_info,
-                )
+                    raise NodeError(
+                        f".alloc in bss pool {node.pool_name!r} cannot emit bytes; "
+                        f"reserve space with `.res` instead",
+                        node.file_info,
+                    )
+                # Real bytes: not a byte-less section, so don't skip it at emit.
+                section.bss = False
         finally:
             self.resolver.pc = saved_pc
             self.resolver.reloc_address = saved_reloc

--- a/a816/program/object_emit.py
+++ b/a816/program/object_emit.py
@@ -108,8 +108,7 @@ class ObjectEmitMixin:
                     from a816.parse.nodes import NodeError
 
                     raise NodeError(
-                        f".alloc in bss pool {node.pool_name!r} cannot emit bytes; "
-                        f"reserve space with `.res` instead",
+                        f".alloc in bss pool {node.pool_name!r} cannot emit bytes; reserve space with `.res` instead",
                         node.file_info,
                     )
                 # Real bytes: not a byte-less section, so don't skip it at emit.

--- a/a816/section.py
+++ b/a816/section.py
@@ -130,6 +130,15 @@ class Section:
     lines: list[tuple[int, int, int, int, int]] = field(default_factory=list)
     """Source-line provenance for adbg debug info."""
 
+    bss: bool = False
+    """Byte-less reservation section (a `.alloc` into a `bss` pool).
+
+    Carries placement + labels but no `code`. The allocator reserves its
+    span (via the matching `PoolAlloc.size`); the final SFC/IPS emit skips
+    it (empty `code`), so WRAM/RAM layout is collision-checked and symbol-
+    bound without writing anything into the image. Must survive the object
+    writer's drop-empty-section pass."""
+
     def __post_init__(self) -> None:
         if self.placement is Placement.PINNED and self.pool_name is not None:
             raise ValueError(

--- a/a816/writers.py
+++ b/a816/writers.py
@@ -173,6 +173,7 @@ class ObjectWriter(Writer):
         # offsets recorded mid-emit reflect the right intra-section position.
         self._pending_emit_bytes: int = 0
         self._has_explicit_position: bool = False
+        self._pending_bss: bool = False
 
     def begin(self) -> None:
         self.sections = []
@@ -185,6 +186,7 @@ class ObjectWriter(Writer):
         self._section_bytes_emitted = 0
         self._pending_emit_bytes = 0
         self._has_explicit_position = False
+        self._pending_bss = False
         self.pool_decls = []
         self.pool_allocs = []
         self.bus_mappings = []
@@ -199,22 +201,31 @@ class ObjectWriter(Writer):
         """
         self._pending_emit_bytes += count
 
-    def start_section(self, base_address: int, explicit: bool = False) -> None:
+    def start_section(self, base_address: int, explicit: bool = False, bss: bool = False) -> None:
         """Open a new section at base_address, closing any current section.
 
         `explicit=True` marks this as the result of a `*=` directive — the
         module loses single-section relocatability once any explicit section
-        is opened.
+        is opened. `bss=True` opens a byte-less reservation section (a `.alloc`
+        into a `bss` pool): it is force-created and protected from the
+        drop-empty pass so it survives with no `code`.
         """
-        # Drop empty pending sections instead of leaving zero-byte placeholders.
-        if self._current_section is not None and not self._current_section.code:
+        # Drop empty pending sections instead of leaving zero-byte placeholders,
+        # but never drop a bss section: empty `code` is its whole point.
+        if self._current_section is not None and not self._current_section.code and not self._current_section.bss:
             self.sections.pop()
         self._pending_base_address = base_address
         self._current_section = None
         self._section_bytes_emitted = 0
         self._pending_emit_bytes = 0
+        self._pending_bss = bss
         if explicit:
             self._has_explicit_position = True
+        if bss:
+            # Materialize immediately: a bss body emits no bytes, so nothing
+            # else would trigger section creation, and the PoolAlloc must
+            # reference a real section index.
+            self._ensure_section()
 
     def relocation_offset(self, pending_block_bytes: int = 0) -> int:
         """Byte offset where the next emitted byte will land in the section."""
@@ -258,8 +269,9 @@ class ObjectWriter(Writer):
         self.aliases.append((name, expression))
 
     def end(self) -> None:
-        # Strip a trailing empty section (e.g. trailing `*=` with no code).
-        if self.sections and not self.sections[-1].code:
+        # Strip a trailing empty section (e.g. trailing `*=` with no code),
+        # but keep a bss section: it is byte-less by design.
+        if self.sections and not self.sections[-1].code and not self.sections[-1].bss:
             self.sections.pop()
         relocatable = not self._has_explicit_position
         obj_file = ObjectFile(
@@ -277,6 +289,7 @@ class ObjectWriter(Writer):
     def _ensure_section(self) -> Section:
         if self._current_section is None:
             section = Section.anonymous_pinned(base_address=self._pending_base_address, code=b"")
+            section.bss = self._pending_bss
             self.sections.append(section)
             self._current_section = section
             self._section_bytes_emitted = 0

--- a/tests/test_object_file.py
+++ b/tests/test_object_file.py
@@ -1,6 +1,22 @@
 from pathlib import Path
 
-from a816.object_file import ObjectFile, RelocationType, Section, SymbolSection, SymbolType
+from a816.object_file import ObjectFile, PoolDecl, RelocationType, Section, SymbolSection, SymbolType
+
+
+def test_pool_decl_bss_round_trips(tmp_path: Path) -> None:
+    """A bss `.pool` must survive write/read. If `bss` is dropped on the way
+    out, an imported bss pool deserializes as bss=False and the inline
+    (bss=True) re-declaration trips `generate_pool`'s shape-check."""
+    obj = ObjectFile([], [])
+    obj.pool_decls = [
+        PoolDecl(name="wram", ranges=[(0x7E0000, 0x7E1FFF)], fill=0x00, strategy="order", bss=True),
+        PoolDecl(name="rom", ranges=[(0xC10000, 0xC1FFFF)], fill=0x00, strategy="order", bss=False),
+    ]
+    obj.write(str(tmp_path / "pools.o"))
+    obj2 = ObjectFile.from_file(str(tmp_path / "pools.o"))
+    by_name = {d.name: d for d in obj2.pool_decls}
+    assert by_name["wram"].bss is True
+    assert by_name["rom"].bss is False
 
 
 def test_write_empty_object_file(tmp_path: Path) -> None:

--- a/tests/test_reserve.py
+++ b/tests/test_reserve.py
@@ -37,6 +37,42 @@ def _symbols(linked: ObjectFile) -> dict[str, int]:
     return {name: value for name, value, *_ in linked.symbols}
 
 
+def test_bss_pool_survives_cross_module_import() -> None:
+    """Regression: a `bss` pool declared in an *imported* module must build.
+
+    The importer both inlines the preamble source (a fresh decl, bss=True)
+    AND reads the preamble's compiled `.o` (an extern decl). If the object
+    format drops `bss`, the `.o` copy deserializes as bss=False and the two
+    collide on `generate_pool`'s shape-check ('already declared with
+    different shape'). A same-file decl never exercises this - only the
+    import path does. Pin the round-trip through compile + link.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        (tmp / "preamble.s").write_text(
+            ".map identifier=3 bank_range=0x7e, 0x7f addr_range=0x0000, 0xffff mask=0x10000 writable=1\n"
+            ".map identifier=1 bank_range=0xc0, 0xfd addr_range=0x0000, 0xffff mask=0x10000 mirror_bank_range=0x40, 0x7d\n"
+            ".pool wram { bss  range 0x7e0000 0x7e1fff  strategy order }\n"
+            ".pool code { range 0xc10000 0xc1ffff  strategy order }\n"
+            ".reserve blob 0x10 in wram\n"
+        )
+        (tmp / "main.s").write_text('.import "preamble"\n.alloc main in code {\n    lda.l blob\n    rts\n}\n')
+        # Compile the imported module first (carries the bss PoolDecl + the
+        # reservation), then the consumer that imports it.
+        pre_o = tmp / "preamble.o"
+        assert Program().assemble_as_object(str(tmp / "preamble.s"), pre_o) == 0
+        main_program = Program()
+        main_program.add_module_path(tmp)
+        main_o = tmp / "main.o"
+        # Before the fix this raised 'pool wram already declared with different
+        # shape' at the importer's compile (inline bss=True vs imported-.o
+        # bss=False).
+        assert main_program.assemble_as_object(str(tmp / "main.s"), main_o) == 0
+        linked = Linker([ObjectFile.from_file(str(pre_o)), ObjectFile.from_file(str(main_o))]).link(base_address=0x8000)
+        # Reserved base label resolves to the bss pool's range start.
+        assert _symbols(linked)["blob"] == 0x7E0000
+
+
 def test_bss_alloc_binds_symbols_without_emitting() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         linked = _link(
@@ -150,9 +186,7 @@ def test_byte_less_alloc_survives_in_any_pool() -> None:
         asm = Path(tmp) / "m.s"
         # reserve into a NON-bss pool (reserves a gap) + a label-only pinned alloc.
         asm.write_text(
-            ".pool rom { range 0xc10000 0xc1ffff }\n"
-            ".reserve gap 0x10 in rom\n"
-            ".alloc at 0xc18000 { entry_marker: }\n"
+            ".pool rom { range 0xc10000 0xc1ffff }\n.reserve gap 0x10 in rom\n.alloc at 0xc18000 { entry_marker: }\n"
         )
         obj = Path(tmp) / "m.o"
         assert Program().assemble_as_object(str(asm), obj) == 0

--- a/tests/test_reserve.py
+++ b/tests/test_reserve.py
@@ -141,12 +141,24 @@ def test_typed_reserve_unknown_struct_errors() -> None:
         assert Program().assemble_as_object(str(asm), Path(tmp) / "m.o") != 0
 
 
-def test_flat_reserve_into_non_bss_pool_errors() -> None:
-    """Reserving in a non-bss (ROM) pool is a clear error, not a struct crash."""
+def test_byte_less_alloc_survives_in_any_pool() -> None:
+    """A byte-less body (a `.reserve`, or a label-only `.alloc at` entry marker)
+    must place + bind + emit nothing, without crashing the object serializer,
+    in a bss pool OR a plain pool. Byte-less sections survive universally; only
+    the bss flag adds the reject-emitted-bytes guard."""
     with tempfile.TemporaryDirectory() as tmp:
         asm = Path(tmp) / "m.s"
-        asm.write_text(".pool rom { range 0xc10000 0xc1ffff }\n.reserve x 0x10 in rom\n")
-        assert Program().assemble_as_object(str(asm), Path(tmp) / "m.o") != 0
+        # reserve into a NON-bss pool (reserves a gap) + a label-only pinned alloc.
+        asm.write_text(
+            ".pool rom { range 0xc10000 0xc1ffff }\n"
+            ".reserve gap 0x10 in rom\n"
+            ".alloc at 0xc18000 { entry_marker: }\n"
+        )
+        obj = Path(tmp) / "m.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        names = {n for n, *_ in ObjectFile.from_file(str(obj)).symbols}
+        assert "gap" in names
+        assert "entry_marker" in names
 
 
 def test_bss_pool_rejects_emitted_bytes() -> None:

--- a/tests/test_reserve.py
+++ b/tests/test_reserve.py
@@ -1,0 +1,115 @@
+"""`.res N` reservation + byte-less (`bss`) pools for WRAM/RAM layout.
+
+`.res` advances the PC without emitting bytes. A `bss` pool reserves and
+overlap-checks address space (WRAM, SRAM, custom RAM maps) but writes nothing
+into the image, and rejects any attempt to emit bytes into it. Exercised
+through the real build path (object compilation + linking), not the
+deprecated direct mode.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from a816.linker import Linker
+from a816.object_file import ObjectFile
+from a816.program import Program
+
+# A writable WRAM map + a bss pool over bank $7E. `code` is a normal ROM pool.
+_PREAMBLE = """
+.map identifier=1 bank_range=0xc0, 0xfd addr_range=0x0000, 0xffff mask=0x10000 mirror_bank_range=0x40, 0x7d
+.map identifier=3 bank_range=0x7e, 0x7f addr_range=0x0000, 0xffff mask=0x10000 writable=1
+.pool wram { bss  range 0x7e0000 0x7e1fff  strategy order }
+.pool code { range 0xc10000 0xc1ffff  strategy order }
+"""
+
+
+def _link(src: str, tmpdir: str) -> ObjectFile:
+    asm = Path(tmpdir) / "m.s"
+    asm.write_text(_PREAMBLE + src)
+    obj = Path(tmpdir) / "m.o"
+    assert Program().assemble_as_object(str(asm), obj) == 0
+    return Linker([ObjectFile.from_file(str(obj))]).link(base_address=0x8000)
+
+
+def _symbols(linked: ObjectFile) -> dict[str, int]:
+    return {name: value for name, value, *_ in linked.symbols}
+
+
+def test_bss_alloc_binds_symbols_without_emitting() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        linked = _link(
+            """
+.alloc in wram {
+foo:
+    .res 2
+bar:
+    .res 1
+baz:
+    .res 0x100
+}
+""",
+            tmp,
+        )
+        syms = _symbols(linked)
+        assert syms["foo"] == 0x7E0000
+        assert syms["bar"] == 0x7E0002  # foo + 2
+        assert syms["baz"] == 0x7E0003  # bar + 1
+        # The bss section survives placement but carries no bytes.
+        bss = [s for s in linked.sections if s.bss]
+        assert len(bss) == 1
+        assert bss[0].code == b""
+
+
+def test_code_references_resolve_to_reserved_wram_addresses() -> None:
+    """A ROM routine that touches reserved WRAM gets the allocator-assigned
+    addresses, and the WRAM bytes never land in the image."""
+    with tempfile.TemporaryDirectory() as tmp:
+        linked = _link(
+            """
+.alloc in wram {
+hp:
+    .res 1
+}
+.alloc r in code {
+    lda.w hp
+    rts
+}
+""",
+            tmp,
+        )
+        code = next(s for s in linked.sections if s.code)
+        # lda.w $0000 (low word of $7E0000), rts. hp resolved to the WRAM slot.
+        assert code.code == b"\xad\x00\x00\x60"
+        # No section carrying WRAM bytes.
+        assert all(s.code == b"" for s in linked.sections if s.bss)
+
+
+def test_bss_pool_rejects_emitted_bytes() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(_PREAMBLE + ".alloc in wram {\nx:\n    .db 0x42\n}\n")
+        # Reported as a non-zero exit by assemble_as_object (NodeError is caught).
+        assert Program().assemble_as_object(str(asm), Path(tmp) / "m.o") != 0
+
+
+def test_negative_reserve_is_rejected() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(_PREAMBLE + ".alloc in wram {\n    .res -1\n}\n")
+        assert Program().assemble_as_object(str(asm), Path(tmp) / "m.o") != 0
+
+
+def test_bss_and_reserve_round_trip_canonical() -> None:
+    """`.pool bss` and `.res` reproduce in canonical output (format stability)."""
+    from a816.parse.mzparser import A816Parser
+
+    pool = A816Parser.parse_as_ast(".pool wram { bss  range 0x7e0000 0x7e1fff }\n", "t.s").nodes[0]
+    canonical = pool.to_canonical()
+    assert "bss" in canonical
+    assert canonical.startswith(".pool wram {")
+
+    res = A816Parser.parse_as_ast(".res 0x10\n", "t.s").nodes[0]
+    assert res.to_canonical() == ".res 0x10"
+    assert res.to_representation()[0] == "res"

--- a/tests/test_reserve.py
+++ b/tests/test_reserve.py
@@ -86,6 +86,69 @@ hp:
         assert all(s.code == b"" for s in linked.sections if s.bss)
 
 
+def test_flat_reserve_binds_symbols() -> None:
+    """`.reserve NAME SIZE in POOL` lays out RAM vars flat, no wrapper alloc."""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(
+            _PREAMBLE
+            + ".reserve player_x  0x2   in wram\n"
+            + ".reserve player_hp 0x1   in wram\n"
+            + ".reserve scratch   0x100 in wram\n"
+        )
+        obj = Path(tmp) / "m.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        linked = Linker([ObjectFile.from_file(str(obj))]).link(base_address=0x8000)
+        syms = _symbols(linked)
+        assert syms["player_x"] == 0x7E0000
+        assert syms["player_hp"] == 0x7E0002  # player_x + 2
+        assert syms["scratch"] == 0x7E0003  # player_hp + 1
+        assert all(s.code == b"" for s in linked.sections if s.bss)
+
+
+_STRUCT = """
+.struct GameState {
+    word score
+    byte lives
+    byte level
+}
+"""
+
+
+def test_typed_reserve_publishes_struct_fields() -> None:
+    """`.reserve NAME as TYPE in POOL` reserves sizeof(TYPE) and binds NAME +
+    NAME.<field> at the allocator-assigned address."""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(_PREAMBLE + _STRUCT + ".reserve game_state as GameState in wram\n.reserve after 0x1 in wram\n")
+        obj = Path(tmp) / "m.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        linked = Linker([ObjectFile.from_file(str(obj))]).link(base_address=0x8000)
+        syms = _symbols(linked)
+        assert syms["game_state"] == 0x7E0000
+        assert syms["game_state.score"] == 0x7E0000  # offset 0
+        assert syms["game_state.lives"] == 0x7E0002  # offset 2 (word + )
+        assert syms["game_state.level"] == 0x7E0003  # offset 3
+        # The next reservation lands past the whole 4-byte struct.
+        assert syms["after"] == 0x7E0004
+        assert all(s.code == b"" for s in linked.sections if s.bss)
+
+
+def test_typed_reserve_unknown_struct_errors() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(_PREAMBLE + ".reserve x as NoSuchStruct in wram\n")
+        assert Program().assemble_as_object(str(asm), Path(tmp) / "m.o") != 0
+
+
+def test_flat_reserve_into_non_bss_pool_errors() -> None:
+    """Reserving in a non-bss (ROM) pool is a clear error, not a struct crash."""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(".pool rom { range 0xc10000 0xc1ffff }\n.reserve x 0x10 in rom\n")
+        assert Program().assemble_as_object(str(asm), Path(tmp) / "m.o") != 0
+
+
 def test_bss_pool_rejects_emitted_bytes() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         asm = Path(tmp) / "m.s"
@@ -113,3 +176,7 @@ def test_bss_and_reserve_round_trip_canonical() -> None:
     res = A816Parser.parse_as_ast(".res 0x10\n", "t.s").nodes[0]
     assert res.to_canonical() == ".res 0x10"
     assert res.to_representation()[0] == "res"
+
+    typed = A816Parser.parse_as_ast(".reserve game_state as GameState in wram\n", "t.s").nodes[0]
+    assert typed.to_canonical() == ".reserve game_state as GameState in wram"
+    assert typed.to_representation() == ("reserve_typed", "game_state", "GameState", "wram")

--- a/tests/test_xobj.py
+++ b/tests/test_xobj.py
@@ -31,7 +31,7 @@ def test_summary_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> 
     assert rc == 0
     assert "sections: 1" in captured.out
     assert "symbols: 1" in captured.out
-    assert "version: 9" in captured.out
+    assert "version: 10" in captured.out
 
 
 def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -40,7 +40,7 @@ def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
     captured = capsys.readouterr()
     assert rc == 0
     data = json.loads(captured.out)
-    assert data["version"] == 9
+    assert data["version"] == 10
     assert data["sections"][0]["base_address"] == 0x008000
     assert bytes.fromhex(data["sections"][0]["code"]) == b"\xea\xea"
     assert data["symbols"][0]["type"] == "GLOBAL"

--- a/tests/test_xobj.py
+++ b/tests/test_xobj.py
@@ -31,7 +31,7 @@ def test_summary_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> 
     assert rc == 0
     assert "sections: 1" in captured.out
     assert "symbols: 1" in captured.out
-    assert "version: 10" in captured.out
+    assert "version: 11" in captured.out
 
 
 def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -40,7 +40,7 @@ def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
     captured = capsys.readouterr()
     assert rc == 0
     data = json.loads(captured.out)
-    assert data["version"] == 10
+    assert data["version"] == 11
     assert data["sections"][0]["base_address"] == 0x008000
     assert bytes.fromhex(data["sections"][0]["code"]) == b"\xea\xea"
     assert data["symbols"][0]["type"] == "GLOBAL"


### PR DESCRIPTION
## Why

WRAM/RAM layout in a816 was hand-assigned — `NAME = 0x7Exxxx` constants scattered across includes, with **silent overlaps** that only surfaced as runtime corruption (a cacheguard report: a text-palette write aliasing a dispatcher's state byte, etc.). The `.pool` allocator already solved exactly this for ROM (assign + overlap-check); this extends it to byte-less regions.

## What

A **`bss` pool** reserves and overlap-checks address space (WRAM, SRAM, SA-1 BW-RAM, any `writable` map) but emits **nothing** into the image, plus directives to lay variables out structurally.

```asm
.map identifier=3 bank_range=0x7e,0x7f addr_range=0x0000,0xffff mask=0x10000 writable=1
.pool wram { bss  range 0x7e0000 0x7e1fff }

.struct Player { word x  word y  byte hp }

.reserve health   0x2           in wram   ; raw size
.reserve player   as Player     in wram   ; struct: base + fields
```
→ `health=$7E0000`, `player=$7E0002`, `player.x=$7E0002`, `player.y=$7E0004`, `player.hp=$7E0006` — allocator-assigned, overlap-checked, zero ROM bytes.

### Primitives
- **`.res N`** — reserve N bytes, advance the PC, emit nothing.
- **`bss` flag** on `.pool` — a byte-less pool. Emitting a byte into a bss alloc is a hard error.
- **`.reserve NAME SIZE in POOL`** — flat reservation (desugars to a bss alloc + `.res`), no wrapper name.
- **`.reserve NAME as TYPE in POOL`** — expands the struct layout into per-field labels (`NAME.field` at each offset, nested structs included) that rebase with the base.

### Lifetime reuse — no new syntax
Two bss pools over the **same range** are per-state arenas: each overlap-checks its own reservations; cross-pool overlap is the intended reuse for states that never coexist (battle vs field). `.context` was considered and dropped — the pool already is the arena.

### Map-agnostic
Works for any `writable` region you declare: `$7E` WRAM, SA-1 `$40` BW-RAM, a custom `$FE` map. a816 doesn't care what the target decodes.

## How it works
- Byte-less sections are first-class: `Section.bss`, survive the writer's drop-empty pass, serialized (object format **v9 → v10**), carried through the linker, skipped at final SFC/IPS emit (and never `_to_physical`'d, so WRAM addresses with no physical mapping are fine).
- Everything runs through the **real object + link path**, not the deprecated direct mode (which now warns `DeprecationWarning`).

## Test plan
- bss alloc binds symbols at WRAM addresses, emits no bytes; a ROM routine touching reserved WRAM gets the assigned address while the WRAM bytes stay out of the image.
- flat + struct-typed `.reserve` (nested structs); next reservation lands past the full struct size.
- two pools over one range reuse bytes.
- errors: emitting into a bss pool; reserving into a non-bss pool; unknown struct type; negative `.res`.

## Out of scope
- `.context` nested/stack lifetimes (per-state pools cover the need).
- Wiring the dormant `.istruct` keyword (superseded by `.reserve ... as`).
