### PR TITLE
Keep both banks when formatting a block move

### DIFF
--- a/a816/formatter/operand_emit.py
+++ b/a816/formatter/operand_emit.py
@@ -42,6 +42,13 @@ def format_operand(opcode_ast: OpcodeAstNode, options: FormattingOptions) -> str
     def with_index(base: str) -> str:
         return f"{base}{comma}{index}" if index else base
 
+    # Block moves (`mvn src, dst`) are the one opcode carrying a second
+    # operand. It is never indexed and never wrapped, so it short-circuits
+    # the addressing-mode tables below rather than threading through them.
+    if opcode_ast.operand2 is not None:
+        second = opcode_ast.operand2.to_canonical().strip()
+        return f"{operand}{comma}{second}"
+
     wrappers: dict[AddressingMode, Callable[[str], str]] = {
         AddressingMode.indirect_indexed: lambda o: with_index(f"({o})"),
         AddressingMode.indirect_indexed_long: lambda o: with_index(f"[{o}]"),

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -996,3 +996,36 @@ class TestPositionDirectiveBlanks(TestCase):
         src = '"""m"""\nlabel_one:\n    rts\n\n*= 0x0AF000\n.incbin "x.bin"\n'
         out = self.formatter.format_text(src)
         self.assertIn("\n\n*=0x0AF000", out)
+
+
+class TestBlockMoveFormatting(TestCase):
+    """`mvn` / `mvp` carry two bank operands.
+
+    The formatter rendered only the first, so `mvn 0x7E, 0x7E` came back
+    as `mvn 0x7E`: source silently rewritten into something the assembler
+    then rejects. Anything downstream of a reformat inherited the loss,
+    which is the worst shape a formatter bug can take.
+    """
+
+    def setUp(self) -> None:
+        self.formatter = A816Formatter()
+
+    def test_mvn_keeps_both_banks(self) -> None:
+        formatted = self.formatter.format_text("main:\n    mvn 0x7E, 0x7E\n")
+        self.assertIn("mvn 0x7E, 0x7E", formatted)
+
+    def test_mvp_keeps_both_banks(self) -> None:
+        formatted = self.formatter.format_text("main:\n    mvp 0x01, 0x02\n")
+        self.assertIn("mvp 0x01, 0x02", formatted)
+
+    def test_block_move_survives_a_second_pass(self) -> None:
+        """Formatting is idempotent, so the second pass must not erode it."""
+        once = self.formatter.format_text("main:\n    mvn 0x7E, 0x7E\n")
+        twice = self.formatter.format_text(once)
+        self.assertEqual(once, twice)
+        self.assertIn("mvn 0x7E, 0x7E", twice)
+
+    def test_block_move_honours_comma_spacing(self) -> None:
+        formatter = A816Formatter(FormattingOptions(space_after_comma=False))
+        formatted = formatter.format_text("main:\n    mvn 0x7E, 0x7E\n")
+        self.assertIn("mvn 0x7E,0x7E", formatted)


### PR DESCRIPTION
`mvn` / `mvp` are the only opcodes carrying a second operand. The formatter rendered just the first, so `mvn 0x7E, 0x7E` came back as `mvn 0x7E` — valid-looking source that the assembler then rejects.

That is the worst shape a formatter bug can take: it rewrites correct source into broken source, silently, and anything downstream of a reformat inherits the loss. Hit it in a real project, where a block move is what copies a direct page into scratch RAM.

The second operand is never indexed and never wrapped, so it short-circuits ahead of the addressing-mode tables rather than threading a second value through every wrapper lambda.

Covered for both mnemonics plus an idempotence case, since a formatter that erodes on the second pass is the same bug wearing a hat.