### PR TITLE
Complete the 65c816 ISA table and derive the disassembler from it

### DIFF
--- a/a816/cpu/cpu_65c816.py
+++ b/a816/cpu/cpu_65c816.py
@@ -133,10 +133,14 @@ def guess_value_size(
 
 
 class Opcode(OpcodeProtocol):
-    def __init__(self, opcode_def: list[int | None], is_a: bool = False, is_x: bool = False):
+    def __init__(self, opcode_def: list[int | None], is_a: bool = False, is_x: bool = False, alias: bool = False):
         self.opcode_def = opcode_def
         self.is_a = is_a
         self.is_x = is_x
+        # `alias=True` marks an encode-only convenience entry (e.g. `jsl` ≡
+        # `jsr.l`). The disassembler's derived byte-to-instruction map skips
+        # these so each opcode byte decodes to exactly one mnemonic.
+        self.alias = alias
         self.size_opcode_map: dict[str, int] = {"b": 0, "w": 1, "l": 2}
 
     def emit_value(self, value_node: "ValueNodeProtocol", size: ValueSize) -> bytes:
@@ -217,6 +221,75 @@ class Opcode(OpcodeProtocol):
         return node_bytes
 
 
+class LongOpcode(Opcode):
+    """Always emits the 24-bit long form, regardless of inferred operand size.
+
+    `jsl` / `jml` are inherently 3-byte-operand instructions (long call / long
+    jump). Encoding them as a plain size-indexed `Opcode` would infer width from
+    the target value, so a sub-bank target (`jsl $1234`) would raise
+    `NoOpcodeForOperandSize`. Pinning the operand to `l` keeps them long.
+    """
+
+    def __init__(self, opcode: int, alias: bool = False) -> None:
+        super().__init__([None, None, opcode], alias=alias)
+
+    def emit(
+        self,
+        value_node: "ValueNodeProtocol | None",
+        resolver: "Resolver",
+        size: ValueSize | None = None,
+    ) -> bytes:
+        return super().emit(value_node, resolver, "l")
+
+    def supposed_length(
+        self,
+        value_node: "ValueNodeProtocol | None",
+        size: ValueSize | None = None,
+        resolver: "Resolver | None" = None,
+    ) -> int:
+        return super().supposed_length(value_node, "l", resolver)
+
+
+class BlockMoveOpcode(OpcodeProtocol):
+    """`mvn` / `mvp` block move: two bank operands.
+
+    Source order is `mvn srcbank, destbank`, but the encoded operand bytes are
+    REVERSED: `opcode, destbank, srcbank`. Each operand contributes its low 8
+    bits (the bank byte). Driven by `OpcodeNode` via `emit_block_move` because
+    the generic single-operand `emit` path can't carry two value nodes.
+    """
+
+    def __init__(self, opcode: int) -> None:
+        self.opcode = opcode
+
+    def emit_block_move(
+        self,
+        src_node: "ValueNodeProtocol",
+        dest_node: "ValueNodeProtocol",
+        resolver: "Resolver",
+    ) -> bytes:
+        del resolver
+        src = src_node.get_value() & 0xFF
+        dest = dest_node.get_value() & 0xFF
+        return struct.pack("BBB", self.opcode, dest, src)
+
+    def emit(
+        self,
+        value_node: "ValueNodeProtocol | None",
+        resolver: "Resolver",
+        size: ValueSize | None = None,
+    ) -> bytes:
+        raise NoOpcodeForOperandSize()  # block move is routed via emit_block_move
+
+    def supposed_length(
+        self,
+        value_node: "ValueNodeProtocol | None",
+        size: ValueSize | None = None,
+        resolver: "Resolver | None" = None,
+    ) -> int:
+        return 3
+
+
 OpcodeDef = OpcodeProtocol | dict[str, OpcodeProtocol]
 
 snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
@@ -253,20 +326,25 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
         AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0xB3])},
     },
     "ora": {
-        AddressingMode.immediate: Opcode([0x09, 0xA9], is_a=True),
+        AddressingMode.immediate: Opcode([0x09, 0x09], is_a=True),
         AddressingMode.direct: Opcode([0x05, 0x0D, 0x0F], is_a=True),
         AddressingMode.direct_indexed: {
-            "x": Opcode([None, 0x1D, 0x1F], is_a=True),
+            "x": Opcode([0x15, 0x1D, 0x1F], is_a=True),
             "y": Opcode([None, 0x19, None], is_a=True),
             "s": Opcode([0x03]),
         },
+        AddressingMode.indirect: Opcode([0x12]),
+        AddressingMode.indirect_long: Opcode([0x07]),
+        AddressingMode.indirect_indexed: {"y": Opcode([0x11])},
         AddressingMode.indirect_indexed_long: {"y": Opcode([0x17])},
+        AddressingMode.dp_or_sr_indirect_indexed: {"x": Opcode([0x01])},
+        AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0x13])},
     },
     "eor": {
-        AddressingMode.immediate: Opcode([0x49, 0x49]),
+        AddressingMode.immediate: Opcode([0x49, 0x49], is_a=True),
         AddressingMode.direct: Opcode([0x45, 0x4D, 0x4F]),
         AddressingMode.direct_indexed: {
-            "x": Opcode([None, 0x5D, 0x5F]),
+            "x": Opcode([0x55, 0x5D, 0x5F]),
             "y": Opcode([None, 0x59, None]),
             "s": Opcode([0x43]),
         },
@@ -292,13 +370,20 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
         AddressingMode.direct: Opcode([0x46, 0x4E]),
         AddressingMode.direct_indexed: {"x": Opcode([0x56, 0x5E])},
     },
-    "jsr": {AddressingMode.direct: Opcode([None, 0x20, 0x22])},
+    "jsr": {
+        AddressingMode.direct: Opcode([None, 0x20, 0x22]),
+        AddressingMode.dp_or_sr_indirect_indexed: Opcode([None, 0xFC]),
+    },
     "jmp": {
         AddressingMode.direct: Opcode([None, 0x4C, 0x5C]),
         AddressingMode.indirect: Opcode([None, 0x6C, None]),
         AddressingMode.indirect_long: Opcode([None, 0xDC, None]),
         AddressingMode.dp_or_sr_indirect_indexed: Opcode([None, 0x7C, None]),
     },
+    # jsl / jml: encode-only aliases for `jsr.l` (0x22) / `jmp.l` (0x5C).
+    # alias=True keeps them out of the disassembler's derived table.
+    "jsl": {AddressingMode.direct: LongOpcode(0x22, alias=True)},
+    "jml": {AddressingMode.direct: LongOpcode(0x5C, alias=True)},
     "inc": {
         AddressingMode.none: OpcodeWithoutOperand(0x1A),
         AddressingMode.direct: Opcode([0xE6, 0xEE]),
@@ -320,6 +405,8 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
         AddressingMode.indirect_indexed: {"y": Opcode([0x71])},
         AddressingMode.indirect_long: Opcode([0x67]),
         AddressingMode.indirect_indexed_long: {"y": Opcode([0x77])},
+        AddressingMode.dp_or_sr_indirect_indexed: {"x": Opcode([0x61])},
+        AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0x73])},
     },
     "and": {
         AddressingMode.immediate: Opcode([0x29, 0x29], is_a=True),
@@ -327,11 +414,14 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
         AddressingMode.direct_indexed: {
             "x": Opcode([0x35, 0x3D, 0x3F]),
             "y": Opcode([None, 0x39, None]),
+            "s": Opcode([0x23]),
         },
         AddressingMode.indirect: Opcode([0x32]),
         AddressingMode.indirect_indexed: {"y": Opcode([0x31])},
         AddressingMode.indirect_long: Opcode([0x27]),
         AddressingMode.indirect_indexed_long: {"y": Opcode([0x37])},
+        AddressingMode.dp_or_sr_indirect_indexed: {"x": Opcode([0x21])},
+        AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0x33])},
     },
     "asl": {
         AddressingMode.none: OpcodeWithoutOperand(0x0A),
@@ -351,6 +441,8 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
     "bpl": {AddressingMode.direct: RelativeJumpOpcode(0x10)},
     "bra": {AddressingMode.direct: RelativeJumpOpcode(0x80)},
     "brl": {AddressingMode.direct: RelativeLongJumpOpcode(0x82)},
+    "bvc": {AddressingMode.direct: RelativeJumpOpcode(0x50)},
+    "bvs": {AddressingMode.direct: RelativeJumpOpcode(0x70)},
     # BRK / COP / WDM are 2-byte instructions on 65816: opcode + a
     # signature byte the handler reads off the stack (PC pushed is the
     # instruction + 2). Force callers to supply the signature so the
@@ -358,6 +450,8 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
     "brk": {AddressingMode.immediate: Opcode([0x00])},
     "cop": {AddressingMode.immediate: Opcode([0x02])},
     "wdm": {AddressingMode.immediate: Opcode([0x42])},
+    "mvn": {AddressingMode.block_move: BlockMoveOpcode(0x54)},
+    "mvp": {AddressingMode.block_move: BlockMoveOpcode(0x44)},
     "clc": {AddressingMode.none: OpcodeWithoutOperand(0x18)},
     "cld": {AddressingMode.none: OpcodeWithoutOperand(0xD8)},
     "cli": {AddressingMode.none: OpcodeWithoutOperand(0x58)},
@@ -366,13 +460,20 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
         AddressingMode.immediate: Opcode([0xC9, 0xC9], is_a=True),
         AddressingMode.direct: Opcode([0xC5, 0xCD, 0xCF], is_a=True),
         AddressingMode.direct_indexed: {
-            "x": Opcode([None, 0xDD, 0xDF], is_a=True),
+            "x": Opcode([0xD5, 0xDD, 0xDF], is_a=True),
             "y": Opcode([None, 0xD9, None], is_a=True),
             "s": Opcode([0xC3]),
         },
+        AddressingMode.indirect: Opcode([0xD2]),
+        AddressingMode.indirect_long: Opcode([0xC7]),
+        AddressingMode.indirect_indexed: {"y": Opcode([0xD1])},
+        AddressingMode.indirect_indexed_long: {"y": Opcode([0xD7])},
+        AddressingMode.dp_or_sr_indirect_indexed: {"x": Opcode([0xC1])},
+        AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0xD3])},
     },
     "pea": {AddressingMode.direct: Opcode([None, 0xF4])},
     "pei": {AddressingMode.indirect: Opcode([0xD4])},
+    "per": {AddressingMode.direct: RelativeLongJumpOpcode(0x62)},
     "pha": {AddressingMode.none: OpcodeWithoutOperand(0x48)},
     "pla": {AddressingMode.none: OpcodeWithoutOperand(0x68)},
     "phy": {AddressingMode.none: OpcodeWithoutOperand(0x5A)},
@@ -410,8 +511,11 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
             "s": Opcode([0xE3]),
         },
         AddressingMode.indirect: Opcode([0xF2]),
+        AddressingMode.indirect_long: Opcode([0xE7]),
         AddressingMode.indirect_indexed: {"y": Opcode([0xF1])},
         AddressingMode.indirect_indexed_long: {"y": Opcode([0xF7])},
+        AddressingMode.dp_or_sr_indirect_indexed: {"x": Opcode([0xE1])},
+        AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0xF3])},
     },
     "sec": {AddressingMode.none: OpcodeWithoutOperand(0x38)},
     "sed": {AddressingMode.none: OpcodeWithoutOperand(0xF8)},
@@ -428,6 +532,8 @@ snes_opcode_table: dict[str, dict[AddressingMode, OpcodeDef]] = {
             "y": Opcode([None, 0x99, None]),
             "s": Opcode([0x83]),
         },
+        AddressingMode.dp_or_sr_indirect_indexed: {"x": Opcode([0x81])},
+        AddressingMode.stack_indexed_indirect_indexed: {"y": Opcode([0x93])},
     },
     "stx": {
         AddressingMode.direct: Opcode([0x86, 0x8E]),

--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -4,9 +4,19 @@
 Provides instruction decoding with support for all addressing modes.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
+
+from a816.cpu.cpu_65c816 import (
+    BlockMoveOpcode,
+    Opcode,
+    OpcodeWithoutOperand,
+    RelativeJumpOpcode,
+    RelativeLongJumpOpcode,
+    snes_opcode_table,
+)
+from a816.cpu.types import AddressingMode as _AsmMode
 
 
 class AddrMode(Enum):
@@ -208,304 +218,106 @@ class Instruction:
 
 # Opcode table: opcode -> (mnemonic, addressing_mode, operand_size)
 # operand_size: 0=none, 1=byte, 2=word, 3=long, -1=M-dependent, -2=X-dependent
-OPCODE_TABLE: dict[int, tuple[str, AddrMode, int]] = {
-    # ADC
-    0x69: ("adc", AddrMode.IMMEDIATE_M, -1),
-    0x65: ("adc", AddrMode.DIRECT, 1),
-    0x75: ("adc", AddrMode.DIRECT_X, 1),
-    0x72: ("adc", AddrMode.DIRECT_IND, 1),
-    0x61: ("adc", AddrMode.DIRECT_IND_X, 1),
-    0x71: ("adc", AddrMode.DIRECT_IND_Y, 1),
-    0x67: ("adc", AddrMode.DIRECT_IND_LONG, 1),
-    0x77: ("adc", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0x6D: ("adc", AddrMode.ABSOLUTE, 2),
-    0x7D: ("adc", AddrMode.ABSOLUTE_X, 2),
-    0x79: ("adc", AddrMode.ABSOLUTE_Y, 2),
-    0x6F: ("adc", AddrMode.ABSOLUTE_LONG, 3),
-    0x7F: ("adc", AddrMode.ABSOLUTE_LONG_X, 3),
-    0x63: ("adc", AddrMode.STACK_REL, 1),
-    0x73: ("adc", AddrMode.STACK_REL_IND_Y, 1),
-    # AND
-    0x29: ("and", AddrMode.IMMEDIATE_M, -1),
-    0x25: ("and", AddrMode.DIRECT, 1),
-    0x35: ("and", AddrMode.DIRECT_X, 1),
-    0x32: ("and", AddrMode.DIRECT_IND, 1),
-    0x21: ("and", AddrMode.DIRECT_IND_X, 1),
-    0x31: ("and", AddrMode.DIRECT_IND_Y, 1),
-    0x27: ("and", AddrMode.DIRECT_IND_LONG, 1),
-    0x37: ("and", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0x2D: ("and", AddrMode.ABSOLUTE, 2),
-    0x3D: ("and", AddrMode.ABSOLUTE_X, 2),
-    0x39: ("and", AddrMode.ABSOLUTE_Y, 2),
-    0x2F: ("and", AddrMode.ABSOLUTE_LONG, 3),
-    0x3F: ("and", AddrMode.ABSOLUTE_LONG_X, 3),
-    0x23: ("and", AddrMode.STACK_REL, 1),
-    0x33: ("and", AddrMode.STACK_REL_IND_Y, 1),
-    # ASL
-    0x0A: ("asl", AddrMode.IMPLIED, 0),
-    0x06: ("asl", AddrMode.DIRECT, 1),
-    0x16: ("asl", AddrMode.DIRECT_X, 1),
-    0x0E: ("asl", AddrMode.ABSOLUTE, 2),
-    0x1E: ("asl", AddrMode.ABSOLUTE_X, 2),
-    # Branch instructions
-    0x90: ("bcc", AddrMode.RELATIVE, 1),
-    0xB0: ("bcs", AddrMode.RELATIVE, 1),
-    0xF0: ("beq", AddrMode.RELATIVE, 1),
-    0x30: ("bmi", AddrMode.RELATIVE, 1),
-    0xD0: ("bne", AddrMode.RELATIVE, 1),
-    0x10: ("bpl", AddrMode.RELATIVE, 1),
-    0x80: ("bra", AddrMode.RELATIVE, 1),
-    0x82: ("brl", AddrMode.RELATIVE_LONG, 2),
-    0x50: ("bvc", AddrMode.RELATIVE, 1),
-    0x70: ("bvs", AddrMode.RELATIVE, 1),
-    # BIT
-    0x89: ("bit", AddrMode.IMMEDIATE_M, -1),
-    0x24: ("bit", AddrMode.DIRECT, 1),
-    0x34: ("bit", AddrMode.DIRECT_X, 1),
-    0x2C: ("bit", AddrMode.ABSOLUTE, 2),
-    0x3C: ("bit", AddrMode.ABSOLUTE_X, 2),
-    # BRK, COP
-    0x00: ("brk", AddrMode.IMMEDIATE_8, 1),
-    0x02: ("cop", AddrMode.IMMEDIATE_8, 1),
-    # Clear/Set flags
-    0x18: ("clc", AddrMode.IMPLIED, 0),
-    0xD8: ("cld", AddrMode.IMPLIED, 0),
-    0x58: ("cli", AddrMode.IMPLIED, 0),
-    0xB8: ("clv", AddrMode.IMPLIED, 0),
-    0x38: ("sec", AddrMode.IMPLIED, 0),
-    0xF8: ("sed", AddrMode.IMPLIED, 0),
-    0x78: ("sei", AddrMode.IMPLIED, 0),
-    # CMP
-    0xC9: ("cmp", AddrMode.IMMEDIATE_M, -1),
-    0xC5: ("cmp", AddrMode.DIRECT, 1),
-    0xD5: ("cmp", AddrMode.DIRECT_X, 1),
-    0xD2: ("cmp", AddrMode.DIRECT_IND, 1),
-    0xC1: ("cmp", AddrMode.DIRECT_IND_X, 1),
-    0xD1: ("cmp", AddrMode.DIRECT_IND_Y, 1),
-    0xC7: ("cmp", AddrMode.DIRECT_IND_LONG, 1),
-    0xD7: ("cmp", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0xCD: ("cmp", AddrMode.ABSOLUTE, 2),
-    0xDD: ("cmp", AddrMode.ABSOLUTE_X, 2),
-    0xD9: ("cmp", AddrMode.ABSOLUTE_Y, 2),
-    0xCF: ("cmp", AddrMode.ABSOLUTE_LONG, 3),
-    0xDF: ("cmp", AddrMode.ABSOLUTE_LONG_X, 3),
-    0xC3: ("cmp", AddrMode.STACK_REL, 1),
-    0xD3: ("cmp", AddrMode.STACK_REL_IND_Y, 1),
-    # CPX
-    0xE0: ("cpx", AddrMode.IMMEDIATE_X, -2),
-    0xE4: ("cpx", AddrMode.DIRECT, 1),
-    0xEC: ("cpx", AddrMode.ABSOLUTE, 2),
-    # CPY
-    0xC0: ("cpy", AddrMode.IMMEDIATE_X, -2),
-    0xC4: ("cpy", AddrMode.DIRECT, 1),
-    0xCC: ("cpy", AddrMode.ABSOLUTE, 2),
-    # DEC
-    0x3A: ("dec", AddrMode.IMPLIED, 0),
-    0xC6: ("dec", AddrMode.DIRECT, 1),
-    0xD6: ("dec", AddrMode.DIRECT_X, 1),
-    0xCE: ("dec", AddrMode.ABSOLUTE, 2),
-    0xDE: ("dec", AddrMode.ABSOLUTE_X, 2),
-    # DEX, DEY
-    0xCA: ("dex", AddrMode.IMPLIED, 0),
-    0x88: ("dey", AddrMode.IMPLIED, 0),
-    # EOR
-    0x49: ("eor", AddrMode.IMMEDIATE_M, -1),
-    0x45: ("eor", AddrMode.DIRECT, 1),
-    0x55: ("eor", AddrMode.DIRECT_X, 1),
-    0x52: ("eor", AddrMode.DIRECT_IND, 1),
-    0x41: ("eor", AddrMode.DIRECT_IND_X, 1),
-    0x51: ("eor", AddrMode.DIRECT_IND_Y, 1),
-    0x47: ("eor", AddrMode.DIRECT_IND_LONG, 1),
-    0x57: ("eor", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0x4D: ("eor", AddrMode.ABSOLUTE, 2),
-    0x5D: ("eor", AddrMode.ABSOLUTE_X, 2),
-    0x59: ("eor", AddrMode.ABSOLUTE_Y, 2),
-    0x4F: ("eor", AddrMode.ABSOLUTE_LONG, 3),
-    0x5F: ("eor", AddrMode.ABSOLUTE_LONG_X, 3),
-    0x43: ("eor", AddrMode.STACK_REL, 1),
-    0x53: ("eor", AddrMode.STACK_REL_IND_Y, 1),
-    # INC
-    0x1A: ("inc", AddrMode.IMPLIED, 0),
-    0xE6: ("inc", AddrMode.DIRECT, 1),
-    0xF6: ("inc", AddrMode.DIRECT_X, 1),
-    0xEE: ("inc", AddrMode.ABSOLUTE, 2),
-    0xFE: ("inc", AddrMode.ABSOLUTE_X, 2),
-    # INX, INY
-    0xE8: ("inx", AddrMode.IMPLIED, 0),
-    0xC8: ("iny", AddrMode.IMPLIED, 0),
-    # JMP
-    0x4C: ("jmp", AddrMode.ABSOLUTE, 2),
-    0x5C: ("jmp", AddrMode.ABSOLUTE_LONG, 3),
-    0x6C: ("jmp", AddrMode.ABSOLUTE_IND, 2),
-    0x7C: ("jmp", AddrMode.ABSOLUTE_IND_X, 2),
-    0xDC: ("jmp", AddrMode.ABSOLUTE_IND_LONG, 2),
-    # JSR, JSL
-    0x20: ("jsr", AddrMode.ABSOLUTE, 2),
-    0x22: ("jsl", AddrMode.ABSOLUTE_LONG, 3),
-    0xFC: ("jsr", AddrMode.ABSOLUTE_IND_X, 2),
-    # LDA
-    0xA9: ("lda", AddrMode.IMMEDIATE_M, -1),
-    0xA5: ("lda", AddrMode.DIRECT, 1),
-    0xB5: ("lda", AddrMode.DIRECT_X, 1),
-    0xB2: ("lda", AddrMode.DIRECT_IND, 1),
-    0xA1: ("lda", AddrMode.DIRECT_IND_X, 1),
-    0xB1: ("lda", AddrMode.DIRECT_IND_Y, 1),
-    0xA7: ("lda", AddrMode.DIRECT_IND_LONG, 1),
-    0xB7: ("lda", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0xAD: ("lda", AddrMode.ABSOLUTE, 2),
-    0xBD: ("lda", AddrMode.ABSOLUTE_X, 2),
-    0xB9: ("lda", AddrMode.ABSOLUTE_Y, 2),
-    0xAF: ("lda", AddrMode.ABSOLUTE_LONG, 3),
-    0xBF: ("lda", AddrMode.ABSOLUTE_LONG_X, 3),
-    0xA3: ("lda", AddrMode.STACK_REL, 1),
-    0xB3: ("lda", AddrMode.STACK_REL_IND_Y, 1),
-    # LDX
-    0xA2: ("ldx", AddrMode.IMMEDIATE_X, -2),
-    0xA6: ("ldx", AddrMode.DIRECT, 1),
-    0xB6: ("ldx", AddrMode.DIRECT_Y, 1),
-    0xAE: ("ldx", AddrMode.ABSOLUTE, 2),
-    0xBE: ("ldx", AddrMode.ABSOLUTE_Y, 2),
-    # LDY
-    0xA0: ("ldy", AddrMode.IMMEDIATE_X, -2),
-    0xA4: ("ldy", AddrMode.DIRECT, 1),
-    0xB4: ("ldy", AddrMode.DIRECT_X, 1),
-    0xAC: ("ldy", AddrMode.ABSOLUTE, 2),
-    0xBC: ("ldy", AddrMode.ABSOLUTE_X, 2),
-    # LSR
-    0x4A: ("lsr", AddrMode.IMPLIED, 0),
-    0x46: ("lsr", AddrMode.DIRECT, 1),
-    0x56: ("lsr", AddrMode.DIRECT_X, 1),
-    0x4E: ("lsr", AddrMode.ABSOLUTE, 2),
-    0x5E: ("lsr", AddrMode.ABSOLUTE_X, 2),
-    # Block move
-    0x54: ("mvn", AddrMode.BLOCK_MOVE, 2),
-    0x44: ("mvp", AddrMode.BLOCK_MOVE, 2),
-    # NOP
-    0xEA: ("nop", AddrMode.IMPLIED, 0),
-    # ORA
-    0x09: ("ora", AddrMode.IMMEDIATE_M, -1),
-    0x05: ("ora", AddrMode.DIRECT, 1),
-    0x15: ("ora", AddrMode.DIRECT_X, 1),
-    0x12: ("ora", AddrMode.DIRECT_IND, 1),
-    0x01: ("ora", AddrMode.DIRECT_IND_X, 1),
-    0x11: ("ora", AddrMode.DIRECT_IND_Y, 1),
-    0x07: ("ora", AddrMode.DIRECT_IND_LONG, 1),
-    0x17: ("ora", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0x0D: ("ora", AddrMode.ABSOLUTE, 2),
-    0x1D: ("ora", AddrMode.ABSOLUTE_X, 2),
-    0x19: ("ora", AddrMode.ABSOLUTE_Y, 2),
-    0x0F: ("ora", AddrMode.ABSOLUTE_LONG, 3),
-    0x1F: ("ora", AddrMode.ABSOLUTE_LONG_X, 3),
-    0x03: ("ora", AddrMode.STACK_REL, 1),
-    0x13: ("ora", AddrMode.STACK_REL_IND_Y, 1),
-    # PEA, PEI, PER
-    0xF4: ("pea", AddrMode.ABSOLUTE, 2),
-    0xD4: ("pei", AddrMode.DIRECT_IND, 1),
-    0x62: ("per", AddrMode.RELATIVE_LONG, 2),
-    # Push/Pull
-    0x48: ("pha", AddrMode.IMPLIED, 0),
-    0x8B: ("phb", AddrMode.IMPLIED, 0),
-    0x0B: ("phd", AddrMode.IMPLIED, 0),
-    0x4B: ("phk", AddrMode.IMPLIED, 0),
-    0x08: ("php", AddrMode.IMPLIED, 0),
-    0xDA: ("phx", AddrMode.IMPLIED, 0),
-    0x5A: ("phy", AddrMode.IMPLIED, 0),
-    0x68: ("pla", AddrMode.IMPLIED, 0),
-    0xAB: ("plb", AddrMode.IMPLIED, 0),
-    0x2B: ("pld", AddrMode.IMPLIED, 0),
-    0x28: ("plp", AddrMode.IMPLIED, 0),
-    0xFA: ("plx", AddrMode.IMPLIED, 0),
-    0x7A: ("ply", AddrMode.IMPLIED, 0),
-    # REP, SEP
-    0xC2: ("rep", AddrMode.IMMEDIATE_8, 1),
-    0xE2: ("sep", AddrMode.IMMEDIATE_8, 1),
-    # ROL
-    0x2A: ("rol", AddrMode.IMPLIED, 0),
-    0x26: ("rol", AddrMode.DIRECT, 1),
-    0x36: ("rol", AddrMode.DIRECT_X, 1),
-    0x2E: ("rol", AddrMode.ABSOLUTE, 2),
-    0x3E: ("rol", AddrMode.ABSOLUTE_X, 2),
-    # ROR
-    0x6A: ("ror", AddrMode.IMPLIED, 0),
-    0x66: ("ror", AddrMode.DIRECT, 1),
-    0x76: ("ror", AddrMode.DIRECT_X, 1),
-    0x6E: ("ror", AddrMode.ABSOLUTE, 2),
-    0x7E: ("ror", AddrMode.ABSOLUTE_X, 2),
-    # RTI, RTL, RTS
-    0x40: ("rti", AddrMode.IMPLIED, 0),
-    0x6B: ("rtl", AddrMode.IMPLIED, 0),
-    0x60: ("rts", AddrMode.IMPLIED, 0),
-    # SBC
-    0xE9: ("sbc", AddrMode.IMMEDIATE_M, -1),
-    0xE5: ("sbc", AddrMode.DIRECT, 1),
-    0xF5: ("sbc", AddrMode.DIRECT_X, 1),
-    0xF2: ("sbc", AddrMode.DIRECT_IND, 1),
-    0xE1: ("sbc", AddrMode.DIRECT_IND_X, 1),
-    0xF1: ("sbc", AddrMode.DIRECT_IND_Y, 1),
-    0xE7: ("sbc", AddrMode.DIRECT_IND_LONG, 1),
-    0xF7: ("sbc", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0xED: ("sbc", AddrMode.ABSOLUTE, 2),
-    0xFD: ("sbc", AddrMode.ABSOLUTE_X, 2),
-    0xF9: ("sbc", AddrMode.ABSOLUTE_Y, 2),
-    0xEF: ("sbc", AddrMode.ABSOLUTE_LONG, 3),
-    0xFF: ("sbc", AddrMode.ABSOLUTE_LONG_X, 3),
-    0xE3: ("sbc", AddrMode.STACK_REL, 1),
-    0xF3: ("sbc", AddrMode.STACK_REL_IND_Y, 1),
-    # STA
-    0x85: ("sta", AddrMode.DIRECT, 1),
-    0x95: ("sta", AddrMode.DIRECT_X, 1),
-    0x92: ("sta", AddrMode.DIRECT_IND, 1),
-    0x81: ("sta", AddrMode.DIRECT_IND_X, 1),
-    0x91: ("sta", AddrMode.DIRECT_IND_Y, 1),
-    0x87: ("sta", AddrMode.DIRECT_IND_LONG, 1),
-    0x97: ("sta", AddrMode.DIRECT_IND_LONG_Y, 1),
-    0x8D: ("sta", AddrMode.ABSOLUTE, 2),
-    0x9D: ("sta", AddrMode.ABSOLUTE_X, 2),
-    0x99: ("sta", AddrMode.ABSOLUTE_Y, 2),
-    0x8F: ("sta", AddrMode.ABSOLUTE_LONG, 3),
-    0x9F: ("sta", AddrMode.ABSOLUTE_LONG_X, 3),
-    0x83: ("sta", AddrMode.STACK_REL, 1),
-    0x93: ("sta", AddrMode.STACK_REL_IND_Y, 1),
-    # STP, WAI
-    0xDB: ("stp", AddrMode.IMPLIED, 0),
-    0xCB: ("wai", AddrMode.IMPLIED, 0),
-    # STX
-    0x86: ("stx", AddrMode.DIRECT, 1),
-    0x96: ("stx", AddrMode.DIRECT_Y, 1),
-    0x8E: ("stx", AddrMode.ABSOLUTE, 2),
-    # STY
-    0x84: ("sty", AddrMode.DIRECT, 1),
-    0x94: ("sty", AddrMode.DIRECT_X, 1),
-    0x8C: ("sty", AddrMode.ABSOLUTE, 2),
-    # STZ
-    0x64: ("stz", AddrMode.DIRECT, 1),
-    0x74: ("stz", AddrMode.DIRECT_X, 1),
-    0x9C: ("stz", AddrMode.ABSOLUTE, 2),
-    0x9E: ("stz", AddrMode.ABSOLUTE_X, 2),
-    # Transfers
-    0xAA: ("tax", AddrMode.IMPLIED, 0),
-    0xA8: ("tay", AddrMode.IMPLIED, 0),
-    0x5B: ("tcd", AddrMode.IMPLIED, 0),
-    0x1B: ("tcs", AddrMode.IMPLIED, 0),
-    0x7B: ("tdc", AddrMode.IMPLIED, 0),
-    0x3B: ("tsc", AddrMode.IMPLIED, 0),
-    0xBA: ("tsx", AddrMode.IMPLIED, 0),
-    0x8A: ("txa", AddrMode.IMPLIED, 0),
-    0x9A: ("txs", AddrMode.IMPLIED, 0),
-    0x9B: ("txy", AddrMode.IMPLIED, 0),
-    0x98: ("tya", AddrMode.IMPLIED, 0),
-    0xBB: ("tyx", AddrMode.IMPLIED, 0),
-    # TRB, TSB
-    0x14: ("trb", AddrMode.DIRECT, 1),
-    0x1C: ("trb", AddrMode.ABSOLUTE, 2),
-    0x04: ("tsb", AddrMode.DIRECT, 1),
-    0x0C: ("tsb", AddrMode.ABSOLUTE, 2),
-    # WDM (reserved)
-    0x42: ("wdm", AddrMode.IMMEDIATE_8, 1),
-    # XBA, XCE
-    0xEB: ("xba", AddrMode.IMPLIED, 0),
-    0xFB: ("xce", AddrMode.IMPLIED, 0),
+#
+# DERIVED from the assembler's `snes_opcode_table` (the single source of
+# truth); the disassembler stands on the assembler's shoulders. Each
+# assembler entry is inverted to byte -> (mnemonic, AddrMode, size) from the
+# emitter type, size slot, and index. Encode-only aliases (`jsl`/`jml`) are
+# skipped so each byte decodes to exactly one mnemonic (0x22 -> `jsr.l`,
+# 0x5C -> `jmp.l`).
+
+# (asm AddressingMode, index) -> per-size-slot (AddrMode, base_size) | None.
+_SLOT_MODES: dict[tuple["_AsmMode", str | None], list[tuple[AddrMode, int] | None]] = {
+    (_AsmMode.direct, None): [(AddrMode.DIRECT, 1), (AddrMode.ABSOLUTE, 2), (AddrMode.ABSOLUTE_LONG, 3)],
+    (_AsmMode.direct_indexed, "x"): [(AddrMode.DIRECT_X, 1), (AddrMode.ABSOLUTE_X, 2), (AddrMode.ABSOLUTE_LONG_X, 3)],
+    (_AsmMode.direct_indexed, "y"): [(AddrMode.DIRECT_Y, 1), (AddrMode.ABSOLUTE_Y, 2), None],
+    (_AsmMode.direct_indexed, "s"): [(AddrMode.STACK_REL, 1), None, None],
+    (_AsmMode.indirect, None): [(AddrMode.DIRECT_IND, 1), (AddrMode.ABSOLUTE_IND, 2), None],
+    (_AsmMode.indirect_long, None): [(AddrMode.DIRECT_IND_LONG, 1), (AddrMode.ABSOLUTE_IND_LONG, 2), None],
+    (_AsmMode.indirect_indexed, "y"): [(AddrMode.DIRECT_IND_Y, 1), None, None],
+    (_AsmMode.indirect_indexed_long, "y"): [(AddrMode.DIRECT_IND_LONG_Y, 1), None, None],
+    (_AsmMode.dp_or_sr_indirect_indexed, "x"): [(AddrMode.DIRECT_IND_X, 1), (AddrMode.ABSOLUTE_IND_X, 2), None],
+    (_AsmMode.dp_or_sr_indirect_indexed, None): [(AddrMode.DIRECT_IND_X, 1), (AddrMode.ABSOLUTE_IND_X, 2), None],
+    (_AsmMode.stack_indexed_indirect_indexed, "y"): [(AddrMode.STACK_REL_IND_Y, 1), None, None],
 }
+
+
+def _immediate_record(op: Opcode) -> tuple[AddrMode, int]:
+    if op.is_a:
+        return AddrMode.IMMEDIATE_M, -1
+    if op.is_x:
+        return AddrMode.IMMEDIATE_X, -2
+    return AddrMode.IMMEDIATE_8, 1
+
+
+def _slot_records(mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Opcode) -> list[tuple[int, AddrMode, int]]:
+    """(byte, AddrMode, size) per filled size slot of a memory-mode `Opcode`."""
+    records: list[tuple[int, AddrMode, int]] = []
+    for i, slot in enumerate(_SLOT_MODES[(asm_mode, index)]):
+        if i >= len(op.opcode_def):
+            break
+        byte = op.opcode_def[i]
+        if byte is None:
+            continue
+        assert slot is not None, f"{mnemonic} {asm_mode} slot {i} has a byte but no mode mapping"
+        records.append((byte, slot[0], slot[1]))
+    return records
+
+
+def _opcode_records(mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Opcode) -> list[tuple[int, AddrMode, int]]:
+    """(byte, AddrMode, size) records for an operand-bearing `Opcode`."""
+    if op.alias:
+        return []  # jsl/jml: encode-only, not decoded
+    if asm_mode is _AsmMode.immediate:
+        byte = op.opcode_def[0]
+        assert byte is not None
+        mode, size = _immediate_record(op)
+        return [(byte, mode, size)]
+    return _slot_records(mnemonic, asm_mode, index, op)
+
+
+def _emitter_records(
+    mnemonic: str, asm_mode: "_AsmMode", index: str | None, em: object
+) -> list[tuple[int, AddrMode, int]]:
+    """(byte, AddrMode, size) records for one emitter. Empty for encode-only aliases.
+
+    Order matters: the relative/block emitters subclass the plain ones.
+    """
+    if isinstance(em, BlockMoveOpcode):
+        return [(em.opcode, AddrMode.BLOCK_MOVE, 2)]
+    if isinstance(em, RelativeLongJumpOpcode):
+        return [(em.opcode, AddrMode.RELATIVE_LONG, 2)]
+    if isinstance(em, RelativeJumpOpcode):
+        return [(em.opcode, AddrMode.RELATIVE, 1)]
+    if isinstance(em, OpcodeWithoutOperand):
+        return [(em.opcode, AddrMode.IMPLIED, 0)]
+    if isinstance(em, Opcode):
+        return _opcode_records(mnemonic, asm_mode, index, em)
+    return []
+
+
+def _mode_records(
+    mnemonic: str, asm_mode: "_AsmMode", emitter: object
+) -> Iterator[tuple[int, AddrMode, int]]:
+    """Flatten one mnemonic+mode entry (single emitter or index dict) to records."""
+    entries = emitter.items() if isinstance(emitter, dict) else [(None, emitter)]
+    for index, em in entries:
+        yield from _emitter_records(mnemonic, asm_mode, index, em)
+
+
+def _derive_opcode_table() -> dict[int, tuple[str, AddrMode, int]]:
+    """Invert `snes_opcode_table` into the decoder's byte->instruction map."""
+    table: dict[int, tuple[str, AddrMode, int]] = {}
+    for mnemonic, modes in snes_opcode_table.items():
+        for asm_mode, emitter in modes.items():
+            for byte, mode, size in _mode_records(mnemonic, asm_mode, emitter):
+                if byte in table:
+                    raise ValueError(f"opcode 0x{byte:02x} claimed by {table[byte][0]!r} and {mnemonic!r}")
+                table[byte] = (mnemonic, mode, size)
+    return table
+
+
+OPCODE_TABLE: dict[int, tuple[str, AddrMode, int]] = _derive_opcode_table()
 
 
 class Disassembler:

--- a/a816/cpu/types.py
+++ b/a816/cpu/types.py
@@ -30,6 +30,7 @@ class AddressingMode(Enum):
     indirect_indexed_long = 7
     dp_or_sr_indirect_indexed = 8
     stack_indexed_indirect_indexed = 9
+    block_move = 10  # mvn / mvp: two bank operands
 
 
 # Type alias for operand size hints

--- a/a816/parse/ast/nodes/opcode.py
+++ b/a816/parse/ast/nodes/opcode.py
@@ -20,12 +20,15 @@ class OpcodeAstNode(AstNode):
         operand: ExpressionAstNode | None,
         index: str | None,
         file_info: Token,
+        operand2: ExpressionAstNode | None = None,
     ):
         super().__init__("opcode", file_info)
         self.addressing_mode = addressing_mode
         self.opcode = opcode
         self.value_size = value_size
         self.operand = operand
+        # Second operand for block-move (`mvn src, dst`); None otherwise.
+        self.operand2 = operand2
         self.index = index
 
     @property

--- a/a816/parse/codegen/opcodes.py
+++ b/a816/parse/codegen/opcodes.py
@@ -62,6 +62,18 @@ def generate_opcode(
     mode = node.addressing_mode
     if mode == AddressingMode.none:
         code.append(OpcodeNode(opcode, addressing_mode=mode, file_info=file_info, resolver=resolver))
+    elif mode == AddressingMode.block_move:
+        assert node.operand is not None and node.operand2 is not None
+        code.append(
+            OpcodeNode(
+                opcode,
+                addressing_mode=mode,
+                value_node=ExpressionNode(node.operand, resolver, file_info),
+                value_node2=ExpressionNode(node.operand2, resolver, file_info),
+                file_info=file_info,
+                resolver=resolver,
+            )
+        )
     else:
         operand = node.operand
         assert operand is not None

--- a/a816/parse/nodes/opcode.py
+++ b/a816/parse/nodes/opcode.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from a816.cpu.cpu_65c816 import NoOpcodeForOperandSize, guess_value_size, snes_opcode_table
+from typing import cast
+
+from a816.cpu.cpu_65c816 import BlockMoveOpcode, NoOpcodeForOperandSize, guess_value_size, snes_opcode_table
 from a816.cpu.mapping import Address
 from a816.cpu.types import AddressingMode, ValueSize
 from a816.diagnostics.suggest import did_you_mean_hint as _did_you_mean_hint
@@ -23,6 +25,7 @@ class OpcodeNode(NodeProtocol):
         addressing_mode: AddressingMode,
         index: str | None = None,
         value_node: ValueNodeProtocol | None = None,
+        value_node2: ValueNodeProtocol | None = None,
         file_info: Token,
         resolver: Resolver,
     ) -> None:
@@ -30,6 +33,8 @@ class OpcodeNode(NodeProtocol):
         self.addressing_mode = addressing_mode
         self.index = index
         self.value_node = value_node
+        # Second operand, block move only (`mvn src, dst`).
+        self.value_node2 = value_node2
         self.size = size
         self.file_info = file_info
         self.resolver = resolver
@@ -65,6 +70,11 @@ class OpcodeNode(NodeProtocol):
         # survives the desugar of legacy `*=` into `.alloc at`.
         self._maybe_update_register_sizes()
         opcode_emitter = self._get_emitter()
+        if self.addressing_mode is AddressingMode.block_move:
+            assert self.value_node is not None and self.value_node2 is not None
+            return cast(BlockMoveOpcode, opcode_emitter).emit_block_move(
+                self.value_node, self.value_node2, self.resolver
+            )
         try:
             return opcode_emitter.emit(self.value_node, self.resolver, self.size)
         except NoOpcodeForOperandSize as e:

--- a/a816/parse/parser_states/opcode.py
+++ b/a816/parse/parser_states/opcode.py
@@ -17,10 +17,29 @@ def is_value_size(value_size: str) -> TypeGuard[ValueSize]:
     return value_size in ["b", "w", "l"]
 
 
+def _parse_block_move(opcode: Token, p: Parser) -> OpcodeAstNode:
+    """`mvn src, dst` / `mvp src, dst`: two bank operands (block move)."""
+    src = parse_expression(p)
+    expect_token(p.next(), TokenType.COMMA)
+    dest = parse_expression(p)
+    return OpcodeAstNode(
+        addressing_mode=AddressingMode.block_move,
+        opcode=opcode.value,
+        value_size=None,
+        operand=src,
+        operand2=dest,
+        index=None,
+        file_info=opcode,
+    )
+
+
 def parse_opcode(p: Parser) -> OpcodeAstNode:
     opcode: Token = p.next()
     size: str | None = None
     index: str | None = None
+
+    if opcode.value.lower() in ("mvn", "mvp"):
+        return _parse_block_move(opcode, p)
 
     if accept_token(opcode, TokenType.OPCODE_NAKED):
         addressing_mode = AddressingMode.none

--- a/a816/parse/scanner_states.py
+++ b/a816/parse/scanner_states.py
@@ -252,7 +252,23 @@ def lex_opcode(s: "Scanner") -> None:
         lex_opcode_size(s)
 
     s.ignore_run(" ")
-    lex_operand(s)
+    if opcode_candidate in ("mvn", "mvp"):
+        lex_block_move_operands(s)
+    else:
+        lex_operand(s)
+
+
+def lex_block_move_operands(s: "Scanner") -> None:
+    """`mvn src, dst` / `mvp src, dst`: two expressions separated by a plain
+    comma. Unlike the normal operand lexer, the comma is a `COMMA` token (a
+    second operand), not an addressing-mode index (`,x`/`,y`/`,s`)."""
+    s.ignore_run(" ")
+    lex_expression(s)
+    s.ignore_run(" ")
+    if s.accept(","):
+        s.emit(TokenType.COMMA)
+    s.ignore_run(" ")
+    lex_expression(s)
 
 
 DIRECTIVE_NAMES = {

--- a/tests/test_disassembler.py
+++ b/tests/test_disassembler.py
@@ -77,9 +77,11 @@ class TestDisassembler:
 
     def test_decode_absolute_long(self) -> None:
         disasm = Disassembler()
-        inst = disasm.decode_instruction(bytes([0x22, 0x00, 0x80, 0x01]), 0x8000)  # jsl $018000
+        inst = disasm.decode_instruction(bytes([0x22, 0x00, 0x80, 0x01]), 0x8000)  # jsr.l $018000
         assert inst is not None
-        assert inst.mnemonic == "jsl"
+        # 0x22 decodes as `jsr` ABSOLUTE_LONG (a816: jsl ≡ jsr.l). The decoder
+        # is derived from the assembler table, which owns 0x22 as jsr.l.
+        assert inst.mnemonic == "jsr"
         assert inst.mode == AddrMode.ABSOLUTE_LONG
         assert inst.operand_value == 0x018000
         assert inst.length == 4
@@ -480,7 +482,7 @@ class TestA816BlockFormat:
 
     def test_minimal_suffixes_round_trip(self) -> None:
         disasm = Disassembler()
-        # lda #0x42, sta 0x1234, lda 0x10, jsl 0x018000, nop
+        # lda #0x42, sta 0x1234, lda 0x10, jsr.l 0x018000, nop
         data = bytes.fromhex("a9428d3412a510220080 01ea".replace(" ", ""))
         instructions = disasm.disassemble(data, 0x008000)
         lines = format_disassembly_block(instructions, show_bytes=False, a816_syntax=True)
@@ -488,7 +490,7 @@ class TestA816BlockFormat:
         assert "lda #0x42" in joined
         assert "sta 0x1234" in joined
         assert "lda 0x10" in joined
-        assert "jsl.l _018000" in joined
+        assert "jsr.l _018000" in joined
         assert "nop" in joined
         assert ".w" not in joined  # no verbose word suffix on absolute / direct
 

--- a/tests/test_opcode_matrix.py
+++ b/tests/test_opcode_matrix.py
@@ -1,0 +1,119 @@
+"""Full 65c816 opcode-matrix coverage.
+
+Single source of truth: the assembler's `snes_opcode_table`. The disassembler's
+`OPCODE_TABLE` is derived from it. For every defined opcode byte this test:
+
+1. synthesizes an a816 source line for the `(mnemonic, addressing-mode)` the
+   decoder reports for that byte, assembles it, and asserts the emitted opcode
+   byte matches, catching the ORA-to-LDA class of hand-table typo; and
+2. disassembles the assembled bytes and asserts the mnemonic + mode round-trip.
+
+If the two tables ever drift, this fails.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from a816.cpu.disassembler import OPCODE_TABLE, AddrMode, Disassembler
+from a816.parse.nodes.opcode import OpcodeNode
+from a816.program import Program
+
+# Per addressing mode, the operand text appended after the mnemonic. Values are
+# chosen to force the exact mode/size slot (dp = 1-byte, abs = 2-byte, long =
+# 3-byte). Relative targets sit just past the instruction so the offset is tiny.
+_OPERAND_SRC: dict[AddrMode, str] = {
+    AddrMode.IMPLIED: "",
+    AddrMode.IMMEDIATE_8: " #0x10",
+    AddrMode.IMMEDIATE_M: " #0x10",
+    AddrMode.IMMEDIATE_X: " #0x10",
+    AddrMode.DIRECT: ".b 0x10",
+    AddrMode.DIRECT_X: ".b 0x10,x",
+    AddrMode.DIRECT_Y: ".b 0x10,y",
+    AddrMode.DIRECT_IND: " (0x10)",
+    AddrMode.DIRECT_IND_X: " (0x10,x)",
+    AddrMode.DIRECT_IND_Y: " (0x10),y",
+    AddrMode.DIRECT_IND_LONG: " [0x10]",
+    AddrMode.DIRECT_IND_LONG_Y: " [0x10],y",
+    AddrMode.ABSOLUTE: ".w 0x1234",
+    AddrMode.ABSOLUTE_X: ".w 0x1234,x",
+    AddrMode.ABSOLUTE_Y: ".w 0x1234,y",
+    AddrMode.ABSOLUTE_LONG: ".l 0x123456",
+    AddrMode.ABSOLUTE_LONG_X: ".l 0x123456,x",
+    AddrMode.ABSOLUTE_IND: " (0x1234)",
+    AddrMode.ABSOLUTE_IND_X: " (0x1234,x)",
+    AddrMode.ABSOLUTE_IND_LONG: " [0x1234]",
+    AddrMode.STACK_REL: " 0x10,s",
+    AddrMode.STACK_REL_IND_Y: " (0x10,s),y",
+    AddrMode.RELATIVE: " 0x008002",
+    AddrMode.RELATIVE_LONG: " 0x008003",
+    AddrMode.BLOCK_MOVE: " 0x01, 0x02",
+}
+
+
+# Exact operand bytes each `_OPERAND_SRC` entry encodes (little-endian), under
+# `.a8`/`.i8` with the instruction anchored at 0x008000. Relative targets are
+# the instruction end, so the signed displacement is 0.
+_OPERAND_BYTES: dict[AddrMode, bytes] = {
+    AddrMode.IMPLIED: b"",
+    AddrMode.IMMEDIATE_8: b"\x10",
+    AddrMode.IMMEDIATE_M: b"\x10",
+    AddrMode.IMMEDIATE_X: b"\x10",
+    AddrMode.DIRECT: b"\x10",
+    AddrMode.DIRECT_X: b"\x10",
+    AddrMode.DIRECT_Y: b"\x10",
+    AddrMode.DIRECT_IND: b"\x10",
+    AddrMode.DIRECT_IND_X: b"\x10",
+    AddrMode.DIRECT_IND_Y: b"\x10",
+    AddrMode.DIRECT_IND_LONG: b"\x10",
+    AddrMode.DIRECT_IND_LONG_Y: b"\x10",
+    AddrMode.ABSOLUTE: b"\x34\x12",
+    AddrMode.ABSOLUTE_X: b"\x34\x12",
+    AddrMode.ABSOLUTE_Y: b"\x34\x12",
+    AddrMode.ABSOLUTE_LONG: b"\x56\x34\x12",
+    AddrMode.ABSOLUTE_LONG_X: b"\x56\x34\x12",
+    AddrMode.ABSOLUTE_IND: b"\x34\x12",
+    AddrMode.ABSOLUTE_IND_X: b"\x34\x12",
+    AddrMode.ABSOLUTE_IND_LONG: b"\x34\x12",
+    AddrMode.STACK_REL: b"\x10",
+    AddrMode.STACK_REL_IND_Y: b"\x10",
+    AddrMode.RELATIVE: b"\x00",
+    AddrMode.RELATIVE_LONG: b"\x00\x00",
+    AddrMode.BLOCK_MOVE: b"\x02\x01",  # opcode, destbank, srcbank
+}
+
+
+def _assemble(line: str) -> bytes:
+    program = Program()
+    # *= anchors relative-branch math; .a8/.i8 pin immediate width to 8-bit so
+    # IMMEDIATE_M/X assemble + disassemble (default flags) at the same length.
+    err, nodes = program.parser.parse(f"*=0x008000\n.a8\n.i8\n{line}")
+    assert err is None, f"parse error for {line!r}: {err}"
+    program.resolve_labels(nodes)
+    out = b""
+    for node in nodes:
+        if isinstance(node, OpcodeNode):
+            out += node.emit(program.resolver.reloc_address)
+    return out
+
+
+def test_table_covers_all_256_opcodes() -> None:
+    assert sorted(OPCODE_TABLE) == list(range(256))
+
+
+@pytest.mark.parametrize("opcode", sorted(OPCODE_TABLE))
+def test_opcode_assembles_and_roundtrips(opcode: int) -> None:
+    mnemonic, mode, _ = OPCODE_TABLE[opcode]
+    line = f"{mnemonic}{_OPERAND_SRC[mode]}"
+
+    assembled = _assemble(line)
+    expected = bytes([opcode]) + _OPERAND_BYTES[mode]
+    assert assembled == expected, f"{line!r} assembled to {assembled.hex()}, expected {expected.hex()}"
+
+    inst = Disassembler().decode_instruction(assembled, 0x008000)
+    assert inst is not None
+    assert inst.mnemonic == mnemonic, f"0x{opcode:02X}: {inst.mnemonic!r} != {mnemonic!r}"
+    assert inst.mode == mode, f"0x{opcode:02X}: {inst.mode} != {mode}"
+    # Decoder must consume exactly what the assembler emitted: no trailing
+    # bytes, no over-read.
+    assert inst.length == len(assembled), f"0x{opcode:02X}: length {inst.length} != {len(assembled)}"


### PR DESCRIPTION
## What

The assembler's `snes_opcode_table` and the disassembler's `OPCODE_TABLE` were two hand-maintained encodings of the same ISA and had drifted. The assembler was missing `bvc`/`bvs`/`per`/`mvn`/`mvp` entirely plus ~25 addressing-mode/opcode entries, and carried the `ora #imm16` opcode typo (0xA9 instead of 0x09). The disassembler, written to read real ROMs, was complete — so a816 could decode instructions it could not encode.

Make the assembler table the single source of truth; the disassembler is derived from it, so the two can no longer diverge.

## Changes

- **Fill every missing addressing mode** on `ora`/`and`/`eor`/`adc`/`sbc`/`cmp`/`sta`/`jsr`.
- **Fix `ora #imm16`** (0xA9 → 0x09) and add `is_a` to `eor` immediate so `eor #imm` under `.a16` emits a 16-bit operand.
- **Add `bvc`/`bvs`** (relative), **`per`** (relative-long), and **`jsl`/`jml`** as encode-only `LongOpcode` aliases for `jsr.l`/`jmp.l` (alias flag keeps them out of the derived decoder, so `0x22` decodes as `jsr.l`).
- **Add `mvn`/`mvp`** block move: new `AddressingMode.block_move`, `BlockMoveOpcode` (bank-reversed encoding), scanner + parser two-operand support, `operand2` plumbing through the opcode AST/codegen/node.
- **Derive the disassembler `OPCODE_TABLE`** from `snes_opcode_table` (inverting by emitter type, size slot, index); delete the hand table. Side effect: disasm now prints `jsr.l`/`jmp.l` instead of `jsl`/`jml`.

## Supersedes #92

#92 fixed only the `ora #imm16` typo; that fix is included here.

## Test

`tests/test_opcode_matrix.py` asserts every one of the 256 opcodes assembles to the exact expected bytes and round-trips through the disassembler to the same mnemonic and mode — so any future table edit that breaks encode/decode agreement fails the suite.