### PR TITLE
Memoise the parsed body of an include

### DIFF
--- a/a816/parse/parser_states/directives.py
+++ b/a816/parse/parser_states/directives.py
@@ -5,6 +5,7 @@ ascii/text/incbin/table/.aN/.iN)."""
 from __future__ import annotations
 
 import ast
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -314,17 +315,64 @@ def _resolve_include_path(p: Parser, keyword: Token, include_path: str) -> str:
     return include_path  # let the eventual open() raise the canonical error
 
 
-def parse_include(p: Parser, keyword: Token) -> IncludeAstNode:
+#: (resolved path, search paths) -> (file stamp, parsed body).
+_INCLUDE_AST_CACHE: dict[tuple[str, tuple[str, ...]], tuple[tuple[int, int], list[AstNode]]] = {}
+
+
+def clear_include_ast_cache() -> None:
+    """Drop every memoised include. For tests and long-running servers."""
+    _INCLUDE_AST_CACHE.clear()
+
+
+def _include_stamp(resolved_path: str) -> tuple[int, int] | None:
+    """Identity of the file on disk, or None when it cannot be stat'd (in
+    which case the include is parsed fresh and never cached)."""
+    try:
+        stat = os.stat(resolved_path)
+    except OSError:
+        return None
+    return stat.st_mtime_ns, stat.st_size
+
+
+def _parse_include_file(resolved_path: str, include_paths: list[Path]) -> list[AstNode]:
     from a816.parse.parser_states.core import parse_initial
 
-    include_path = parse_directive_with_quoted_string(p)
-    resolved_path = _resolve_include_path(p, keyword, include_path)
     with open(resolved_path, encoding="utf-8") as fd:
         source = fd.read()
     scanner = Scanner(cast(ScannerStateFunc, lex_initial))
     tokens = scanner.scan(resolved_path, source)
-    parser = Parser(tokens, cast(StateFunc, parse_initial), include_paths=p.include_paths)
-    sub_ast = parser.parse()
+    parser = Parser(tokens, cast(StateFunc, parse_initial), include_paths=include_paths)
+    return parser.parse()
+
+
+def _included_ast(resolved_path: str, include_paths: list[Path]) -> list[AstNode]:
+    """The parsed body of an include, memoised per file revision.
+
+    A header pulled in from thirty sites was scanned and parsed thirty
+    times; on one project that came to 1024 parses of 55 distinct files.
+    The body only depends on the file's bytes and the search paths used to
+    resolve its own nested includes, so it is shared between sites.
+
+    Codegen reads these nodes and emits fresh ones rather than mutating
+    them, which is what makes sharing safe."""
+    key = (resolved_path, tuple(str(path) for path in include_paths))
+    stamp = _include_stamp(resolved_path)
+    if stamp is not None:
+        cached = _INCLUDE_AST_CACHE.get(key)
+        if cached is not None and cached[0] == stamp:
+            return cached[1]
+    sub_ast = _parse_include_file(resolved_path, include_paths)
+    if stamp is not None:
+        # Keyed per file, so the cache stays the size of the project rather
+        # than growing with every edit.
+        _INCLUDE_AST_CACHE[key] = (stamp, sub_ast)
+    return sub_ast
+
+
+def parse_include(p: Parser, keyword: Token) -> IncludeAstNode:
+    include_path = parse_directive_with_quoted_string(p)
+    resolved_path = _resolve_include_path(p, keyword, include_path)
+    sub_ast = _included_ast(resolved_path, p.include_paths)
     return IncludeAstNode(include_path, sub_ast, keyword, resolved_path=resolved_path)
 
 

--- a/tests/test_include_ast_cache.py
+++ b/tests/test_include_ast_cache.py
@@ -1,0 +1,98 @@
+"""Behaviour pins for the memoised `.include` body.
+
+A header pulled in from many sites used to be scanned and parsed once per
+site. These tests pin that it is parsed once per revision instead, and
+that a revision is noticed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from a816.parse.ast.nodes import IncludeAstNode
+from a816.parse.mzparser import A816Parser
+from a816.parse.parser_states.directives import clear_include_ast_cache
+
+
+def _write(root: Path, name: str, text: str) -> Path:
+    path = root / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _include_nodes(nodes: list[object]) -> list[IncludeAstNode]:
+    return [node for node in nodes if isinstance(node, IncludeAstNode)]
+
+
+def _parse(source_path: Path) -> list[object]:
+    result = A816Parser.parse_as_ast(source_path.read_text(encoding="utf-8"), str(source_path))
+    return list(result.nodes)
+
+
+def test_two_sites_share_one_parsed_body(tmp_path: Path) -> None:
+    """The pin: including the same header twice parses it once."""
+    clear_include_ast_cache()
+    _write(tmp_path, "header.i", "CONST = 0x1234\n")
+    main = _write(tmp_path, "main.s", '.include "header.i"\n.include "header.i"\n')
+
+    includes = _include_nodes(_parse(main))
+
+    assert len(includes) == 2
+    assert includes[0].included_nodes is includes[1].included_nodes
+
+
+def test_separate_headers_do_not_collide(tmp_path: Path) -> None:
+    clear_include_ast_cache()
+    _write(tmp_path, "a.i", "A = 1\n")
+    _write(tmp_path, "b.i", "B = 2\n")
+    main = _write(tmp_path, "main.s", '.include "a.i"\n.include "b.i"\n')
+
+    includes = _include_nodes(_parse(main))
+
+    assert includes[0].included_nodes is not includes[1].included_nodes
+
+
+def test_a_rewritten_header_is_reparsed(tmp_path: Path) -> None:
+    """Stale bodies would be worse than no cache at all."""
+    clear_include_ast_cache()
+    header = _write(tmp_path, "header.i", "CONST = 1\n")
+    main = _write(tmp_path, "main.s", '.include "header.i"\n')
+
+    first = _include_nodes(_parse(main))[0].included_nodes
+
+    header.write_text("CONST = 2\nOTHER = 3\n", encoding="utf-8")
+    stamp = header.stat()
+    os.utime(header, ns=(stamp.st_atime_ns, stamp.st_mtime_ns + 1_000_000))
+
+    second = _include_nodes(_parse(main))[0].included_nodes
+
+    assert second is not first
+    assert len(second) > len(first)
+
+
+def test_clearing_the_cache_forces_a_reparse(tmp_path: Path) -> None:
+    clear_include_ast_cache()
+    _write(tmp_path, "header.i", "CONST = 1\n")
+    main = _write(tmp_path, "main.s", '.include "header.i"\n')
+
+    first = _include_nodes(_parse(main))[0].included_nodes
+    clear_include_ast_cache()
+    second = _include_nodes(_parse(main))[0].included_nodes
+
+    assert second is not first
+    assert len(second) == len(first)
+
+
+def test_nested_includes_are_shared_too(tmp_path: Path) -> None:
+    clear_include_ast_cache()
+    _write(tmp_path, "leaf.i", "LEAF = 1\n")
+    _write(tmp_path, "mid_a.i", '.include "leaf.i"\n')
+    _write(tmp_path, "mid_b.i", '.include "leaf.i"\n')
+    main = _write(tmp_path, "main.s", '.include "mid_a.i"\n.include "mid_b.i"\n')
+
+    mids = _include_nodes(_parse(main))
+    leaf_a = _include_nodes(list(mids[0].included_nodes))[0]
+    leaf_b = _include_nodes(list(mids[1].included_nodes))[0]
+
+    assert leaf_a.included_nodes is leaf_b.included_nodes


### PR DESCRIPTION
`.include` is textual, so a header pulled in from many sites was read, scanned and parsed once per site. On ff4 that came to 1024 parses of 55 distinct files, with `bank20.i` alone parsed 296 times. `parse_include` now memoises the parsed body per `(resolved path, search paths)`, keyed on the file's mtime and size, so a header is parsed once per revision and shared between sites.

The body only depends on the file's bytes and the paths used to resolve its own nested includes, and codegen reads those nodes to emit fresh ones rather than mutating them, which is what makes sharing safe. The cache is keyed per file rather than per revision, so it stays the size of the project instead of growing with every edit; a file that cannot be stat'd is parsed fresh and never cached. `clear_include_ast_cache()` exists for tests and long-running servers.

Since sharing one sub-AST between sites is the risk, output was checked end to end rather than only in the index: ff4's IPS patch and cacheguard's SFC are both byte-identical with the cache on and off. The workspace index was also rebuilt twelve times on a free-threaded interpreter, interleaving cold and warm caches against the now-parallel parse, with no divergence in documents, labels, symbols, macros, pools or allocs.

On the honest numbers: standalone this was worth 1.27x on ff4, but now that the parallel parse from #113 is merged the remaining win is about 1.10x on a GIL build and roughly nothing on 3.14t, since the fan-out already absorbs the redundant work. It still removes 746 parses per rebuild and helps single-threaded consumers, but it is no longer the interesting lever. Finishing ff4's own migration from `.include` to `.import` is: cacheguard, at the same 60-odd document scale, indexes in 0.97s against ff4's 2.25s purely on that discipline.