### PR TITLE
Complete the 65c816 ISA table and derive the disassembler from it

### DIFF
--- a/a816/cli.py
+++ b/a816/cli.py
@@ -29,7 +29,7 @@ import sys
 from pathlib import Path
 
 from a816.config import discover_a816_config
-from a816.exceptions import LinkerError
+from a816.exceptions import A816Error, LinkerError
 from a816.linker import Linker
 from a816.object_file import ObjectFile
 from a816.parse.nodes import NodeError
@@ -295,6 +295,14 @@ def cli_main() -> None:
         sys.exit(1)
     except NodeError as e:
         print(e.format(), file=sys.stderr)
+        sys.exit(1)
+    except A816Error as e:
+        # Other assembler errors (e.g. UnmappedBankError) carry their own
+        # `format()`; fall back to a simple render if a subclass lacks one.
+        from a816.errors import format_error_simple
+
+        message = e.format() if hasattr(e, "format") else format_error_simple("error", str(e))
+        print(message, file=sys.stderr)
         sys.exit(1)
     except Exception as e:
         from a816.errors import format_error_simple

--- a/a816/cpu/disassembler.py
+++ b/a816/cpu/disassembler.py
@@ -250,7 +250,9 @@ def _immediate_record(op: Opcode) -> tuple[AddrMode, int]:
     return AddrMode.IMMEDIATE_8, 1
 
 
-def _slot_records(mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Opcode) -> list[tuple[int, AddrMode, int]]:
+def _slot_records(
+    mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Opcode
+) -> list[tuple[int, AddrMode, int]]:
     """(byte, AddrMode, size) per filled size slot of a memory-mode `Opcode`."""
     records: list[tuple[int, AddrMode, int]] = []
     for i, slot in enumerate(_SLOT_MODES[(asm_mode, index)]):
@@ -264,7 +266,9 @@ def _slot_records(mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Op
     return records
 
 
-def _opcode_records(mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Opcode) -> list[tuple[int, AddrMode, int]]:
+def _opcode_records(
+    mnemonic: str, asm_mode: "_AsmMode", index: str | None, op: Opcode
+) -> list[tuple[int, AddrMode, int]]:
     """(byte, AddrMode, size) records for an operand-bearing `Opcode`."""
     if op.alias:
         return []  # jsl/jml: encode-only, not decoded
@@ -296,9 +300,7 @@ def _emitter_records(
     return []
 
 
-def _mode_records(
-    mnemonic: str, asm_mode: "_AsmMode", emitter: object
-) -> Iterator[tuple[int, AddrMode, int]]:
+def _mode_records(mnemonic: str, asm_mode: "_AsmMode", emitter: object) -> Iterator[tuple[int, AddrMode, int]]:
     """Flatten one mnemonic+mode entry (single emitter or index dict) to records."""
     entries = emitter.items() if isinstance(emitter, dict) else [(None, emitter)]
     for index, em in entries:

--- a/a816/cpu/mapping.py
+++ b/a816/cpu/mapping.py
@@ -42,7 +42,12 @@ class Bus:
         return self.mappings != {}
 
     def get_mapping_for_bank(self, bank: int) -> Mapping:
-        return self.mappings[self.lookup[bank]]
+        try:
+            return self.mappings[self.lookup[bank]]
+        except KeyError as exc:
+            from a816.exceptions import UnmappedBankError
+
+            raise UnmappedBankError(bank, mapped_banks=list(self.lookup.keys())) from exc
 
     def map(
         self,
@@ -92,7 +97,15 @@ class Address:
         return self.logical_value >> 16
 
     def _get_mapping(self) -> Mapping:
-        return self.bus.get_mapping_for_bank(self._get_bank())
+        from a816.exceptions import UnmappedBankError
+
+        try:
+            return self.bus.get_mapping_for_bank(self._get_bank())
+        except UnmappedBankError as exc:
+            # Re-raise with the full logical address so the diagnostic can show
+            # the offending `$xxyyzz`, not just the bank byte.
+            exc.logical_address = self.logical_value
+            raise
 
     @property
     def physical(self) -> int | None:

--- a/a816/exceptions.py
+++ b/a816/exceptions.py
@@ -177,6 +177,62 @@ class ExpressionEvaluationError(LinkerError):
 
 
 # =============================================================================
+# Bus / Mapping Errors
+# =============================================================================
+
+
+class UnmappedBankError(A816Error):
+    """Raised when an address lands in a bank no `.map` region covers.
+
+    The bus `lookup` table only carries banks declared by a `.map`
+    directive (or the rom_type's default mapping). A `.pool` / `.alloc` /
+    `*=` placing code or data at an unmapped bank used to surface as a bare
+    `KeyError: <bank>` deep in the traceback - useless to anyone reading the
+    build output. This carries the bank, the banks that *are* mapped, and an
+    optional source location so the diagnostic points at the offending
+    construct.
+    """
+
+    def __init__(
+        self,
+        bank: int,
+        logical_address: int | None = None,
+        mapped_banks: list[int] | None = None,
+    ) -> None:
+        self.bank = bank
+        self.logical_address = logical_address
+        self.mapped_banks = sorted(mapped_banks) if mapped_banks else []
+        super().__init__(f"bank ${bank:02X} is not covered by any `.map` region")
+
+    @staticmethod
+    def _format_ranges(banks: list[int]) -> str:
+        """Collapse a sorted bank list into contiguous `$xx-$yy` ranges."""
+        if not banks:
+            return "(none)"
+        ranges: list[str] = []
+        start = prev = banks[0]
+        for bank in banks[1:]:
+            if bank == prev + 1:
+                prev = bank
+                continue
+            ranges.append(f"${start:02X}" if start == prev else f"${start:02X}-${prev:02X}")
+            start = prev = bank
+        ranges.append(f"${start:02X}" if start == prev else f"${start:02X}-${prev:02X}")
+        return ", ".join(ranges)
+
+    def format(self) -> str:
+        # Late import: intentional to avoid circular dependency with errors module
+        from a816.errors import format_error_simple
+
+        details: list[tuple[str, str]] = [("bank", f"${self.bank:02X}")]
+        if self.logical_address is not None:
+            details.append(("address", f"${self.logical_address:06X}"))
+        details.append(("mapped banks", self._format_ranges(self.mapped_banks)))
+        message = f"bank ${self.bank:02X} is not covered by any `.map` region (and is not backed by the configured ROM)"
+        return format_error_simple("error", message, details=details)
+
+
+# =============================================================================
 # CPU/Opcode Errors
 # =============================================================================
 

--- a/a816/linker.py
+++ b/a816/linker.py
@@ -111,7 +111,8 @@ class Linker:
                 key = (req.pool_name, req.symbol_name)
                 alloc_obj = first_placed.get(key)
                 if alloc_obj is None:
-                    alloc_obj = pool.request(req.symbol_name, req.size)
+                    pinned = req.pinned_addr if req.pinned_addr >= 0 else None
+                    alloc_obj = pool.request(req.symbol_name, req.size, pinned)
                     first_placed[key] = alloc_obj
                 self._section_pool_alloc[(obj_idx, req.section_idx)] = alloc_obj
         for pool in merged.values():
@@ -126,10 +127,21 @@ class Linker:
         own delta, not by the module's relocation.
         """
         for local_idx, section in enumerate(obj_file.sections):
-            if (obj_idx, local_idx) not in self._pool_section_deltas:
+            key = (obj_idx, local_idx)
+            if key not in self._pool_section_deltas:
                 continue
-            if section.placed_base <= address < section.placed_base + len(section.code):
-                return self._pool_section_deltas[(obj_idx, local_idx)]
+            # Byte-less (bss/reserve) sections carry no code, so `len(code)`
+            # is 0 and an address-range check against the emitted bytes never
+            # matches. Use the allocation's reserved size for the span so a
+            # reserved symbol still picks up its section delta, required once
+            # a pinned reserve shifts a pool's final addresses away from the
+            # sequential sandbox bases.
+            alloc = getattr(self, "_section_pool_alloc", {}).get(key)
+            span = len(section.code)
+            if alloc is not None:
+                span = max(span, getattr(alloc, "size", 0))
+            if section.placed_base <= address < section.placed_base + span:
+                return self._pool_section_deltas[key]
         return None
 
     @staticmethod

--- a/a816/module_builder.py
+++ b/a816/module_builder.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from a816.program import Program
 
+from a816.exceptions import A816Error
 from a816.linker import Linker
 from a816.module_loader import resolve_module
 from a816.object_file import ObjectFile
@@ -440,6 +441,10 @@ def build_with_imports(
         )
 
     except Exception as e:
-        logger.error(f"Build failed: {e}")  # NOSONAR python:S8572
+        # A816Error subclasses carry a `format()` that renders a source-located,
+        # human-readable diagnostic; prefer it over the bare `str()` so the
+        # build output is actionable rather than e.g. `Build failed: 252`.
+        formatted = e.format() if isinstance(e, A816Error) and hasattr(e, "format") else str(e)
+        logger.error(f"Build failed: {formatted}")  # NOSONAR python:S8572
         logger.debug("Build traceback", exc_info=True)
-        return BuildResult(exit_code=1, diagnostics=[str(e)])
+        return BuildResult(exit_code=1, diagnostics=[formatted])

--- a/a816/object_file.py
+++ b/a816/object_file.py
@@ -111,11 +111,15 @@ class PoolAlloc:
     symbol_name: str
     section_idx: int
     size: int
+    pinned_addr: int = -1
+    """Fixed address for a `.reserve NAME SIZE at ADDR in POOL` request; -1
+    when the allocator is free to pick. Round-trips so the linker honors the
+    pin across modules."""
 
 
 class ObjectFile:
     MAGIC_NUMBER = 0x41383136  # 'A816'
-    VERSION = 0x000B  # Version 11: PoolDecl carries the bss flag (round-trips through import).
+    VERSION = 0x000C  # Version 12: PoolAlloc carries pinned_addr (fixed-address reserves).
 
     def __init__(
         self,
@@ -227,7 +231,7 @@ class ObjectFile:
             f.write(pool_bytes)
             f.write(struct.pack("<B", len(sym_bytes)))
             f.write(sym_bytes)
-            f.write(struct.pack("<II", alloc.section_idx, alloc.size))
+            f.write(struct.pack("<IIi", alloc.section_idx, alloc.size, alloc.pinned_addr))
 
     def _write_bus_mappings(self, f: IO[bytes]) -> None:
         f.write(struct.pack("<H", len(self.bus_mappings)))
@@ -429,8 +433,16 @@ class ObjectFile:
             pool_name = f.read(pool_len).decode("utf-8")
             (sym_len,) = struct.unpack("<B", f.read(1))
             sym_name = f.read(sym_len).decode("utf-8")
-            section_idx, size = struct.unpack("<II", f.read(8))
-            out.append(PoolAlloc(pool_name=pool_name, symbol_name=sym_name, section_idx=section_idx, size=size))
+            section_idx, size, pinned_addr = struct.unpack("<IIi", f.read(12))
+            out.append(
+                PoolAlloc(
+                    pool_name=pool_name,
+                    symbol_name=sym_name,
+                    section_idx=section_idx,
+                    size=size,
+                    pinned_addr=pinned_addr,
+                )
+            )
         return out
 
     @staticmethod

--- a/a816/parse/ast/nodes/pool.py
+++ b/a816/parse/ast/nodes/pool.py
@@ -107,7 +107,10 @@ class AllocAstNode(AstNode):
         if self.is_pinned:
             addr = self.at_address.to_canonical() if self.at_address else "?"
             size = f" size {self.at_size.to_canonical()}" if self.at_size else ""
-            return f".alloc {head}at {addr}{size} {{\n{body}\n}}"
+            # Pinned *inside* a named pool (`.reserve NAME SIZE at ADDR in POOL`)
+            # keeps the `in POOL` tail; anonymous pins drop it.
+            tail = f" in {self.pool_name}" if self.pool_name else ""
+            return f".alloc {head}at {addr}{size}{tail} {{\n{body}\n}}"
         return f".alloc {head}in {self.pool_name} {{\n{body}\n}}"
 
 

--- a/a816/parse/codegen/pool.py
+++ b/a816/parse/codegen/pool.py
@@ -165,7 +165,10 @@ def generate_alloc(
 ) -> GenNodes:
     from a816.parse.nodes import AllocNode, PopScopeNode, ScopeNode
 
-    if node.is_pinned:
+    pinned_addr: int | None = None
+    if node.is_pinned and node.pool_name is None:
+        # `.alloc at ADDR { body }`: synthesize a per-location pool that the
+        # body floats into (the pool's single range starts at ADDR).
         pool_name = _synthesize_pinned_pool(node, resolver, file_info)
         alloc_name = node.name or _anonymous_alloc_name(file_info, pool_name)
     else:
@@ -173,6 +176,11 @@ def generate_alloc(
             raise NodeError(f"alloc into unknown pool {node.pool_name!r}", file_info)
         pool_name = node.pool_name
         alloc_name = node.name or _anonymous_alloc_name(file_info, pool_name)
+        if node.is_pinned and node.at_address is not None:
+            # `.reserve NAME SIZE at ADDR in POOL`: pin the slot at ADDR
+            # inside the existing (named) pool; the allocator validates the
+            # span is in-range and overlap-free rather than choosing it.
+            pinned_addr = _eval_int(node.at_address, resolver, file_info)
 
     _reject_nested_placement(node)
     # Open an AllocBodyScope around the body so per-block underscore
@@ -187,7 +195,7 @@ def generate_alloc(
     body_nodes += _code_gen(node.body.body, resolver, macro_definitions)
     body_nodes.append(PopScopeNode(resolver, exports=True))
     resolver.restore_scope(exports=True)
-    return [AllocNode(alloc_name, pool_name, body_nodes, resolver, file_info)]
+    return [AllocNode(alloc_name, pool_name, body_nodes, resolver, file_info, pinned_addr=pinned_addr)]
 
 
 def generate_reserve_typed(

--- a/a816/parse/nodes/alloc.py
+++ b/a816/parse/nodes/alloc.py
@@ -28,12 +28,17 @@ class AllocNode(NodeProtocol):
         body: list[NodeProtocol],
         resolver: Resolver,
         file_info: Token,
+        pinned_addr: int | None = None,
     ) -> None:
         self.name = name
         self.pool_name = pool_name
         self.body = body
         self.resolver = resolver
         self.file_info = file_info
+        # Fixed address for a `.reserve NAME SIZE at ADDR in POOL` request;
+        # None lets the pool allocator pick. Carried into `pool.request` and
+        # the object-mode PoolAlloc so the pin survives to link time.
+        self.pinned_addr = pinned_addr
         self._alloc: Allocation | None = None
         self._size: int = 0
         # Only set in object mode (`_request_slot`). Stays `None` in
@@ -123,7 +128,7 @@ class AllocNode(NodeProtocol):
     def _request_slot(self) -> None:
         pool = self.resolver.pools[self.pool_name]
         self._size = max(1, self._measure_body())
-        self._alloc = pool.request(self.name, self._size)
+        self._alloc = pool.request(self.name, self._size, self.pinned_addr)
         # Object mode defers allocator to link time. Bind the alloc's
         # symbol + body labels at the sandbox PC (pool start + cursor)
         # so they record sensible offsets; the linker rebases the body

--- a/a816/parse/parser_states/directives.py
+++ b/a816/parse/parser_states/directives.py
@@ -503,11 +503,15 @@ def _parse_pinned_alloc_tail(p: Parser, parse_block: ParseBlockFn, keyword: Toke
 def parse_reserve(p: Parser) -> AllocAstNode | ReserveTypedAstNode:
     """Parse a flat byte-less reservation into a `bss` pool:
 
-    * `.reserve NAME SIZE in POOL`: reserve SIZE bytes.
+    * `.reserve NAME SIZE in POOL`: reserve SIZE bytes (allocator picks addr).
+    * `.reserve NAME SIZE at ADDR in POOL`: reserve SIZE bytes pinned at ADDR
+      (allocator validates the span is in-range + overlap-free). Used for
+      fixed memory maps (VRAM/MMIO) where the address is the contract.
     * `.reserve NAME as TYPE in POOL`: reserve sizeof(TYPE) + publish fields.
 
-    The size form desugars to `.alloc NAME in POOL { .res SIZE }`; the `as`
-    form is expanded against the struct layout at codegen.
+    The size form desugars to `.alloc NAME in POOL { .res SIZE }` (plus an
+    `at ADDR` pin when present); the `as` form is expanded against the struct
+    layout at codegen.
     """
     keyword = p.current()
     name_token = p.next()
@@ -524,11 +528,16 @@ def parse_reserve(p: Parser) -> AllocAstNode | ReserveTypedAstNode:
         return ReserveTypedAstNode(name_token.value, type_token.value, pool_token.value, keyword)
 
     size_expr = parse_expression(p)
+    # Optional `at ADDR` pin between SIZE and `in POOL`.
+    at_address: ExpressionAstNode | None = None
+    if p.current().type == TokenType.IDENTIFIER and p.current().value == "at":
+        p.next()  # consume `at`
+        at_address = parse_expression(p)
     _expect_contextual_keyword(p, "in")
     pool_token = p.next()
     expect_token(pool_token, TokenType.IDENTIFIER)
     body = BlockAstNode([ReserveAstNode(size_expr, keyword)], keyword)
-    return AllocAstNode(name_token.value, pool_token.value, body, keyword)
+    return AllocAstNode(name_token.value, pool_token.value, body, keyword, at_address=at_address)
 
 
 def _parse_alloc_body(p: Parser, parse_block: ParseBlockFn) -> BlockAstNode:

--- a/a816/pool.py
+++ b/a816/pool.py
@@ -62,6 +62,17 @@ class Allocation:
     name: str
     size: int
     addr: int = -1
+    pinned_addr: int = -1
+    """Fixed-address request (`.reserve NAME SIZE at ADDR in POOL`): the
+    allocator places this span *at* `pinned_addr` (validating it lies within
+    a pool range and overlaps nothing else, then carving it) before floating
+    allocations are placed. Kept separate from `addr` so `placed` stays False
+    until `allocate()` runs (object mode binds body labels at the sandbox base
+    uniformly and lets the linker apply the final address)."""
+
+    @property
+    def pinned(self) -> bool:
+        return self.pinned_addr >= 0
 
     @property
     def placed(self) -> bool:
@@ -86,12 +97,15 @@ class Pool:
             raise PoolError(f"fill byte 0x{self.fill:x} out of range")
         self.ranges = _normalize_ranges(self.ranges)
 
-    def request(self, name: str, size: int) -> Allocation:
+    def request(self, name: str, size: int, addr: int | None = None) -> Allocation:
         if size <= 0:
             raise PoolError(f"alloc '{name}' has non-positive size {size}")
         if self._allocated:
             raise PoolError(f"pool '{self.name}' already allocated; cannot request more")
-        alloc = Allocation(name=name, size=size)
+        if addr is not None:
+            alloc = Allocation(name=name, size=size, pinned_addr=addr)
+        else:
+            alloc = Allocation(name=name, size=size)
         self.allocations.append(alloc)
         return alloc
 
@@ -109,16 +123,31 @@ class Pool:
     def allocate(self) -> None:
         if self._allocated:
             return
-        order = _sort_allocations(self.allocations, self.strategy)
+        pinned = [a for a in self.allocations if a.pinned]
+        floating = [a for a in self.allocations if not a.pinned]
+        order = _sort_allocations(floating, self.strategy)
         free = list(self.ranges)
         total = sum(r.size for r in self.ranges)
         logger.info(
-            "pool %s: %d alloc(s) into %d range(s) totaling %d bytes",
+            "pool %s: %d pinned + %d floating alloc(s) into %d range(s) totaling %d bytes",
             self.name,
+            len(pinned),
             len(order),
             len(self.ranges),
             total,
         )
+        for alloc in sorted(pinned, key=lambda a: a.pinned_addr):
+            alloc.addr = alloc.pinned_addr
+            free = _carve(alloc, free, self.ranges, self.name)
+            free_total = sum(r.size for r in free)
+            logger.info(
+                "  pinned %s size %d at 0x%06x  (free: %d bytes across %d range(s))",
+                alloc.name,
+                alloc.size,
+                alloc.addr,
+                free_total,
+                len(free),
+            )
         for alloc in order:
             free = _place(alloc, free)
             free_total = sum(r.size for r in free)
@@ -205,6 +234,33 @@ def _place(alloc: Allocation, free: list[PoolRange]) -> list[PoolRange]:
             alloc.addr = chunk.start
             return _shrink_chunk(free, idx, alloc.size)
     raise PoolOverflowError(f"alloc '{alloc.name}' size {alloc.size} does not fit in any free chunk")
+
+
+def _carve(alloc: Allocation, free: list[PoolRange], ranges: list[PoolRange], pool_name: str) -> list[PoolRange]:
+    span_start = alloc.addr
+    span_end = alloc.addr + alloc.size - 1
+    for idx, chunk in enumerate(free):
+        if span_start < chunk.start or span_end > chunk.end:
+            continue
+        # span fits wholly inside this free chunk: split off head + tail.
+        out: list[PoolRange] = list(free[:idx])
+        if span_start > chunk.start:
+            out.append(PoolRange(start=chunk.start, end=span_start - 1, allow_bank_cross=chunk.allow_bank_cross))
+        if span_end < chunk.end:
+            out.append(PoolRange(start=span_end + 1, end=chunk.end, allow_bank_cross=chunk.allow_bank_cross))
+        out.extend(free[idx + 1 :])
+        return out
+    # No free chunk contains the span. If a declared pool range does contain it,
+    # the conflict is with another (already-carved) allocation; otherwise the
+    # address simply lies outside the pool.
+    if any(r.start <= span_start and span_end <= r.end for r in ranges):
+        raise PoolOverlapError(
+            f"pinned alloc '{alloc.name}' 0x{span_start:06x}..0x{span_end:06x} "
+            f"overlaps another allocation in pool '{pool_name}'"
+        )
+    raise PoolInvalidRangeError(
+        f"pinned alloc '{alloc.name}' 0x{span_start:06x}..0x{span_end:06x} is outside the ranges of pool '{pool_name}'"
+    )
 
 
 def _shrink_chunk(free: list[PoolRange], idx: int, used: int) -> list[PoolRange]:

--- a/a816/program/core.py
+++ b/a816/program/core.py
@@ -209,11 +209,13 @@ class Program(EmitMixin, ObjectEmitMixin, AssembleMixin, DebugMixin, LinkMixin):
         caller would have written the logical address pre-multi-section
         anyway, so the fallback preserves existing behavior.
         """
+        from a816.exceptions import UnmappedBankError
+
         try:
             bus = self.resolver.get_bus()
             addr = bus.get_address(logical_address)
             physical = addr.physical
-        except KeyError:
+        except (KeyError, UnmappedBankError):
             return logical_address
         if physical is None:
             return logical_address

--- a/a816/program/object_emit.py
+++ b/a816/program/object_emit.py
@@ -126,6 +126,7 @@ class ObjectEmitMixin:
                 symbol_name=node.name,
                 section_idx=actual_idx,
                 size=node._size,
+                pinned_addr=node.pinned_addr if node.pinned_addr is not None else -1,
             )
         )
 

--- a/a816/symbols.py
+++ b/a816/symbols.py
@@ -516,7 +516,13 @@ class Resolver:
         # index so each alloc's private label exports (and relocates)
         # under a distinct name.
         if isinstance(scope, AllocBodyScope):
-            if name.startswith("_") and mangle_nested and idx > 0:
+            # Private (underscore) labels are local to THIS alloc body; mangle them
+            # to a per-scope-index name so two allocs' `_loop`/`_done` don't collide
+            # as bare globals in the flat link table (a wild, layout-dependent
+            # branch). The index-0 alloc is NOT exempt: an alloc can legitimately be
+            # scope index 0 in its module, and skipping it leaked bare privates that
+            # collided across modules (boot crash). Include idx 0.
+            if name.startswith("_") and mangle_nested:
                 return f"__sc{idx}__{name}"
             return name
         if mangle_nested and idx > 0 and not isinstance(scope, NamedScope):
@@ -533,7 +539,11 @@ class Resolver:
         names pass through unchanged so externs and root labels are untouched.
         """
         owner = self.current_scope.find_label_scope(name)
-        if owner is None or owner is self.scopes[0]:
+        # Root-owned (scopes[0]) and unknown/extern names pass through bare - EXCEPT
+        # when scopes[0] is itself an AllocBodyScope: its private labels must still
+        # mangle (mirrors _export_name including idx 0), else a reference binds bare
+        # while the definition exports `__sc0__name`.
+        if owner is None or (owner is self.scopes[0] and not isinstance(owner, AllocBodyScope)):
             return name
         return self._export_name(name, owner, self.scopes.index(owner), mangle_nested=True)
 

--- a/a816/xdds.py
+++ b/a816/xdds.py
@@ -355,9 +355,11 @@ def make_rom_data_provider(rom_bytes: bytes, bus: Bus) -> Callable[[int, int], b
     """
 
     def provide(logical_addr: int, length: int) -> bytes:
+        from a816.exceptions import UnmappedBankError
+
         try:
             physical = bus.get_address(logical_addr).physical
-        except KeyError:
+        except (KeyError, UnmappedBankError):
             return b""
         if physical is None:
             return b""

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -405,6 +405,31 @@ legacy `*=` shape).
 Overlap with any other pinned region (legacy `*=` included) trips
 the overlap auditor with both locations named.
 
+### `.reserve NAME SIZE [at ADDR] in POOL`
+
+Byte-less reservation into a (typically `bss`) pool; lays out a RAM/VRAM
+variable flat, no wrapper `.alloc` block. `NAME` binds at the reserved
+address; nothing is emitted into the image.
+
+* `.reserve NAME SIZE in POOL`: the allocator picks the address.
+* `.reserve NAME SIZE at ADDR in POOL`: pins the slot at `ADDR`. The
+  allocator validates the span lies within a pool range and overlaps no
+  other allocation (pinned or floating), then carves it out. Use for fixed
+  memory maps (VRAM, MMIO mirrors) where the address is the contract but
+  you still want overlap checking across the whole layout.
+* `.reserve NAME as TYPE in POOL`: reserves `sizeof(TYPE)` and publishes
+  `NAME.<field>` at each struct offset.
+
+```ca65
+.pool vram { bss  range 0x0000 0x7fff  strategy order }
+.reserve bg_char 0x2000 at 0x1000 in vram   ; pinned VRAM word
+.reserve bg1_map 0x0800 at 0x6800 in vram
+.reserve scratch 0x0040           in vram   ; allocator picks a free hole
+```
+
+Pinned spans that fall outside the pool or collide with another allocation
+fail the build, naming the offending reservation.
+
 ### `.relocate SYMBOL OLD_START OLD_END into POOL { body }`
 
 Moves `SYMBOL` from `[OLD_START, OLD_END]` into the pool — old range

--- a/hatch_version.py
+++ b/hatch_version.py
@@ -1,0 +1,16 @@
+"""Build-time version source for hatchling.
+
+Reads the `VERSION` env var when set (CI and release pipelines inject the real
+tag), otherwise falls back to a dev placeholder so local builds and editable
+installs work without exporting anything.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEV_VERSION = "0.0.0.dev0"
+
+
+def get_version() -> str:
+    return os.environ.get("VERSION") or DEV_VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,9 @@ dependencies = ["pygls>=2.1.1,<3", "lsprotocol>=2025.0.0,<2026"]
 dynamic = ["version"]
 
 [tool.hatch.version]
-source = "env"
-variable = "VERSION"
+source = "code"
+path = "hatch_version.py"
+expression = "get_version()"
 
 [tool.hatch.build.targets.wheel]
 only-include = ["a816", "script"]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,6 +1,7 @@
 import unittest
 
 from a816.cpu.mapping import Bus
+from a816.exceptions import UnmappedBankError
 
 # mapping.yml
 #   rom name=program.rom size=0x180000
@@ -77,3 +78,32 @@ class MappingTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _ = rom_address + "coin"
+
+    def test_unmapped_bank_raises_clear_error(self) -> None:
+        # Bank $FC is outside every mapped range; the bus must raise a clear
+        # UnmappedBankError, not the bare KeyError that used to leak out.
+        with self.assertRaises(UnmappedBankError) as ctx:
+            self.bus.get_mapping_for_bank(0xFC)
+        self.assertEqual(ctx.exception.bank, 0xFC)
+
+    def test_unmapped_bank_via_get_address_carries_logical_address(self) -> None:
+        # Going through `get_address` attaches the full logical address so the
+        # diagnostic can show `$FC8000`, not just the bank byte.
+        with self.assertRaises(UnmappedBankError) as ctx:
+            self.bus.get_address(0xFC8000)
+        self.assertEqual(ctx.exception.bank, 0xFC)
+        self.assertEqual(ctx.exception.logical_address, 0xFC8000)
+
+    def test_unmapped_bank_error_message_lists_mapped_ranges(self) -> None:
+        try:
+            self.bus.get_address(0xFC0000)
+        except UnmappedBankError as exc:
+            rendered = exc.format()
+            self.assertIn("$FC", rendered)
+            self.assertIn("$FC0000", rendered)
+            # Mapped ranges collapse into contiguous spans (ram $7E-$7F is
+            # adjacent to the rom mirror $80-$CF, so they merge to $7E-$CF).
+            self.assertIn("$00-$6F", rendered)
+            self.assertIn("$7E-$CF", rendered)
+        else:  # pragma: no cover - guard against silent regression
+            self.fail("expected UnmappedBankError")

--- a/tests/test_reserve.py
+++ b/tests/test_reserve.py
@@ -142,6 +142,58 @@ def test_flat_reserve_binds_symbols() -> None:
         assert all(s.code == b"" for s in linked.sections if s.bss)
 
 
+def test_pinned_reserve_binds_at_fixed_address() -> None:
+    """`.reserve NAME SIZE at ADDR in POOL` pins the slot at ADDR, leaving the
+    surrounding pool free for the allocator. Models fixed memory maps (VRAM/MMIO)
+    where the address is the contract, not the allocator's choice."""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(
+            _PREAMBLE
+            + ".reserve tilemap  0x800 at 0x7e1000 in wram\n"
+            + ".reserve charbase 0x400 at 0x7e0200 in wram\n"
+            + ".reserve floating 0x10        in wram\n"
+        )
+        obj = Path(tmp) / "m.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        linked = Linker([ObjectFile.from_file(str(obj))]).link(base_address=0x8000)
+        syms = _symbols(linked)
+        assert syms["tilemap"] == 0x7E1000
+        assert syms["charbase"] == 0x7E0200
+        # Floating alloc lands in free space, clear of both pinned spans.
+        assert syms["floating"] == 0x7E0000
+        assert all(s.code == b"" for s in linked.sections if s.bss)
+
+
+def test_pinned_reserve_overlap_is_rejected() -> None:
+    """Two pinned spans that collide fail the build (overlap check)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(_PREAMBLE + ".reserve a 0x100 at 0x7e0000 in wram\n" + ".reserve b 0x100 at 0x7e0080 in wram\n")
+        obj = Path(tmp) / "m.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        # Overlap surfaces at link (allocator) time.
+        try:
+            Linker([ObjectFile.from_file(str(obj))]).link(base_address=0x8000)
+        except Exception:  # PoolOverlapError, wrapped or direct
+            return
+        raise AssertionError("expected overlap rejection for colliding pinned reserves")
+
+
+def test_pinned_reserve_out_of_range_is_rejected() -> None:
+    """A pin outside the pool's ranges fails the build."""
+    with tempfile.TemporaryDirectory() as tmp:
+        asm = Path(tmp) / "m.s"
+        asm.write_text(_PREAMBLE + ".reserve x 0x10 at 0x7e9000 in wram\n")
+        obj = Path(tmp) / "m.o"
+        assert Program().assemble_as_object(str(asm), obj) == 0
+        try:
+            Linker([ObjectFile.from_file(str(obj))]).link(base_address=0x8000)
+        except Exception:
+            return
+        raise AssertionError("expected out-of-range rejection for pinned reserve")
+
+
 _STRUCT = """
 .struct GameState {
     word score

--- a/tests/test_separate_compilation.py
+++ b/tests/test_separate_compilation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from a816.exceptions import UnresolvedSymbolError
+from a816.exceptions import UnmappedBankError, UnresolvedSymbolError
 from a816.linker import Linker
 from a816.object_file import ObjectFile, SymbolType
 from a816.program import Program
@@ -576,8 +576,9 @@ helper:
 
         program = Program()
 
-        # Address with no physical mapping should raise KeyError (unmapped bank)
-        with pytest.raises(KeyError):
+        # An address in a bank no `.map` covers raises a clear UnmappedBankError,
+        # not the bare KeyError that used to leak from the bus lookup.
+        with pytest.raises(UnmappedBankError, match=r"bank \$FF"):
             program.get_physical_address(0xFFFFFF)
 
     def test_link_as_patch_empty_code(self) -> None:

--- a/tests/test_xobj.py
+++ b/tests/test_xobj.py
@@ -31,7 +31,7 @@ def test_summary_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> 
     assert rc == 0
     assert "sections: 1" in captured.out
     assert "symbols: 1" in captured.out
-    assert "version: 11" in captured.out
+    assert "version: 12" in captured.out
 
 
 def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -40,7 +40,7 @@ def test_json_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> N
     captured = capsys.readouterr()
     assert rc == 0
     data = json.loads(captured.out)
-    assert data["version"] == 11
+    assert data["version"] == 12
     assert data["sections"][0]["base_address"] == 0x008000
     assert bytes.fromhex(data["sections"][0]["code"]) == b"\xea\xea"
     assert data["symbols"][0]["type"] == "GLOBAL"

--- a/uv.lock
+++ b/uv.lock
@@ -12,18 +12,20 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "kintsuki" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "lsprotocol" },
-    { name = "pygls" },
+    { name = "lsprotocol", specifier = ">=2025.0.0,<2026" },
+    { name = "pygls", specifier = ">=2.1.1,<3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "kintsuki", specifier = ">=0.0.0a14" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
@@ -200,6 +202,15 @@ wheels = [
 ]
 
 [[package]]
+name = "kintsuki"
+version = "0.0.0a14"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/dc/7d8178ba8beb53fe9b139d8a8eb75268dadd5e4a90e708e6ff248863bf32/kintsuki-0.0.0a14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cc608cf831890fec028301358b81a7524b3e18c009aecfbe83d35c1b9f15e418", size = 822166, upload-time = "2026-05-22T06:51:27.732Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b2/7bdc4e08511ace748548c595e43637e63613b37ba66713a5abb77d730828/kintsuki-0.0.0a14-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:29224cf73e06f27d8f85c3daf7f1ef980c8a5b86506bc06f52ff5daaef311ab3", size = 762081, upload-time = "2026-05-22T06:51:29.513Z" },
+]
+
+[[package]]
 name = "lsprotocol"
 version = "2025.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -232,16 +243,16 @@ wheels = [
 
 [[package]]
 name = "pygls"
-version = "2.0.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
     { name = "lsprotocol" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/94/cce3560f6c7296be43bd67ba342f8972b8adddfe407b62b25d1fb90c514b/pygls-2.0.1.tar.gz", hash = "sha256:2f774a669fbe2ece977d302786f01f9b0c5df7d0204ea0fa371ecb08288d6b86", size = 55796, upload-time = "2026-01-26T23:04:33.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl", hash = "sha256:d29748042cea5bedc98285eb3e2c0c60bf3fc73786319519001bf72bbe8f36cc", size = 69536, upload-time = "2026-01-26T23:04:35.197Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Fills in the remaining gaps of the 65c816 instruction set and makes the
disassembler a derivation of the encode table rather than a parallel
hand-written one, plus three adjacent improvements that rode along.

**ISA table (main change).** Completes the opcode matrix: width-aware
immediates (`.a8`/`.a16`), `bvc`/`bvs`/`per`, `jsl`/`jml` as encode-only
aliases of `jsr.l`/`jmp.l`, and `mvn`/`mvp` block moves (bank-reversed
encoding, two-operand scanner/parser/codegen path). The disassembler's
hand-written `OPCODE_TABLE` is replaced by an inversion of the single
source-of-truth table by emitter type, size slot, and index. A new
256-opcode matrix test asserts every opcode encodes to the expected bytes
and round-trips back to the same mnemonic/mode, so any future table edit
that breaks encode/decode agreement fails loudly.

**Fixed-address reserves.** `.reserve NAME SIZE at ADDR in POOL` pins a
byte-less reservation at a chosen address inside a named pool; the allocator
validates the span is in-range and overlap-free, then carves it before
placing floating allocations. For fixed memory maps (VRAM/MMIO) where the
address is the contract but you still want overlap checking across the whole
layout. Object format bumped to v12 to round-trip the pin across modules.

**Unmapped-bank diagnostics.** Addresses landing in a bank no `.map` covers
used to surface as a bare `KeyError: <bank>` deep in a traceback. They now
raise `UnmappedBankError` carrying the bank, the full logical address, and
the mapped ranges (collapsed to contiguous spans), rendered as a proper
source-located diagnostic.

**Build version.** Hatch reads the version from `hatch_version.py` (code
source) instead of a bare env var, falling back to a dev placeholder so
local and editable installs work without exporting anything.

## Risk

Object format v12 is not backward-compatible with v11 `.o` files - recompile
sources. The symbols.py label-mangling change (index-0 alloc bodies now
mangle private `_underscore` labels too) fixes a cross-module collision that
caused a boot crash; it changes exported names for index-0 alloc bodies.
