### PR TITLE
ORA #imm16 was encoded as LDA (opcode A9 not 09)

### DIFF
--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -253,7 +253,7 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
         AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0xB3])},
     },
     "ora": {
-        AddressingMode.immediate: Opcode([0x09, 0xA9], is_a=True),
+        AddressingMode.immediate: Opcode([0x09, 0x09], is_a=True),
         AddressingMode.direct: Opcode([0x05, 0x0D, 0x0F], is_a=True),
         AddressingMode.direct_indexed: {
             "x": Opcode([None, 0x1D, 0x1F], is_a=True),

--- a/tests/test_code_gen.py
+++ b/tests/test_code_gen.py
@@ -80,6 +80,32 @@ class CodeGenTest(unittest.TestCase):
                 assert isinstance(node, OpcodeNode)
                 self.assertEqual(node.emit(program.resolver.reloc_address), expected)
 
+    def test_alu_immediate_opcodes_under_a16(self) -> None:
+        """16-bit immediate ALU opcodes must each use their own opcode.
+
+        Regression: `ora #imm` under .a16 was mis-encoded as `$A9` (LDA),
+        copy-pasted from the lda row, so `ora #0x2000` silently became
+        `lda #0x2000` (replace instead of OR). Pin the whole family.
+        """
+        cases = {
+            "ora": b"\x09\x00\x20",
+            "and": b"\x29\x00\x20",
+            "eor": b"\x49\x00\x20",
+            "adc": b"\x69\x00\x20",
+            "sbc": b"\xe9\x00\x20",
+            "lda": b"\xa9\x00\x20",
+            "cmp": b"\xc9\x00\x20",
+        }
+        for opcode, expected in cases.items():
+            with self.subTest(opcode=opcode):
+                program = Program()
+                _, nodes = program.parser.parse(f"{opcode} #0x2000")
+                program.resolve_labels(nodes)
+                program.resolver.a_size = 16
+                node = nodes[-1]
+                assert isinstance(node, OpcodeNode)
+                self.assertEqual(node.emit(program.resolver.reloc_address), expected)
+
     def test_ateq_reslove(self) -> None:
         program = Program()
         program.resolve_labels(


### PR DESCRIPTION
## What

`ora` immediate 16-bit opcode was `0xA9` (= `LDA`), copy-pasted from the `lda` row above. Under `.a16`, `ora #imm` silently assembled to `lda #imm` — replace A instead of OR. Fix to `0x09`.

8-bit `ora` and other ALU immediates unaffected.

## Why

Found downstream in cacheguard: `ora #0x2000` (force BG3 priority bit) became `lda #0x2000`, blanking every tilemap cell.

## Test

`test_alu_immediate_opcodes_under_a16` pins the whole `ora/and/eor/adc/sbc/lda/cmp` immediate family under `.a16`, so this opcode-table typo class cannot recur.