### PR TITLE
Resolve struct types through .include for S001

### DIFF
--- a/a816/fluff/core.py
+++ b/a816/fluff/core.py
@@ -108,8 +108,8 @@ class LintContext:
     parse_failed: bool
     # Search paths forwarded by the lint entry-points. `module_paths` lets
     # struct-type rules (S001) follow `.import` chains so cross-module
-    # struct names resolve. `include_paths` is reserved for future rules
-    # that need to chase `.include` outside the already-inlined AST.
+    # struct names resolve; `include_paths_for_lookup` does the same for
+    # `.include` targets the parser could not resolve on its own.
     module_paths: list[Path] | None = None
     include_paths_for_lookup: list[Path] | None = None
 
@@ -117,6 +117,7 @@ class LintContext:
     _expanded_top_level: list[AstNode] | None = field(default=None, init=False, repr=False)
     _placement_hits: dict[str, list[Diagnostic]] | None = field(default=None, init=False, repr=False)
     _imported_struct_types: set[str] | None = field(default=None, init=False, repr=False)
+    _included_struct_types: set[str] | None = field(default=None, init=False, repr=False)
 
     @property
     def flat_nodes(self) -> list[AstNode]:

--- a/a816/fluff/rules_style.py
+++ b/a816/fluff/rules_style.py
@@ -26,6 +26,7 @@ from a816.parse.ast.nodes import (
     ExpressionAstNode,
     ExprNode,
     ImportAstNode,
+    IncludeAstNode,
     IncludeIpsAstNode,
     LabelDeclAstNode,
     OpcodeAstNode,
@@ -89,15 +90,23 @@ def _walk_cast_nodes(
 
 
 def _collect_known_struct_types(ctx: LintContext) -> set[str]:
-    """Struct types declared in this file plus those reachable via imports.
+    """Struct types declared in this file plus those it can reach.
 
     Local `.struct` decls are always available. `.import` targets are
-    resolved through the stdlib + module-path search order; their files
-    get parsed once per lint and the discovered struct names cached on
-    the context.
+    resolved through the stdlib + module-path search order, and
+    `.include` targets through the parser's own resolution (falling back
+    to the configured include paths); their files get parsed once per
+    lint and the discovered struct names cached on the context.
+
+    Includes matter as much as imports here: a project that keeps its
+    struct declarations in a `.i` header and pulls it in from one
+    entrypoint has every other file reaching those types by `.include`,
+    and linting each file on its own would otherwise report every cast
+    in the project as targeting an unknown type.
     """
     known = {n.name for n in ctx.flat_nodes if isinstance(n, StructAstNode)}
     known |= _collect_imported_struct_types(ctx)
+    known |= _collect_included_struct_types(ctx)
     return known
 
 
@@ -113,6 +122,43 @@ def _collect_imported_struct_types(ctx: LintContext) -> set[str]:
                 discovered |= _struct_names_in_file(module_path, seen_paths)
     ctx._imported_struct_types = discovered
     return discovered
+
+
+def _collect_included_struct_types(ctx: LintContext) -> set[str]:
+    if ctx._included_struct_types is not None:
+        return ctx._included_struct_types
+    discovered: set[str] = set()
+    seen_paths: set[str] = set()
+    for node in ctx.flat_nodes:
+        if isinstance(node, IncludeAstNode):
+            include_path = _resolve_include_for_lint(node, ctx)
+            if include_path is not None:
+                discovered |= _struct_names_in_file(include_path, seen_paths)
+    ctx._included_struct_types = discovered
+    return discovered
+
+
+def _resolve_include_for_lint(node: IncludeAstNode, ctx: LintContext) -> Path | None:
+    """Map an `.include` to an absolute path.
+
+    The parser already records `resolved_path` when it could resolve the
+    file itself; that is the common case and is honoured first. Otherwise
+    the name is tried against the lint context's include paths and then
+    the including file's own directory, matching how the assembler
+    searches.
+    """
+    resolved = getattr(node, "resolved_path", None)
+    if resolved:
+        candidate = Path(resolved)
+        if candidate.is_file():
+            return candidate
+    bases: list[Path] = list(ctx.include_paths_for_lookup or [])
+    bases.append(ctx.path.parent)
+    for base in bases:
+        candidate = base / node.file_path
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _resolve_import_for_lint(module_name: str, ctx: LintContext) -> Path | None:
@@ -148,6 +194,11 @@ def _struct_names_in_file(path: Path, seen_paths: set[str]) -> set[str]:
             transitive = resolve_module(node.module_name, ".s", [])
             if transitive is not None:
                 names |= _struct_names_in_file(transitive, seen_paths)
+        elif isinstance(node, IncludeAstNode):
+            nested = getattr(node, "resolved_path", None) or (path.parent / node.file_path)
+            nested_path = Path(nested)
+            if nested_path.is_file():
+                names |= _struct_names_in_file(nested_path, seen_paths)
     return names
 
 

--- a/tests/test_fluff_lint.py
+++ b/tests/test_fluff_lint.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import pytest
 
 from a816.fluff import fluff_main, lint_file
+from a816.fluff.core import LintContext
+from a816.fluff.rules_style import _resolve_include_for_lint, _struct_names_in_file
+from a816.parse.ast.nodes import IncludeAstNode
+from a816.parse.tokens import Token, TokenType
 
 
 def test_doc001_flags_missing_module_docstring(tmp_path: Path) -> None:
@@ -595,3 +599,95 @@ def test_s001_follows_a_nested_include(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert "S001" not in [d.code for d in lint_file(src)]
+
+
+def test_s001_resolves_an_include_through_the_configured_include_paths(tmp_path: Path) -> None:
+    """A header the file names but does not sit beside still resolves.
+
+    `include-paths` in `a816.toml` is how a project points at its header
+    directory, and the assembler searches it, so the lint has to as well.
+    """
+    (tmp_path / "a816.toml").write_text('include-paths = ["headers"]\n', encoding="utf-8")
+    headers = tmp_path / "headers"
+    headers.mkdir()
+    (headers / "types.i").write_text(
+        '"""Types."""\n.struct Player {\n    word hp\n}\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "src" / "main.s"
+    src.parent.mkdir()
+    src.write_text(
+        '"""Module."""\n.include "types.i"\np := (0x7E1000 as Player)\n',
+        encoding="utf-8",
+    )
+    assert "S001" not in [d.code for d in lint_file(src)]
+
+
+def test_struct_names_in_file_stops_on_a_cycle(tmp_path: Path) -> None:
+    """Headers that include each other must terminate.
+
+    Driven through the helper rather than a lint run: the parser itself
+    recurses without limit on a cyclic include, so a full lint never
+    reaches this guard.
+    """
+    (tmp_path / "a.i").write_text('"""A."""\n.struct Player {\n    word hp\n}\n', encoding="utf-8")
+    seen = {str((tmp_path / "a.i").resolve())}
+    assert _struct_names_in_file(tmp_path / "a.i", seen) == set()
+
+
+def test_struct_names_in_file_shrugs_off_an_unreadable_path(tmp_path: Path) -> None:
+    """A header that cannot be read yields no names instead of raising."""
+    target = tmp_path / "types.i"
+    target.mkdir()
+    assert _struct_names_in_file(target, set()) == set()
+
+
+def test_s001_include_lookup_is_cached_across_casts(tmp_path: Path) -> None:
+    """Several casts in one file share a single walk of the include graph."""
+    (tmp_path / "types.i").write_text(
+        '"""Types."""\n.struct Player {\n    word hp\n}\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "main.s"
+    src.write_text(
+        '"""Module."""\n.include "types.i"\np := (0x7E1000 as Player)\nq := (0x7E1010 as Player)\n',
+        encoding="utf-8",
+    )
+    assert "S001" not in [d.code for d in lint_file(src)]
+
+
+def _include_node(file_path: str, resolved_path: str | None) -> IncludeAstNode:
+    """An `.include` node standing on its own, outside any parse."""
+    return IncludeAstNode(
+        file_path=file_path,
+        included_nodes=[],
+        file_info=Token(TokenType.QUOTED_STRING, file_path),
+        resolved_path=resolved_path,
+    )
+
+
+def test_resolve_include_falls_back_when_the_parser_left_no_path(tmp_path: Path) -> None:
+    """The node's own `resolved_path` is preferred, then the search paths.
+
+    Nested headers are parsed without include paths, so their include
+    nodes come back unresolved and only this fallback finds them.
+    """
+    headers = tmp_path / "headers"
+    headers.mkdir()
+    (headers / "types.i").write_text('"""Types."""\n.struct Player {\n    word hp\n}\n', encoding="utf-8")
+    node = _include_node("types.i", resolved_path=str(tmp_path / "gone.i"))
+    ctx = LintContext(
+        path=tmp_path / "main.s",
+        text="",
+        nodes=[],
+        parse_failed=False,
+        include_paths_for_lookup=[headers],
+    )
+    assert _resolve_include_for_lint(node, ctx) == headers / "types.i"
+
+
+def test_resolve_include_returns_none_when_nothing_matches(tmp_path: Path) -> None:
+    """An include naming a file that exists nowhere resolves to nothing."""
+    node = _include_node("absent.i", resolved_path=None)
+    ctx = LintContext(path=tmp_path / "main.s", text="", nodes=[], parse_failed=False)
+    assert _resolve_include_for_lint(node, ctx) is None

--- a/tests/test_fluff_lint.py
+++ b/tests/test_fluff_lint.py
@@ -544,3 +544,54 @@ def test_doc003_does_not_attribute_above_label_when_previous_was_a_label(tmp_pat
     )
     diags = lint_file(src)
     assert all(d.code != "DOC003" for d in diags), [d.format() for d in diags]
+
+
+def test_s001_resolves_struct_types_through_include(tmp_path: Path) -> None:
+    """A struct declared in an included header is a known type.
+
+    Projects that keep their struct declarations in a `.i` header pull it
+    in with `.include`, so a file linted on its own has to follow that
+    edge; otherwise every cast in the project reports an unknown type.
+    """
+    (tmp_path / "types.i").write_text(
+        '"""Types."""\n.struct Player {\n    word hp\n}\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "main.s"
+    src.write_text(
+        '"""Module."""\n.include "types.i"\np := (0x7E1000 as Player)\n',
+        encoding="utf-8",
+    )
+    assert "S001" not in [d.code for d in lint_file(src)]
+
+
+def test_s001_still_flags_a_type_no_include_declares(tmp_path: Path) -> None:
+    """Following includes must not turn the rule into a rubber stamp."""
+    (tmp_path / "types.i").write_text(
+        '"""Types."""\n.struct Player {\n    word hp\n}\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "main.s"
+    src.write_text(
+        '"""Module."""\n.include "types.i"\np := (0x7E1000 as Monster)\n',
+        encoding="utf-8",
+    )
+    assert "S001" in [d.code for d in lint_file(src)]
+
+
+def test_s001_follows_a_nested_include(tmp_path: Path) -> None:
+    """Headers include other headers; the walk has to go all the way down."""
+    (tmp_path / "base.i").write_text(
+        '"""Base."""\n.struct Player {\n    word hp\n}\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "types.i").write_text(
+        '"""Types."""\n.include "base.i"\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "main.s"
+    src.write_text(
+        '"""Module."""\n.include "types.i"\np := (0x7E1000 as Player)\n',
+        encoding="utf-8",
+    )
+    assert "S001" not in [d.code for d in lint_file(src)]


### PR DESCRIPTION
S001 knew a struct type only when the file declared it or reached it through `.import`. A project that keeps its declarations in a `.i` header and pulls it in with `.include` had every cast in every file reported as targeting an unknown type — the rule firing on correct code, which is the shape that gets a lint switched off rather than fixed.

Includes are now followed the way imports already were. The parser records `resolved_path` on the node, so that is honoured first, with the configured include paths and the file's own directory as fallbacks; the walk recurses, so a header including another header still resolves, and results are cached per context alongside the import set. `LintContext.include_paths_for_lookup` existed for exactly this and its comment said as much.

Scope worth being explicit about: this resolves types a file can actually name. It does not help a file that reaches a struct only because some entrypoint composed the translation unit — that would need entrypoint-seeded linting, which changes what every rule sees and is a much larger change.

The negative case is covered too: a type no include declares still reports, so following includes does not turn the rule into a rubber stamp.